### PR TITLE
Global Nan Colors

### DIFF
--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -211,7 +211,7 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         timeScale: {value: timeScale},
         animateProg: {value: animProg},
         depthRatio: {value: depthRatio},
-        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio/2, zRange[1]*depthRatio/2)},
+        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio, zRange[1]*depthRatio)},
         vertBounds:{value: new THREE.Vector2(yRange[0]/aspectRatio, yRange[1]/aspectRatio)},
       },
       vertexShader:pointVert,

--- a/src/components/textures/shaders/flatFrag3D.glsl
+++ b/src/components/textures/shaders/flatFrag3D.glsl
@@ -6,17 +6,18 @@ uniform sampler2D cmap;
 uniform float cOffset;
 uniform float cScale;
 uniform float animateProg;
+uniform float nanAlpha;
+uniform vec3 nanColor;
 
 varying vec2 vUv;
 out vec4 Color;
 
 void main() {
-    vec4 val = texture(data,vec3(vUv, animateProg));
-    float d = val.x;
-    float sampLoc = d == 1. ? d : (d - 0.5)*cScale + 0.5;
-    sampLoc = d == 1. ? d : min(sampLoc+cOffset,0.99);
-    vec4 color = texture(cmap, vec2(sampLoc,0.5));
-    color.a = val.x > 0.999 ? 0. : 1.;
 
-    Color = color;
+    float strength = texture(data,vec3(vUv, animateProg)).r;
+    bool isNaN = strength == 1.;
+    float sampLoc = isNaN ? strength: (strength - 0.5)*cScale + 0.5;
+    sampLoc = isNaN ? strength : sampLoc+cOffset;
+    Color = isNaN ? vec4(nanColor, nanAlpha) : vec4(texture2D(cmap, vec2(sampLoc, 0.5)).rgb, 1.);
+
 }

--- a/src/components/textures/shaders/flatSphereFrag.glsl
+++ b/src/components/textures/shaders/flatSphereFrag.glsl
@@ -15,6 +15,8 @@ uniform float animateProg;
 uniform bool selectTS;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
+uniform vec3 nanColor;
+uniform float nanAlpha;
 
 #define pi 3.141592653
 
@@ -31,10 +33,13 @@ vec2 giveUV(vec3 position){
 void main(){
     vec2 sampleCoord = giveUV(aPosition);
     float strength = texture(map, sampleCoord).r;
-    strength = strength == 1. ? strength : (strength - 0.5)*cScale + 0.5;
-    strength = strength == 1. ? strength : min(strength+cOffset,0.99);
-    color = texture(cmap, vec2(strength, 0.5));
-    color.a = 1.;
-    // color = vec4(sampleCoord, 0., 1.0);
+    bool isNaN = strength == 1.;
+    strength = isNaN ? strength : (strength - 0.5)*cScale + 0.5;
+    strength = isNaN ? strength : min(strength+cOffset,0.99);
+    color = isNaN ? vec4(nanColor, nanAlpha) : texture(cmap, vec2(strength, 0.5));
+    if (!isNaN){
+        color.a = 1.;
+    }
+
 
 }

--- a/src/components/textures/shaders/fragmentFlat.glsl
+++ b/src/components/textures/shaders/fragmentFlat.glsl
@@ -4,19 +4,21 @@ precision highp sampler3D;
 
 out vec4 color;
 
-in vec2 Vuv;
+varying vec2 vUv;
 
-uniform sampler2D map;
+uniform sampler2D data;
 uniform sampler2D cmap;
-
-
+uniform float nanAlpha;
+uniform vec3 nanColor;
+uniform float cOffset;
+uniform float cScale;
 
 void main(){
 
-    float strength = texture2D(map, Vuv).r;
-
-    color = vec4(strength,0.,0.,1.);
-
-    color.rgb = texture2D(cmap, vec2(strength, 0.5)).rgb;
+    float strength = texture2D(data, vUv).r;
+    bool isNaN = strength == 1.;
+    float sampLoc = isNaN ? strength: (strength - 0.5)*cScale + 0.5;
+    sampLoc = isNaN ? strength : sampLoc+cOffset;
+    color = isNaN ? vec4(nanColor, nanAlpha) : vec4(texture2D(cmap, vec2(sampLoc, 0.5)).rgb, 1.);
 
 }

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -6,6 +6,8 @@ import sphereFrag from './sphereFrag.glsl';
 import fragOpt from './fragmentOpt.glsl';
 import flatSphereFrag from './flatSphereFrag.glsl'
 import bordersFrag from './bordersFrag.glsl'
+import fragmentFlat from './fragmentFlat.glsl'
+import flatFrag3D from './flatFrag3D.glsl'
 export {
     pointFrag,
     pointVert,
@@ -14,5 +16,7 @@ export {
     sphereFrag,
     fragOpt,
     flatSphereFrag,
-    bordersFrag
+    bordersFrag,
+    fragmentFlat,
+    flatFrag3D
 }

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -36,9 +36,9 @@ bool isValidPoint(){
 void main() {
     vValue = value/255.;
     vec3 scaledPos = position;
-    scaledPos.z += depthRatio;
-    scaledPos.z = mod(scaledPos.z + animateProg*2.*depthRatio, 2.*depthRatio);
-    scaledPos.z -= depthRatio;
+    scaledPos.z += depthRatio/2.;
+    scaledPos.z = mod(scaledPos.z + animateProg*depthRatio, depthRatio);
+    scaledPos.z -= depthRatio/2.;
 
     scaledPos.z *= timeScale;
     gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -16,6 +16,8 @@ uniform vec4[10] selectBounds;
 uniform bool selectTS;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
+uniform vec3 nanColor;
+uniform float nanAlpha;
 
 #define pi 3.141592653
 
@@ -50,18 +52,22 @@ void main(){
     
     if (inBounds) {
     float strength = texture(map, vec3(sampleCoord, animateProg)).r;
-    strength = strength == 1. ? strength : (strength - 0.5)*cScale + 0.5;
-    strength = strength == 1. ? strength : min(strength+cOffset,0.99);
-    color = texture(cmap, vec2(strength, 0.5));
-    
+    bool isNaN = strength == 1.;
+    strength = isNaN ? strength : (strength - 0.5)*cScale + 0.5;
+    strength = isNaN ? strength : min(strength+cOffset,0.99);
+    color = isNaN ? vec4(nanColor, nanAlpha) : texture(cmap, vec2(strength, 0.5));
+    if (!isNaN){
+        color.a = 1.;
+    }
     bool cond = isValid(sampleCoord);
     if (!cond && selectTS){
         color.rgb *= 0.65;
     }
     } else {
-        color = vec4(0.0, 0.0, 0.0, 1.0); // Black
+        color = vec4(nanColor, 1.); // Black
+        color.a = nanAlpha;
     }
-    color.a = 1.;
+    
     // color = vec4(sampleCoord, 0., 1.0);
 
 }

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -136,21 +136,6 @@ const VolumeOptions = ()=>{
               className='w-full mb-2'
           onValueChange={(vals:number[]) => setTransparency(vals[0])}
           />
-      <b>NaN Transparency</b>
-      <UISlider
-              min={0}
-              max={1}
-              step={0.05}
-              value={[nanTransparency]}
-              className='w-full mb-2'
-          onValueChange={(vals:number[]) => setNanTransparency(vals[0])}
-          />
-        <b>NaN Color</b>
-      <input type="color"
-      className='w-[100%] cursor-pointer'
-              value={nanColor}
-          onChange={e => setNanColor(e.target.value)}
-          />
     </div>
   )
 }
@@ -260,15 +245,34 @@ const SpatialExtent = () =>{
 }
 
 const GlobalOptions = () =>{
-  const {showBorders, borderColor, setShowBorders, setBorderColor} = usePlotStore(useShallow(state => ({
+  const {showBorders, borderColor, nanColor, nanTransparency, setShowBorders, setBorderColor, setNanColor, setNanTransparency} = usePlotStore(useShallow(state => ({
     showBorders: state.showBorders,
     borderColor: state.borderColor,
+    nanColor: state.nanColor,
+    nanTransparency: state.nanTransparency,
     setShowBorders: state.setShowBorders,
-    setBorderColor: state.setBorderColor
+    setBorderColor: state.setBorderColor,
+    setNanColor: state.setNanColor,
+    setNanTransparency: state.setNanTransparency
   })))
 
   return (
     <div className='grid gap-y-[5px] items-center w-50 text-center'>
+      <b>NaN Transparency</b>
+      <UISlider
+              min={0}
+              max={1}
+              step={0.05}
+              value={[nanTransparency]}
+              className='w-full mb-2'
+          onValueChange={(vals:number[]) => setNanTransparency(vals[0])}
+          />
+        <b>NaN Color</b>
+      <input type="color"
+      className='w-[100%] cursor-pointer'
+              value={nanColor}
+          onChange={e => setNanColor(e.target.value)}
+          />
       <Button variant="pink" size="sm" className="w-[100%] cursor-[pointer] mb-2 mt-2" onClick={() => setShowBorders(!showBorders)}>{showBorders ? "Hide Borders" : "Show Borders" }</Button>
       {showBorders && <div>
       <b>Border Color</b>
@@ -345,7 +349,7 @@ const AdjustPlot = () => {
           {plotType === 'volume' && <VolumeOptions />}
           {plotType === 'point-cloud' && <PointOptions />}
           {(plotType === 'volume' || plotType === 'point-cloud') && <DimSlicer />}
-          <GlobalOptions />
+          {plotType != 'point-cloud' && <GlobalOptions />}
         </PopoverContent>
       </Popover>
   )

--- a/src/components/ui/css/MainPanel.css
+++ b/src/components/ui/css/MainPanel.css
@@ -62,7 +62,7 @@
 }
 
 .colormaps{
-    height: 50vh;
+    max-height: 50vh;
     width: 234px;
     display:grid;
     gap:3px;


### PR DESCRIPTION
This allows the user to adjust the Nan and transparency for the Sphere and Flatmap views. It is currently disabled on PointCloud.
Allows see through in the sphere

<img width="682" height="625" alt="image" src="https://github.com/user-attachments/assets/0ffa5275-e15b-4f21-96cb-107ae68f5677" />

Looks cool with ocean NaN values

<img width="615" height="618" alt="image" src="https://github.com/user-attachments/assets/07da260f-60fb-4ccc-9d92-d142d0124ea0" />

This also fixed an issue with the analysis in Flatview. 

```ts
dataIdx += isFlat ? 0 : Math.floor((dimArrays[0].length-1) * animProg) * xSize*ySize
```

This line fixed it. As it previously wasn't scaling properly and was using the length of the array for indexing. When indexing goes to `length - 1` 

While exploring a noticed a flaw in the PointCloud animation logic that broke during the 4D update. So I tweaked that and tested on personal dataset. Should be more robust now.  