### PR TITLE
first css cleanup

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,28 +16,6 @@
   --text-paragraph: hsla(0, 0%, 29%, 1);
   --text-link: hsla(0, 0%, 15%, 1);
   --text-link-hover: hsla(0, 0%, 13%, 1);
-  /* for tweakpane */
-  --tp-base-background-color: hsla(0, 0%, 10%, 0.80);
-  --tp-base-shadow-color: hsla(0, 0%, 0%, 0.2);
-  --tp-button-background-color: hsla(0, 0%, 80%, 1.00);
-  --tp-button-background-color-active: hsla(0, 0%, 100%, 1.00);
-  --tp-button-background-color-focus: hsla(0, 0%, 95%, 1.00);
-  --tp-button-background-color-hover: hsla(0, 0%, 85%, 1.00);
-  --tp-button-foreground-color: hsla(0, 0%, 0%, 0.80);
-  --tp-container-background-color: hsla(0, 0%, 0%, 0.30);
-  --tp-container-background-color-active: hsla(0, 0%, 0%, 0.60);
-  --tp-container-background-color-focus: hsla(0, 0%, 0%, 0.50);
-  --tp-container-background-color-hover: hsla(0, 0%, 0%, 0.40);
-  --tp-container-foreground-color: hsla(0, 0%, 100%, 0.50);
-  --tp-groove-foreground-color: hsla(0, 0%, 0%, 0.20);
-  --tp-input-background-color: hsla(0, 0%, 0%, 0.30);
-  --tp-input-background-color-active: hsla(0, 0%, 0%, 0.60);
-  --tp-input-background-color-focus: hsla(0, 0%, 0%, 0.50);
-  --tp-input-background-color-hover: hsla(0, 0%, 0%, 0.40);
-  --tp-input-foreground-color: hsla(0, 0%, 100%, 0.50);
-  --tp-label-foreground-color: hsla(0, 0%, 100%, 0.50);
-  --tp-monitor-background-color: hsla(0, 0%, 0%, 0.30);
-  --tp-monitor-foreground-color: hsla(0, 0%, 100%, 0.30);
   /* added by https://ui.shadcn.com */
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -74,7 +52,7 @@
 }
 /* Light Theme */
 [data-theme='light'] {
-  --background: hsla(0, 0%, 98%, 1);
+  --background: #ededed;
   --foreground: hsla(0, 0%, 9%, 1);
   --background-plot: hsla(0, 5%, 85%, 0.8);
   --text-plot: hsla(0, 0%, 0%, 0.9);
@@ -91,33 +69,11 @@
   --text-paragraph: hsla(0, 0%, 29%, 1);
   --text-link: hsla(0, 0%, 15%, 1);
   --text-link-hover: hsla(0, 0%, 13%, 1);
-  /* for tweakpane light theme */
-  --tp-base-background-color: hsla(230, 5%, 90%, 1.00);
-  --tp-base-shadow-color: hsla(0, 0%, 0%, 0.10);
-  --tp-button-background-color: hsla(230, 7%, 75%, 1.00);
-  --tp-button-background-color-active: hsla(230, 7%, 60%, 1.00);
-  --tp-button-background-color-focus: hsla(230, 7%, 65%, 1.00);
-  --tp-button-background-color-hover: hsla(230, 7%, 70%, 1.00);
-  --tp-button-foreground-color: hsla(230, 10%, 30%, 1.00);
-  --tp-container-background-color: hsla(230, 15%, 30%, 0.20);
-  --tp-container-background-color-active: hsla(230, 15%, 30%, 0.32);
-  --tp-container-background-color-focus: hsla(230, 15%, 30%, 0.28);
-  --tp-container-background-color-hover: hsla(230, 15%, 30%, 0.24);
-  --tp-container-foreground-color: hsla(230, 10%, 30%, 1.00);
-  --tp-groove-foreground-color: hsla(230, 15%, 30%, 0.10);
-  --tp-input-background-color: hsla(230, 15%, 30%, 0.10);
-  --tp-input-background-color-active: hsla(230, 15%, 30%, 0.22);
-  --tp-input-background-color-focus: hsla(230, 15%, 30%, 0.18);
-  --tp-input-background-color-hover: hsla(230, 15%, 30%, 0.14);
-  --tp-input-foreground-color: hsla(230, 10%, 30%, 1.00);
-  --tp-label-foreground-color: hsla(230, 10%, 30%, 0.70);
-  --tp-monitor-background-color: hsla(230, 15%, 30%, 0.10);
-  --tp-monitor-foreground-color: hsla(230, 10%, 30%, 0.50);
 }
 
 /* Dark Theme */
 [data-theme='dark'] {
-  --background: #1e2023;
+  --background: #0a0a0a;
   --foreground: hsla(0, 0%, 100%, 0.9);
   --background-plot: hsla(0, 0%, 0%, 0.3);
   --text-plot: hsla(0, 0%, 100%, 0.9);
@@ -171,6 +127,7 @@
 
 body {
   font-size: 12px;
+  background: linear-gradient(to bottom right, #2a2a2a, #1c1c1c);
 }
 
 .canvas {

--- a/src/components/ui/PlotType.tsx
+++ b/src/components/ui/PlotType.tsx
@@ -4,6 +4,8 @@ import React, { useEffect, useState } from 'react'
 import './css/MainPanel.css'
 import { usePlotStore } from '@/utils/GlobalStates';
 import { useShallow } from 'zustand/shallow';
+import Image from 'next/image';
+
 const plotTypes = ['volume', 'point-cloud', 'sphere', 'flat']
 
 const PlotType = ({currentOpen, setOpen} : {currentOpen: string, setOpen: React.Dispatch<React.SetStateAction<string>>}) => {
@@ -21,12 +23,43 @@ const PlotType = ({currentOpen, setOpen} : {currentOpen: string, setOpen: React.
 
   return (
     <div style={{position:'relative'}}>
-        <div className='panel-item' onClick={e=>{setShowOptions(x=>!x); setOpen('plot-type')}} > <img src={`/plottypes/${plotType}.svg`} alt="" height={'60%'} width={'60%'}/> </div>
-        <div className='panel-item-options' style={{transform: showOptions ? 'scale(100%) ' : 'scale(0%) ', overflow:'hidden', height:'600px', paddingTop:'40px'}}>
-            {plotTypes.map((val)=>(
-                <img key={val} className='plot-type' src={`/plottypes/${val}.svg`} onClick={e=>{setShowOptions(false); setPlotType(val)}}/>
-            ))}
-        </div>
+      <div
+        className='panel-item'
+        onClick={e => {
+          setShowOptions(x => !x);
+          setOpen('plot-type');
+        }}
+      >
+        <Image
+          src={`/plottypes/${plotType}.svg`}
+          alt=""
+          height={48}
+          width={48}
+          style={{objectFit: 'contain'}}
+        />
+      </div>
+      <div
+        className='panel-item-options'
+        style={{
+          transform: showOptions ? 'scale(100%)' : 'scale(0%)',
+        }}
+      >
+        {plotTypes.map((val) => (
+          <Image
+            key={val}
+            className='plot-type'
+            src={`/plottypes/${val}.svg`}
+            alt={val}
+            width={90}
+            height={90}
+            style={{cursor: 'pointer'}}
+            onClick={e => {
+              setShowOptions(false);
+              setPlotType(val);
+            }}
+          />
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/ui/VariableScroller.tsx
+++ b/src/components/ui/VariableScroller.tsx
@@ -43,9 +43,8 @@ const MetaDataInfo = ({meta} : {meta : any}) =>{
     },[currentSize])
 
     return(
-        <div className='meta-container max-w-sm md:max-w-md'
-          style={{ background: 'var(--background)',border: '1px solid var(--border)', borderRadius: '8px', padding: '10px', marginBottom: '10px' }}>
-            <div className='meta-info'>
+        <div className='meta-container max-w-sm md:max-w-md'>
+            <div>
                 <b>Long Name:</b> {`${meta.long_name}`}<br/>
                     <br/>
                     <b>Shape:</b> {`[${formatArray(meta.shape)}]`}<br/>

--- a/src/components/ui/css/MainPanel.css
+++ b/src/components/ui/css/MainPanel.css
@@ -119,15 +119,15 @@
 }
 
 .cmap{
-    padding: 1px 0px;
+    padding: 2px 0px;
     cursor: pointer;
     max-width: 200px;
     height: 24px;
-    border-radius: 4px;
+    border-radius: 6px;
 }
 
 .cmap:hover{
-    transform: scale(1.25, 0.9);
+    transform: scale(1.05, 1.4);
     transition: 0.1s;
 }
 

--- a/src/components/ui/css/MainPanel.css
+++ b/src/components/ui/css/MainPanel.css
@@ -5,24 +5,33 @@
     justify-content: space-around;
     align-items: center;
     right: 20px;
-    width: 100px;
+    width: 60px;
     height: 50vh;
+    min-height: 250px;
     top: 25vh;;
     z-index: 2;
-    background-color: beige;
-    border-radius: 50px;
+    padding: 0.4rem 0.4rem;
+    background: rgba(40, 40, 50, 0.1);
+    border: 0.5px solid rgba(255, 255, 255, 0.18);
+    box-shadow: 0 2px 2px 0 rgba(217, 213, 216, 0.22);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    font-size: 1.85rem;
+    border-radius: 1.55rem;
     user-select: none;
 }
 
 .panel-item{
     position: relative;
-    width: 90px;
-    height: 90px;
+    width: 48px;
+    height: 48px;
+    padding: 2px;
     border-radius: 50%;
-    background-color: aqua;
+    background-color: var(--foreground);
+    color: var(--background);
     cursor: pointer;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    /* margin-top: 10px; */
+    /* margin-bottom: 10px; */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -30,21 +39,35 @@
 }
 
 
-.panel-item-options{
+.panel-item-options {
     position: absolute;
+    top: 4px;
     right: calc(100% + 10px);
-    width: 110px;
-    background-color: rgb(182, 182, 45);
+    width: 60px;
+    height: 50vh;
+    min-height: 250px;
+    max-height: 350px;
     display: flex;
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
-    border-radius: 50px;
     transform-origin: 125% 37%;
     transition: 0.25s;
-    align-self: center;
+    padding: 0.4rem 0.4rem;
+    background: rgba(40, 40, 50, 0.1);
+    border: 0.5px solid rgba(255, 255, 255, 0.18);
+    box-shadow: 0 2px 2px 0 rgba(217, 213, 216, 0.22);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    font-size: 1.85rem;
+    border-radius: 1.55rem;
     z-index: 1;
     overflow: auto;
+}
+
+.panel-item-options b {
+    font-size: 1rem;
+    font-weight: bold;
 }
 
 .panel-item-options::-webkit-scrollbar{
@@ -63,9 +86,11 @@
 
 .plot-type{
     cursor: pointer;
-    margin: 20px 10px;
-    width: 90px;
-    height: 90px;
+    background-color: var(--foreground);
+    padding: 2px;
+    width: 48px;
+    height: 48px;
+    border-radius: 1.55rem;
 }
 
 .plot-type:hover{
@@ -83,12 +108,13 @@
     padding: 1px 0px;
     cursor: pointer;
     width: 100px;
+    font-size: 24px;
 }
 
 .variable-item:hover{
-    background-color: aliceblue;
+    background-color: var(--accent-2);
     border-radius: 3px;
-    transform: scale(120%);
+    transform: scale(95%);
     transition: 0.1s;
 }
 
@@ -96,12 +122,12 @@
     padding: 1px 0px;
     cursor: pointer;
     max-width: 200px;
-    height: 50px;
-    border-radius: 10px;
+    height: 24px;
+    border-radius: 4px;
 }
 
 .cmap:hover{
-    transform: scale(1.05, 1.4);
+    transform: scale(1.25, 0.9);
     transition: 0.1s;
 }
 
@@ -121,12 +147,12 @@
 
 .meta-options{
     position: absolute;
-    right: 110%;
+    right: 102%;
     top: 0%;
     background-color: bisque;
 }
 
-.meta-container{
+.meta-container {
     text-align: center;
     position: absolute;
     width: 200px;
@@ -134,10 +160,15 @@
     top: 0%;
     z-index: 1;
     font-size: 16px;
-    border-radius: 50px;
+    border-radius: 10px;
     padding: 10px;
     display: flex;
     flex-direction: column;
+    /* background: rgba(40, 40, 50, 0.1);  */
+    box-shadow: 0 2px 2px 0 rgba(217, 213, 216, 0.22);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    border: 0.5px solid rgba(255, 255, 255, 0.18);
 }
 
 .meta-container button{
@@ -151,36 +182,99 @@
     width: 98%;
 }
 
+@media (max-width: 768px) {
+  .panel-container {
+    flex-direction: row;
+    width: 90vw;
+    max-width: 600px;
+    left: 50%;
+    right: auto;
+    top: auto;
+    bottom: 0.5rem;
+    transform: translateX(-50%);
+    height: auto;
+    min-height: 0;
+  }
 
-@media (max-width: 1024px) {
-  .meta-container{
-    top: 12%;
+  .panel-item-options {
+    position: fixed; /* Changed from absolute to fixed */
+    left: 0; /* Always start from left edge of screen */
+    bottom: 110%; /* Keep same bottom positioning */
+    top: auto;
+    right: auto;
+    transform: none;
+    /* width: 50vw; */
+    max-width: 50vw;
+    min-width: 60px;
+    max-height: 200px;
+    min-height: 20vh;
+    height: auto;
+    width: auto;
+    border-radius: 1.55rem 1.55rem 0 0;
+    z-index: 10;
+    overflow-y: auto;
+    overflow-x: hidden;
+    background: rgba(40, 40, 50, 0.1);
+    box-shadow: 0 2px 2px 0 rgba(217, 213, 216, 0.22);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    border: 0.5px solid rgba(255, 255, 255, 0.18);
+    font-size: 0.9rem;
+    padding: 0.3rem 0.3rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    transition: 0.25s;
+  }
+
+  /* Additional adjustments for mobile items */
+  .variable-item {
     font-size: 16px;
-    min-width: 350px;
-    max-width: 450px;
+    width: 50px;
+    text-align: left;
+    padding-left: 4px;
   }
-}
+  .variable-scroller {
+    width: 100%; 
+    padding: 0px 0px;
+    align-items: stretch;
+  }
 
-@media (max-width: 570px) {
-  .meta-container{
-    top: 12%;
-    font-size: 16px;
-    width: 85%;
+  .panel-item-options b {
+    font-size: 0.8rem; /* Smaller bold text */
   }
-  .scroll-item {
-    font-size: 32px;
-    margin: 3px;
-  }
-}
+  .meta-container {
+    position: fixed;
+    bottom: 4.5rem;
+    right: calc(-164px + 0rem);
+    left: auto;
+    top: auto;
+    
+    width: auto;
+    max-width: 42vw;
+    min-width: 60px;
 
-@media (max-width: 480px) {
-  .meta-container{
-    top: 12%;
     font-size: 14px;
-    width: 85%;
+    padding: 0.6rem;
+    border-radius: 1rem;
+    z-index: 10;
+
+    background: rgba(40, 40, 50, 0.1);
+    box-shadow: 0 2px 2px 0 rgba(217, 213, 216, 0.22);
+    backdrop-filter: blur(22px) saturate(180%);
+    -webkit-backdrop-filter: blur(22px) saturate(180%);
+    border: 0.5px solid rgba(255, 255, 255, 0.18);
+    overflow-y: auto;
+    text-align: left;
   }
-  .scroll-item {
-    font-size: 24px;
-    margin: 3px;
+
+  .meta-container button {
+    margin: 8px 10px 10px;
+    font-size: 12px;
+    padding: 4px 8px;
+  }
+  .cmap{
+    max-width: 40vw;
   }
 }


### PR DESCRIPTION
some css cleanup (removed some tweakpane css), but also updated the latest css to be mobile friendly. Please, see if it's possible to continue from here, or achieve the same from a different approach. 

In the final version it would be nice to have also some text underneath, like in 

<img width="522" height="113" alt="Screenshot 2025-07-22 at 00 51 12" src="https://github.com/user-attachments/assets/e0e5c39e-2660-4c2d-b603-c0374a56c962" />

we are still missing the `stores` option, `camera, lineplot -> (maybe into options?)`.

