### PR TITLE
Initial Commit

### DIFF
--- a/src/components/LandingHome.tsx
+++ b/src/components/LandingHome.tsx
@@ -29,7 +29,7 @@ export function LandingHome() {
 
   const ZarrDS = useMemo(() => new ZarrDataset(currentStore), [currentStore]) //Update Dataset if store changes
   const [titleDescription, setTitleDescription] = useState<{ title?: string; description?: string }>({});
-
+  
   useEffect(() => {
     let isMounted = true;
     GetTitleDescription(currentStore).then((result) => {

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -25,7 +25,6 @@ const HorizontalAxis = ({flipX, flipY}: {flipX: boolean, flipY: boolean}) =>{
     timeScale: state.timeScale,
     animProg: state.animProg
   })))
-
   const dimLengths = [dimArrays[0].length, dimArrays[1].length, dimArrays[2].length]
 
   const {shape, dataShape} = useGlobalStore(useShallow(state => ({
@@ -38,6 +37,7 @@ const HorizontalAxis = ({flipX, flipY}: {flipX: boolean, flipY: boolean}) =>{
   const depthRatio = useMemo(()=>dataShape[0]/dataShape[1]*timeScale/2,[dataShape, timeScale]);
 
   const shapeRatio = useMemo(()=>shape.y/shape.x, [shape])
+
   //@ts-expect-error The THREE people messed up their types in this component. It does take a string
   const lineMat = useMemo(()=>new LineMaterial({color: 'orange', linewidth: 5}),[])
   const dimResolution = 7;

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -27,7 +27,7 @@ export const DataCube = ({ volTexture }: DataCubeProps ) => {
       nanTransparency: state.nanTransparency,
       nanColor: state.nanColor
     })))
-
+    const aspectRatio = shape.y/shape.x
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
       glslVersion: THREE.GLSL3,
       uniforms: {
@@ -38,7 +38,7 @@ export const DataCube = ({ volTexture }: DataCubeProps ) => {
           threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
           scale: {value: shape},
           flatBounds:{value: new THREE.Vector4(-xRange[1],-xRange[0],zRange[0],zRange[1])},
-          vertBounds:{value: new THREE.Vector2(yRange[0]/shape.x,yRange[1]/shape.x)},
+          vertBounds:{value: new THREE.Vector2(yRange[0]*aspectRatio,yRange[1]*aspectRatio)},
           steps: { value: quality },
           animateProg: {value: animProg},
           transparency: {value: transparency},
@@ -51,7 +51,7 @@ export const DataCube = ({ volTexture }: DataCubeProps ) => {
       blending: THREE.NormalBlending,
       depthWrite: false,
       side: THREE.BackSide,
-    }),[volTexture, colormap, cOffset, cScale, valueRange, xRange, yRange, zRange, quality, animProg, useFragOpt, transparency, nanTransparency, nanColor]);
+    }),[volTexture, shape, colormap, cOffset, cScale, valueRange, xRange, yRange, zRange, quality, animProg, useFragOpt, transparency, nanTransparency, nanColor]);
         
   // Use geometry once, avoid recreating -- Using a sphere to avoid the weird angles you get with cube
     const geometry = useMemo(() => new THREE.IcosahedronGeometry(2, 4), []);

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -98,12 +98,13 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
           setShowLoading: state.setShowLoading  
         }
         )))
-    const {colormap, variable, isFlat, metadata, valueScales, setIsFlat, setDataArray} = useGlobalStore(useShallow(state=>({
+    const {colormap, variable, isFlat, metadata, valueScales, is4D, setIsFlat, setDataArray} = useGlobalStore(useShallow(state=>({
       colormap: state.colormap, 
       variable: state.variable, 
       isFlat: state.isFlat, 
       metadata: state.metadata, 
       valueScales: state.valueScales,
+      is4D: state.is4D,
       setIsFlat: state.setIsFlat, 
       setDataArray: state.setDataArray
     })))
@@ -173,7 +174,12 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       //Get Metadata
       ZarrDS.GetAttributes(variable).then((result)=>{
         setMetadata(result);
-        const [dimArrs, dimMetas, dimNames] = ZarrDS.GetDimArrays()
+        let [dimArrs, dimMetas, dimNames] = ZarrDS.GetDimArrays()
+        if (is4D){
+          dimArrs = dimArrs.slice(1);
+          dimMetas = dimMetas.slice(1);
+          dimNames = dimNames.slice(1);
+        }
         setDimArrays(dimArrs)
         setDimNames(dimNames)
         if (dimArrs.length > 2){

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -157,6 +157,7 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
     }, [texture]);
     const aspectRatio = useMemo(()=>width/height,[width,height]);
     const depthRatio = useMemo(()=>depth/height,[depth,height]);
+
     const { positions, values } = useMemo(() => {
       let positions;
       try{
@@ -165,7 +166,6 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         setOom(true) //Set out of memeory error
         return {positions: [], values: []};
       }
-      
       const values = new Uint8Array(depth*height*width);
       //Generate grid points based on texture shape
       for (let z = 0; z < depth; z++) {
@@ -174,13 +174,13 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
             const index = x + y * width + z * width * height;
             const value = (data as number[])[index] || 0;
               // Normalize coordinates acceptable range
-            const px = ((x / (width - 1)) - 0.5) * aspectRatio /2; //The divide by two is So it's the same scale as the volume 
-            const py = ((y / (height - 1)) - 0.5)/2;
-            const pz = ((z / (depth - 1)) - 0.5) * depthRatio /2;
+            const px = ((x / (width - 1)) - 0.5) ; 
+            const py = ((y / (height - 1)) - 0.5)/aspectRatio;
+            const pz = ((z / (depth - 1)) - 0.5) * depthRatio ;
             const posIdx = index*3;
             positions[posIdx] = px * 2;
-            positions[posIdx + 1] = py * 2;
-            positions[posIdx + 2] = pz * 2;
+            positions[posIdx + 1] = py *2 ;
+            positions[posIdx + 2] = pz ;
             values[index] = value;
           }
         }
@@ -211,8 +211,8 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         timeScale: {value: timeScale},
         animateProg: {value: animProg},
         depthRatio: {value: depthRatio},
-        flatBounds:{value: new THREE.Vector4(xRange[0]*aspectRatio/2, xRange[1]*aspectRatio/2, zRange[0]*depthRatio/2, zRange[1]*depthRatio/2)},
-        vertBounds:{value: new THREE.Vector2(yRange[0]/2, yRange[1]/2)},
+        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio/2, zRange[1]*depthRatio/2)},
+        vertBounds:{value: new THREE.Vector2(yRange[0]/aspectRatio, yRange[1]/aspectRatio)},
       },
       vertexShader:pointVert,
       fragmentShader:pointFrag,
@@ -223,7 +223,6 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
     })
     ),[pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, pointIDs, stride, selectTS, animProg, timeScale, depthRatio, aspectRatio, xRange, yRange, zRange]);
 
-    
 
     return (
       <>

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -42,7 +42,6 @@ void main() {
 
     scaledPos.z *= timeScale;
     gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
-    //If it is nan we just yeet it tf out of the screen space. LMAO I love this solution
     float pointScale = pointSize/gl_Position.w;
     pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
 

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -116,6 +116,7 @@ const Dataset = () => {
               setShowLocalInput((prev) => !prev);
               setShowStoreInput(false);
               setActiveOption('local')
+              setInitStore('local')
             }}
           >
             Local

--- a/src/components/ui/MainPanel/MetaDataInfo.tsx
+++ b/src/components/ui/MainPanel/MetaDataInfo.tsx
@@ -69,7 +69,8 @@ const MetaDataInfo = ({ meta, setShowMeta }: { meta: any, setShowMeta: React.Dis
   })
 
   useEffect(()=>{
-    setSlice([0,null])
+    setSlice([0,null]);
+    setIdx4D(null)
   },[meta])
 
   return (
@@ -131,6 +132,7 @@ const MetaDataInfo = ({ meta, setShowMeta }: { meta: any, setShowMeta: React.Dis
       <Button
         variant="destructive"
         className="cursor-pointer hover:scale-[1.05]"
+        disabled={(is4D && idx4D == null)}
         onClick={() => {
           if (variable == meta.name){
             setReFetch(!reFetch)

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -18,7 +18,7 @@ const Variables = () => {
       zMeta: state.zMeta,
     }))
   );
-
+  console.log(zMeta)
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [meta, setMeta] = useState<any>(null);
 

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -18,7 +18,6 @@ const Variables = () => {
       zMeta: state.zMeta,
     }))
   );
-  console.log(zMeta)
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [meta, setMeta] = useState<any>(null);
 

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -83,11 +83,11 @@ export class ZarrDataset{
 		const outVar = await zarr.open(group.resolve(variable), {kind:"array"})
 		let [totalSize, _chunkSize, chunkShape] = GetSize(outVar);
 		if (is4D){
-			totalSize /= chunkShape[0];
+			totalSize /= outVar.shape[0];
 			chunkShape = chunkShape.slice(1);
+			_chunkSize /=  outVar.shape[0] //Don't need to use this but Lint is being a whiner
 		}
 		const hasTimeChunks = is4D ? outVar.shape[1]/chunkShape[0] > 1 : outVar.shape[0]/chunkShape[0] > 1
-		console.log(hasTimeChunks)
 		// Type check using zarr.Array.is
 		if (outVar.is("number") || outVar.is("bigint")) {
 			let chunk;

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -1,8 +1,7 @@
 import { create } from "zustand";
 import * as THREE from 'three';
-import * as zarr from 'zarrita'
 import { GetColorMapTexture } from "@/components/textures";
-import { GetStore, ZARR_STORES } from "@/components/zarr/ZarrLoaderLRU";
+import { GetStore } from "@/components/zarr/ZarrLoaderLRU";
 
 const ESDC = 'https://s3.bgc-jena.mpg.de:9000/esdl-esdc-v3.0.2/esdc-16d-2.5deg-46x72x1440-3.0.2.zarr'
 
@@ -41,6 +40,8 @@ type StoreState = {
   isFlat: boolean;
   progress: number,
   downloading: boolean;
+  is4D: boolean;
+  idx4D: number | null;
 
   setDataShape: (dataShape: number[]) => void;
   setShape: (shape: THREE.Vector3) => void;
@@ -67,6 +68,8 @@ type StoreState = {
   setIsFlat: (isFlat: boolean) => void;
   setProgress: (progress: number) => void;
   setDownloading: (downloading: boolean) => void;
+  setIs4D: (is4D: boolean) => void;
+  setIdx4D: (idx4D: number | null) => void;
 };
 
 export const useGlobalStore = create<StoreState>((set, get) => ({
@@ -93,6 +96,9 @@ export const useGlobalStore = create<StoreState>((set, get) => ({
   isFlat:false,
   progress: 0,
   downloading: false,
+  is4D: false,
+  idx4D: null,
+
 
 
   setDataShape: (dataShape) => set({ dataShape}),
@@ -138,8 +144,9 @@ export const useGlobalStore = create<StoreState>((set, get) => ({
   setPlotOn: (plotOn) => set({ plotOn }),
   setIsFlat: (isFlat) => set({ isFlat}),
   setProgress: (progress) => set({ progress }),
-  setDownloading: (downloading) => set({ downloading })
-
+  setDownloading: (downloading) => set({ downloading }),
+  setIs4D: (is4D) => set({ is4D }),
+  setIdx4D: (idx4D) => set({ idx4D }),
 }));
 
 type PlotState ={

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -54,6 +54,9 @@ export function parseLoc(input:number, units: string | undefined, verbose: boole
         return input
     }
     if (typeof(input) == 'bigint'){
+      if (!units){
+        return Number(input)
+      }
       try{
         const scale = parseTimeUnit(units)
         const timeStamp = Number(input) * scale;


### PR DESCRIPTION
This update is aimed to make BrowZarr more flexible with personal datasets. This one allows the use of four dimensional datasets. 
When the user tries to access a variable that is 4D, they will be prompted to select an index along the first dimension. 

<img width="273" height="355" alt="image" src="https://github.com/user-attachments/assets/7830e6a2-18a2-432c-859a-9be9fef2121b" />

After inputting the value they will then be allowed to plot 

<img width="269" height="384" alt="image" src="https://github.com/user-attachments/assets/6083b1d7-af71-4da2-8a00-a83439fef05c" />

I also added logic to check if there are chunks along the time dimension. If there aren't it won't show a slicer. This logic is also implemented in the ZarrLoader component.

I also cleaned up some logic in the ZarrLoader with regards to shape that I don't think would have been flexible with additional personal datasets. However, I will need more datasets to explore to check how robust the current logic is.


