### PR TITLE
Unified Timeseries Colors

### DIFF
--- a/src/components/plots/plotarea/LinePlot.tsx
+++ b/src/components/plots/plotarea/LinePlot.tsx
@@ -7,7 +7,6 @@ import './LinePlot.css'
 import { useGlobalStore } from '@/utils/GlobalStates'
 import { useShallow } from 'zustand/shallow'
 import PlotLineOptions from '@/components/ui/LinePlotArea/PlotLineOptions'
-import { evaluate_cmap } from 'js-colormaps-es';
 import { IoCloseCircleSharp } from "react-icons/io5";
 import { DimCoords } from '@/utils/GlobalStates'
 
@@ -69,7 +68,12 @@ function PointInfo({pointID,pointLoc,showPointInfo, plotUnits}:pointInfo){
 }
 
 function PointCoords(){
-  const {coords, timeSeries, setDimCoords, setTimeSeries} = useGlobalStore(useShallow(state=>({coords: state.dimCoords, timeSeries: state.timeSeries, setDimCoords: state.setDimCoords, setTimeSeries: state.setTimeSeries})))
+  const {coords, timeSeries, setDimCoords, setTimeSeries} = useGlobalStore(useShallow(state=>({
+    coords: state.dimCoords, 
+    timeSeries: state.timeSeries, 
+    setDimCoords: state.setDimCoords, 
+    setTimeSeries: state.setTimeSeries}
+  )))
   const [moving,setMoving] = useState<boolean>(false)
   const initialMouse = useRef<number[]>([0,Math.round(window.innerHeight*0.255)])
   const initialDiv = useRef<number[]>([0,Math.round(window.innerHeight*0.255)])
@@ -130,7 +134,7 @@ function PointCoords(){
         <div className='plot-coords'
         key={val}   
         style={{
-          background: `rgb(${evaluate_cmap(idx/10,'Paired')})`,
+          background: `rgb(${timeSeries[val]['color']})`,
           justifyContent:'space-between'
         }}
       >

--- a/src/components/plots/plotarea/ThickLine.tsx
+++ b/src/components/plots/plotarea/ThickLine.tsx
@@ -40,15 +40,13 @@ const ThickLine = ({height, xScale, yScale, pointSetters} : ThickLineProps) => {
 		lineResolution: state.lineResolution,
     useCustomColor: state.useCustomColor
   })))
-  const compCache = useRef<string[]> ([]) //Store ids of already calculated spots.
 	const {camera} = useThree()
 
   const {maxVal, minVal} = valueScales
-
   const materials = useMemo(()=>{
         const materialObj: { [key: string]: THREE.ShaderMaterial } = {};
         Object.keys(timeSeries).reverse().map((val, idx)=>{ 
-        const [r,g,b] = evaluate_cmap(idx/10,"Paired");
+        const [r,g,b] = timeSeries[val]['color']
         materialObj[val] = 
         new THREE.ShaderMaterial({
                 glslVersion: THREE.GLSL3,
@@ -93,7 +91,7 @@ const ThickLine = ({height, xScale, yScale, pointSetters} : ThickLineProps) => {
     const geomObj: Record<string, THREE.BufferGeometry> = {}
     const tempInstances: Record<string, THREE.Vector3[]> = {}
     Object.keys(timeSeries).map((val, idx)=>{ 
-      const tempTS = timeSeries[val] as number[]
+      const tempTS = timeSeries[val]['data'] as number[]
       const normed = tempTS.map((i) => (i - minVal) / (maxVal - minVal))
       const size = tempTS.length;
       const xCoords = linspace(-viewWidth,viewWidth,size)
@@ -165,9 +163,9 @@ const ThickLine = ({height, xScale, yScale, pointSetters} : ThickLineProps) => {
 		<group>
       {Object.keys(timeSeries).map((val, idx)=>(
         <mesh key={`lineMesh_${idx}`} geometry={geometries[val]} material={ materials[val]} />))}
-      {showPoints && Object.keys(timeSeries).map((val, idx)=> 
+      {/* {showPoints && Object.keys(timeSeries).map((val, idx)=> 
         <PlotPoints key={`plotPoints_${idx}`} points={instancePoints[val]} tsID={val} colIDX={idx} pointSetters={pointSetters} scalers={{xScale,yScale}}/>
-      )}
+      )} */}
 		</group>
 		</>
   )

--- a/src/components/textures/shaders/flatFrag3D.glsl
+++ b/src/components/textures/shaders/flatFrag3D.glsl
@@ -17,7 +17,7 @@ void main() {
     float strength = texture(data,vec3(vUv, animateProg)).r;
     bool isNaN = strength == 1.;
     float sampLoc = isNaN ? strength: (strength - 0.5)*cScale + 0.5;
-    sampLoc = isNaN ? strength : sampLoc+cOffset;
+    sampLoc = isNaN ? strength : min(sampLoc+cOffset,0.995);
     Color = isNaN ? vec4(nanColor, nanAlpha) : vec4(texture2D(cmap, vec2(sampLoc, 0.5)).rgb, 1.);
 
 }

--- a/src/components/textures/shaders/fragmentFlat.glsl
+++ b/src/components/textures/shaders/fragmentFlat.glsl
@@ -18,7 +18,7 @@ void main(){
     float strength = texture2D(data, vUv).r;
     bool isNaN = strength == 1.;
     float sampLoc = isNaN ? strength: (strength - 0.5)*cScale + 0.5;
-    sampLoc = isNaN ? strength : sampLoc+cOffset;
+    sampLoc = isNaN ? strength : min(sampLoc+cOffset,0.995);
     color = isNaN ? vec4(nanColor, nanAlpha) : vec4(texture2D(cmap, vec2(sampLoc, 0.5)).rgb, 1.);
 
 }

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -21,7 +21,7 @@ type StoreState = {
   shape: THREE.Vector3;
   valueScales: { maxVal: number; minVal: number };
   colormap: THREE.DataTexture;
-  timeSeries: Record<string, any>;
+  timeSeries: Record<string, Record<string, any>>;
   strides: number[];
   showLoading: boolean;
   metadata: Record<string, any> | null;
@@ -47,8 +47,8 @@ type StoreState = {
   setShape: (shape: THREE.Vector3) => void;
   setValueScales: (valueScales: { maxVal: number; minVal: number }) => void;
   setColormap: (colormap: THREE.DataTexture) => void;
-  setTimeSeries: (timeSeries: Record<string, number[]>) => void;
-  updateTimeSeries: (newEntries: Record<string, number[]>) => void;
+  setTimeSeries: (timeSeries: Record<string, Record<string, any>>) => void;
+  updateTimeSeries: (newEntries: Record<string, Record<string, any>>) => void;
   setStrides: (strides: number[]) => void;
   setShowLoading: (showLoading: boolean) => void;
   setMetadata: (metadata: object | null) => void;
@@ -186,6 +186,7 @@ type PlotState ={
   latExtent: [number, number];
   lonResolution: number;
   latResolution: number;
+  colorIdx: number;
 
   setQuality: (quality: number) => void;
   setTimeScale: (timeScale : number) =>void;
@@ -223,10 +224,11 @@ type PlotState ={
   setLatExtent: (latExtent: [number, number]) => void;
   setLonResolution: (lonResolution: number) => void;
   setLatResolution: (latResolution: number) => void;
+  incrementColorIdx: () => void;
+  getColorIdx: () => number;
 }
 
-export const usePlotStore = create<PlotState>((set) => ({
-  //Create the initial state for the plot store
+export const usePlotStore = create<PlotState>((set, get) => ({
   plotType: "sphere", 
   pointSize: 5,
   scalePoints: false,
@@ -263,6 +265,7 @@ export const usePlotStore = create<PlotState>((set) => ({
   latExtent: [-90, 90],
   lonResolution: 1,
   latResolution: 1,
+  colorIdx: 0,
 
   setQuality: (quality) => set({ quality }),
   setTimeScale: (timeScale) => set({ timeScale }),
@@ -299,7 +302,11 @@ export const usePlotStore = create<PlotState>((set) => ({
   setLonExtent: (lonExtent) => set({ lonExtent }),
   setLatExtent: (latExtent) => set({ latExtent }),
   setLonResolution: (lonResolution) => set({ lonResolution }),
-  setLatResolution: (latResolution) => set({ latResolution })
+  setLatResolution: (latResolution) => set({ latResolution }),
+  incrementColorIdx: () => set(state => ({ 
+    colorIdx: (state.colorIdx + 1) % 10 
+  })),
+  getColorIdx: () => get().colorIdx,
 }))
 
 


### PR DESCRIPTION
Made it so the colors sticks to the timeseries lines and labels. Additionally, tied the highlighted columns to the IDs for the timeseries. So they disappear as well now when removing a timeseries line. Also works with the highlighted squares in the sphere view. 

<img width="697" height="424" alt="image" src="https://github.com/user-attachments/assets/a7439c7b-7c0f-4bc0-b42f-083cb2608a87" />

<img width="634" height="398" alt="image" src="https://github.com/user-attachments/assets/9451a633-5db0-4fc1-80c7-69c1d68e89a2" />
