### PR TITLE
Main Menu Tweaks

### DIFF
--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -237,7 +237,7 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         timeScale: {value: timeScale},
         animateProg: {value: animProg},
         depthRatio: {value: depthRatio},
-        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio, zRange[1]*depthRatio)},
+        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio/2, zRange[1]*depthRatio/2)},
         vertBounds:{value: new THREE.Vector2(yRange[0]/aspectRatio, yRange[1]/aspectRatio)},
       },
       vertexShader:pointVert,

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -346,18 +346,20 @@ const AdjustPlot = () => {
   return (
       <Popover>
         <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-10 cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
-            disabled={!enableCond}
-            style={{
-              color: enableCond ? '' : 'var(--text-disabled)',
-              transform: enableCond ? '' : 'scale(1)'
-            }}
-          >
-            <LuSettings className="size-8" />
-          </Button>
+          <div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-10 cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
+              disabled={!enableCond}
+              style={{
+                color: enableCond ? '' : 'var(--text-disabled)',
+                transform: enableCond ? '' : 'scale(1)'
+              }}
+            >
+              <LuSettings className="size-8" />
+            </Button>
+          </div>
         </PopoverTrigger>
         <PopoverContent
           side={isMobile ? 'top' : 'left'}

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -138,18 +138,20 @@ const AnalysisOptions = () => {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-10 cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
-          disabled={!plotOn}
-          style={{
-            color: plotOn ? '' : 'var(--text-disabled)',
-            transform: plotOn ? '' : 'scale(1)'
-          }}
-        >
-          <PiMathOperationsBold className="size-8"/>
-        </Button>
+        <div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-10 cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
+            disabled={!plotOn}
+            style={{
+              color: plotOn ? '' : 'var(--text-disabled)',
+              transform: plotOn ? '' : 'scale(1)'
+            }}
+          >
+            <PiMathOperationsBold className="size-8"/>
+          </Button>
+        </div>
       </PopoverTrigger>
       
       <PopoverContent

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -42,6 +42,7 @@ const Colormaps = () => {
     <div className="relative">
       <Popover>
       <PopoverTrigger asChild>
+        <div>
         <Button
           size="icon"
           className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out rounded-full'
@@ -53,6 +54,7 @@ const Colormaps = () => {
             height: "32px",
           }}
         > </Button>
+        </div>
       </PopoverTrigger>
       <PopoverContent
         side={popoverSide}

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -15,7 +15,7 @@ const ZARR_STORES = {
   SEASFIRE: 'https://s3.bgc-jena.mpg.de:9000/misc/seasfire_rechunked.zarr',
 };
 
-const Dataset = () => {
+const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>}) => {
   const [showStoreInput, setShowStoreInput] = useState(false);
   const [showLocalInput, setShowLocalInput] = useState(false);
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
@@ -40,16 +40,17 @@ const Dataset = () => {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
-            tabIndex={0}
-            variant="ghost"
-            size="icon"
-            className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out'
-            aria-label="Select dataset"
-            >
-            <TbDatabasePlus className="size-8" />
-        </Button>
-        
+        <div>
+          <Button
+              tabIndex={0}
+              variant="ghost"
+              size="icon"
+              className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out'
+              aria-label="Select dataset"
+              >
+              <TbDatabasePlus className="size-8" />
+          </Button>
+        </div>
       </PopoverTrigger>
       <PopoverContent
         side={popoverSide}
@@ -63,6 +64,7 @@ const Dataset = () => {
             setShowLocalInput(false);
             setActiveOption('ESDC')
             setInitStore(ZARR_STORES.ESDC);
+            setOpenVariables(true)
           }}
         >
           ESDC
@@ -75,6 +77,7 @@ const Dataset = () => {
             setShowLocalInput(false);
             setActiveOption('seasfire')
             setInitStore(ZARR_STORES.SEASFIRE);
+            setOpenVariables(true)
           }}
         >
           Seasfire
@@ -98,6 +101,7 @@ const Dataset = () => {
                 e.preventDefault();
                 const input = e.currentTarget.elements[0] as HTMLInputElement;
                 setInitStore(input.value);
+                setOpenVariables(true)
               }}
             >
               <Input className="w-[100px]" placeholder="Store URL" />
@@ -115,14 +119,13 @@ const Dataset = () => {
               setShowLocalInput((prev) => !prev);
               setShowStoreInput(false);
               setActiveOption('local')
-              setInitStore('local')
             }}
           >
             Local
           </Button>
           {showLocalInput && (
             <div className="mt-2">
-              <LocalZarr setShowLocal={setShowLocalInput} />
+              <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenVariables} />
             </div>
           )}
         </div>

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -5,9 +5,8 @@ import { useZarrStore, useGlobalStore } from '@/utils/GlobalStates';
 import { Input } from '../input';
 import ZarrParser from '@/components/zarr/ZarrParser';
 
-const LocalZarr = ({setShowLocal}:{setShowLocal: React.Dispatch<React.SetStateAction<boolean>>}) => {
+const LocalZarr = ({setShowLocal, setOpenVariables}:{setShowLocal: React.Dispatch<React.SetStateAction<boolean>>, setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>}) => {
   const setCurrentStore = useZarrStore(state => state.setCurrentStore)
-  const setVariable = useGlobalStore(state => state.setVariable)
 
   const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
@@ -46,8 +45,8 @@ const LocalZarr = ({setShowLocal}:{setShowLocal: React.Dispatch<React.SetStateAc
       }
       const gs = zarr.open(store, {kind: 'group'});
       gs.then(e=>{setCurrentStore(e)})
-      setVariable("Default")
       setShowLocal(false)
+      setOpenVariables(true)
     } catch (error) {
       if (error instanceof Error) {
         console.log(`Error opening Zarr store: ${error.message}`);

--- a/src/components/ui/MainPanel/MainPanel.tsx
+++ b/src/components/ui/MainPanel/MainPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 import 'rc-slider/assets/index.css'
-import React from 'react'
+import React, {useState} from 'react'
 import '../css/MainPanel.css'
 import {PlotType, Variables, Colormaps, AdjustPlot, Dataset, PlayButton, AnalysisOptions} from '../index'
 import { PiFileMagnifyingGlass } from "react-icons/pi";
@@ -9,15 +9,11 @@ import { useAnalysisStore } from '@/utils/GlobalStates';
 import { useShallow } from 'zustand/shallow';
 
 const MainPanel = () => {
-  const {analysisMode, setAnalysisMode} = useAnalysisStore(useShallow(state => ({
-    analysisMode: state.analysisMode,
-    setAnalysisMode: state.setAnalysisMode
-  })))
-
+  const [openVariables, setOpenVariables] = useState<boolean>(false)
   return (
     <Card className="panel-container">
-      <Dataset  />
-      <Variables />
+      <Dataset  setOpenVariables={setOpenVariables} />
+      <Variables openVariables={openVariables} setOpenVariables={setOpenVariables} />
       <PlotType />
       <Colormaps />
       <AdjustPlot  />

--- a/src/components/ui/MainPanel/PlotType.tsx
+++ b/src/components/ui/MainPanel/PlotType.tsx
@@ -40,16 +40,17 @@ const PlotType = () => {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out'
-          tabIndex={0}
-          aria-label="Select plot type"
-        >
-          {plotIcons[plotType as keyof typeof plotIcons]}
-        </Button>
-
+        <div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out'
+            tabIndex={0}
+            aria-label="Select plot type"
+          >
+            {plotIcons[plotType as keyof typeof plotIcons]}
+          </Button>
+      </div>
       </PopoverTrigger>
       <PopoverContent
         side={popoverSide}

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -9,7 +9,7 @@ import MetaDataInfo from "./MetaDataInfo";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button";
 
-const Variables = () => {
+const Variables = ({openVariables, setOpenVariables}:{openVariables: boolean, setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>}) => {
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
 
   const [showMeta, setShowMeta] = useState(false);
@@ -40,16 +40,18 @@ const Variables = () => {
       }, []);
 
   return (
-        <Popover>
+        <Popover open={openVariables} onOpenChange={setOpenVariables}>
         <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
-            tabIndex={0}
-            aria-label="Select variable">
-              <TbVariable className="size-8"/>
-          </Button>
+          <div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
+              tabIndex={0}
+              aria-label="Select variable">
+                <TbVariable className="size-8"/>
+            </Button>
+          </div>
         </PopoverTrigger>
         <PopoverContent
           side={popoverSide}


### PR DESCRIPTION
Scaling the buttons directly in the popover triggers caused the popover content to wiggle with the resize

![wiggle](https://github.com/user-attachments/assets/28f52e13-3e5e-456e-85c3-9cac422a2ed5)

So I wrapped all of the buttons in a div

```ts
<div>
<Button />
</div>
 ```

![no-wiggle](https://github.com/user-attachments/assets/6e296854-1204-472b-91f4-a3d2624a229c)

I also made it so switching Datasets automatically opens the variables menu

![menu_swap](https://github.com/user-attachments/assets/ad844ac1-d2a8-4bd4-9f60-0f9679e32c33)

