### PR TITLE
Export View as Image

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,6 +148,7 @@ html, body {
 
 body {
   font-size: 12px;
+  font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
 }
 
 .canvas {

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -12,6 +12,7 @@ import AnalysisInfo from './AnalysisInfo';
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
 import AnalysisWG from './AnalysisWG';
 import { ParseExtent } from '@/utils/HelperFuncs';
+import ExportCanvas from '@/utils/ExportCanvas';
 
 
 const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
@@ -229,8 +230,10 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       {((!isFlat && plotType != "flat") || (isFlat && plotType === 'sphere')) && <>
       <Canvas id='main-canvas' camera={{ position: isFlat ? [0,0,5] : [-4.5, 3, 4.5], fov: 50 }}
         frameloop="demand"
+        gl={{ preserveDrawingBuffer: true }}
       >
         <CountryBorders/>
+        <ExportCanvas show={show}/>
         {!isFlat && show && <AxisLines />}
         {plotType == "volume" && show && 
           <>

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -257,6 +257,7 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
         <Canvas id='main-canvas' camera={{ position: [0,0,5], zoom: 1000 }}
         orthographic frameloop="demand"
         >
+          <ExportCanvas show={show}/>
           <CountryBorders/>
           <FlatMap texture={texture as THREE.DataTexture | THREE.Data3DTexture} infoSetters={infoSetters} />
           <Orbiter isFlat={true}/>

--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -135,7 +135,7 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
         >{vals[idx].toFixed(2)}
         </p>
         ))}
-        <canvas  ref={canvasRef} width={512} height={24} onMouseDown={handleMouseDown}/>
+        <canvas id="colorbar-canvas" ref={canvasRef} width={512} height={24} onMouseDown={handleMouseDown}/>
         <p className="colorbar-title"
             style={{
             position:'absolute',

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -1,22 +1,21 @@
 "use client";
-import React, { useMemo } from "react";
-import { LuChevronsUpDown } from "react-icons/lu";
-import { IoIosCheckmark } from "react-icons/io";
+import React from "react";
 import Image from "next/image";
 import { PlotLineButton } from "@/components/ui";
 import ThemeSwitch  from "@/components/ui/ThemeSwitch";
 import logo from "@/app/logo.png"
 import './css/Navbar.css'
 import { useShallow } from "zustand/shallow";
-import { useGlobalStore, usePlotStore } from "@/utils/GlobalStates";
-import { colormaps } from '@/components/textures';
+import { useGlobalStore, useImageExportStore, usePlotStore } from "@/utils/GlobalStates";
 import { useEffect, useState, useRef } from "react";
-import { GetColorMapTexture } from "@/components/textures";
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { MdFlipCameraIos } from "react-icons/md";
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer";
 import AboutInfo from "@/components/ui/AboutInfo";
+import { IoImage } from "react-icons/io5";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
+import { Input } from "./input";
 
 import {
   Tooltip,
@@ -44,103 +43,39 @@ const FiveDotsIcon: React.FC<{ className?: string }> = ({ className }) => {
   );
 };
 
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
-
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-
-const ColorMaps = ({cmap, setCmap} : {cmap : string, setCmap : React.Dispatch<React.SetStateAction<string>>}) => {
-  const [open, setOpen] = useState(false)
-  return (
-    <Popover open={open} onOpenChange={setOpen}>    
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="w-[100%] justify-between"
-        >
-          {cmap === "Default" ?  "Select Colormap..." : cmap }
-          <LuChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[100%] p-0">
-        <Command>
-          <CommandInput placeholder="Search framework..." />
-          <CommandList>
-            <CommandEmpty>No Colormap found.</CommandEmpty>
-            <CommandGroup>
-              {colormaps.map((value) => (
-                <CommandItem
-                  key={value}
-                  value={value}
-                  onSelect={(currentValue) => {
-                    setCmap(currentValue)
-                    setOpen(false);
-                  }}
-                >
-                  <IoIosCheckmark
-                    className={cn(
-                      "mr-2 h-4 w-4",
-                      value === cmap ? "opacity-100" : "opacity-0"
-                    )}
-                  />
-                  {value}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  )
-
-}
-
 const Navbar = React.memo(function Navbar(){
-  const {setInitStore, setVariable, setColormap, setTimeSeries, setDimCoords, isFlat, plotOn, variables, variable} = useGlobalStore(
+  const { isFlat, plotOn} = useGlobalStore(
     useShallow(state=>({
-      setInitStore : state.setInitStore, 
-      setVariable : state.setVariable,
-      setColormap : state.setColormap,
-      setTimeSeries: state.setTimeSeries,
-      setDimCoords: state.setDimCoords,
       isFlat: state.isFlat,
       plotOn: state.plotOn,
-      variables: state.variables,
-      variable: state.variable
     })))
 
+  const {
+    includeBackground,
+    includeColorbar,
+    doubleSize,
+    ExportImg, 
+    setIncludeBackground, 
+    setIncludeColorbar, 
+    setDoubleSize} = useImageExportStore(useShallow(state => ({
+      includeBackground: state.includeBackground,
+      includeColorbar: state.includeColorbar,
+      doubleSize: state.doubleSize,
+      ExportImg: state.ExportImg,
+      setIncludeBackground: state.setIncludeBackground,
+      setIncludeColorbar: state.setIncludeColorbar,
+      setDoubleSize: state.setDoubleSize
+  })))
 
-  const {setPlotType, plotType, resetCamera, setAnimate, setResetCamera} = usePlotStore(useShallow(state=> ({
-    setPlotType: state.setPlotType,
-    plotType: state.plotType,
+
+  const {resetCamera,setResetCamera} = usePlotStore(useShallow(state=> ({
     resetCamera: state.resetCamera,
-    setAnimate: state.setAnimate,
     setResetCamera: state.setResetCamera
   })))
 
-  const [showStoreInput, setShowStoreInput] = useState<boolean>(false)
-  const [showLocalInput, setShowLocalInput] = useState<boolean>(false)
-  const [cmap, setCmap] = useState<string>("Default")
-  const [flipCmap, setFlipCmap] = useState<boolean>(false)
-  const colormap = useGlobalStore(useShallow(state=>state.colormap))
   const [isOpen, setIsOpen] = useState<boolean>(true)
   const navRef = useRef<HTMLElement | null>(null)
 
-  useEffect(()=>{
-    setColormap(GetColorMapTexture(colormap, cmap === "Default" ? "Spectral" : cmap, 1, "#000000", 0, flipCmap));
-  },[cmap, flipCmap])
   
   return (
     <nav className="navbar" ref={navRef}>
@@ -151,15 +86,13 @@ const Navbar = React.memo(function Navbar(){
             size="icon"
             className="navbar-trigger size-10"
             aria-expanded={isOpen}
-            aria-label={isOpen ? "Close navigation" : "Open navigation"}
-            title={isOpen ? "Close navigation" : "Open navigation"}
             onClick={() => setIsOpen((prev) => !prev)}
           >
             <FiveDotsIcon className="navbar-trigger-icon rotating size-6" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="right" align="start">
-          {isOpen ? <span>Close navigation</span> : <span>Open navigation</span>}
+          {isOpen ? 'Close navigation' : 'Open navigation'}
         </TooltipContent>
       </Tooltip>
 
@@ -175,7 +108,6 @@ const Navbar = React.memo(function Navbar(){
                       size="icon"
                       className="cursor-pointer"
                       tabIndex={0}
-                      aria-label="About Browzarr"
                       title="About Browzarr">
                         <Image src={logo} alt="browzarr" />
                     </Button>
@@ -204,8 +136,6 @@ const Navbar = React.memo(function Navbar(){
                   size="icon"
                   className="size-10 cursor-pointer"
                   tabIndex={0}
-                  aria-label="Reset camera view"
-                  title="Reset camera view"
                   onClick={() => setResetCamera(!resetCamera)}
                 >
                   <MdFlipCameraIos className="size-8" />
@@ -217,11 +147,50 @@ const Navbar = React.memo(function Navbar(){
             </Tooltip>
 
           )}
-          {/* {!isFlat && plotOn && <PlotTweaker/>} */}
           {plotOn && !isFlat && <PlotLineButton />}
+          {plotOn && 
+          <Popover>
+            <PopoverTrigger asChild>
+              <div>
+                <Tooltip delayDuration={500} >
+                  <TooltipTrigger asChild>
+                    <Button 
+                      variant="ghost"
+                      size="icon"
+                      className="cursor-pointer"
+                    >
+                      <IoImage className="size-8"/>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" align="start">
+                    Export view as Image
+                  </TooltipContent>
+              </Tooltip>
+              </div>
+            </PopoverTrigger>
+            <PopoverContent
+              side="right"
+              className="w-[200px]"
+            >
+              <div className="grid grid-cols-[auto_50px] items-center gap-2">
+                <label htmlFor="includeBG">Include Background</label>
+                <Input id='includeBG' type="checkbox" checked={includeBackground} onChange={e => setIncludeBackground(e.target.checked)}/>
+                <label htmlFor="includeCbar">Include Colorbar</label>
+                <Input id='includeCbar' type="checkbox" checked={includeColorbar} onChange={e => setIncludeColorbar(e.target.checked)}/>
+                <label htmlFor="includeCbar" >Double Resolution</label>
+                <Input id='includeCbar' type="checkbox" checked={doubleSize} onChange={e => setDoubleSize(e.target.checked)}/>
+                <Button
+                  className="col-span-2"
+                  variant='pink'
+                  onClick={e=>ExportImg()}
+                >Export</Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+          
+          }
+          <ThemeSwitch />
         </div>
-
-        <ThemeSwitch />
       </div>
     </nav>
   );

--- a/src/utils/ExportCanvas.tsx
+++ b/src/utils/ExportCanvas.tsx
@@ -64,6 +64,7 @@ const ExportCanvas = ({show}:{show: boolean}) => {
             gl.render(scene, camera)
         }
         else{
+            gl.render(scene, camera)
             ctx.drawImage(gl.domElement, 0, 0, docWidth, docHeight) 
         }
 

--- a/src/utils/ExportCanvas.tsx
+++ b/src/utils/ExportCanvas.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import React, { useEffect, useRef } from 'react'
+import { useGlobalStore, useImageExportStore } from './GlobalStates'
+import { useShallow } from 'zustand/shallow'
+import { useThree } from '@react-three/fiber'
+import { useCSSVariable } from '@/components/ui';
+import * as THREE from 'three'
+
+const ExportCanvas = ({show}:{show: boolean}) => {
+    const {valueScales, variable, metadata } = useGlobalStore(useShallow(state => ({
+        valueScales: state.valueScales,
+        variable: state.variable,
+        metadata: state.metadata
+    })))
+
+    const {exportImg, includeBackground, includeColorbar, doubleSize} = useImageExportStore(useShallow(state => ({
+        exportImg: state.exportImg,
+        includeBackground: state.includeBackground,
+        includeColorbar: state.includeColorbar,
+        doubleSize: state.doubleSize
+    })))
+    
+    const {gl, scene, camera} = useThree()
+    const skipFirst = useRef<boolean>(true)
+    const textColor = useCSSVariable('--text-plot')
+    const bgColor = useCSSVariable('--background')
+
+    useEffect(()=>{   
+        if (!show){
+            return
+        }
+        if (skipFirst.current){ // It will try to render on first load. So this has to be here to stop it. Will retweak logic at some point cause it doesn't ALWAYS try. 
+            skipFirst.current = false
+            return
+        }
+        const docWidth = doubleSize ? window.innerWidth * 2 : window.innerWidth
+        const docHeight = doubleSize ? window.innerHeight * 2 : window.innerHeight
+
+        // Create a new canvas for compositing
+        const compositeCanvas = document.createElement('canvas')
+        const ctx = compositeCanvas.getContext('2d')
+        if (!ctx){return}
+
+        compositeCanvas.width = docWidth
+        compositeCanvas.height = docHeight
+        const cbarWidth = doubleSize ? 1024 : 512
+        const cbarHeight = doubleSize ? 48: 24;
+        const cbarStartPos = Math.round(docWidth/2 - cbarWidth/2)
+
+        const cbarTop = doubleSize ? docHeight - 140 : docHeight-70
+        
+        if (includeBackground){
+            ctx.fillStyle = bgColor
+            ctx.fillRect(0, 0, compositeCanvas.width, compositeCanvas.height)
+        }
+        if (doubleSize){
+            const originalSize = gl.getSize(new THREE.Vector2())
+            // Set higher resolution
+            gl.setSize(docWidth, docHeight)
+            gl.render(scene, camera)
+            ctx.drawImage(gl.domElement, 0, 0, docWidth, docHeight) 
+            gl.setSize(originalSize.x, originalSize.y)
+            gl.render(scene, camera)
+        }
+        else{
+            ctx.drawImage(gl.domElement, 0, 0, docWidth, docHeight) 
+        }
+
+        const variableSize = doubleSize ? 72 : 36
+        ctx.fillStyle = textColor
+        ctx.font = `${variableSize}px "Segoe UI"`
+        ctx.fillText(variable, doubleSize ? 40 : 20, doubleSize ? 100 : 50) // Variable in top Left
+
+        const cbarTickSize = doubleSize ? 28 : 14
+        const unitSize = doubleSize ? 40 : 20
+        
+        if (includeColorbar){
+            const secondCanvas = document.getElementById('colorbar-canvas')
+
+            if (secondCanvas instanceof HTMLCanvasElement) {
+                ctx.drawImage(secondCanvas, cbarStartPos, cbarTop , cbarWidth, cbarHeight) // These are the default dimensions of the colorbar-canvas. It is 50px from bottom
+            }
+            const labelNum = 10; // Number of cbar "ticks"
+            const valRange = valueScales.maxVal-valueScales.minVal;
+            const valScale = 1/(labelNum-1)
+            const posDelta = 1/(labelNum-1)*cbarWidth
+        
+            for (let i =0; i < labelNum; i++){
+                ctx.font = `${cbarTickSize}px "Segoe UI"`
+                ctx.textAlign = 'center'
+                ctx.textBaseline = 'top'
+                ctx.fillText(String((valueScales.minVal+(i*valScale*valRange)).toFixed(2)), cbarStartPos+i*posDelta, cbarTop+cbarHeight+6) 
+            }
+
+            ctx.fillStyle = textColor
+            ctx.font = `${unitSize}px "Segoe UI" bold`
+            ctx.textAlign = 'center'
+            ctx.fillText(metadata?.units, cbarStartPos+cbarWidth/2, cbarTop-unitSize-6) // Cbar Units above middle of cbar
+        }
+        
+
+        const waterMarkSize = doubleSize ? 40 : 20
+        ctx.fillStyle = "#888888"
+        ctx.font = `${waterMarkSize}px "Segoe UI", serif `
+        ctx.textAlign = 'left'
+        ctx.textBaseline = 'bottom'
+        ctx.fillText("BrowZarr.io", doubleSize ? 20 : 10, doubleSize ? docHeight - 20 : docHeight - 10) // Watermark
+
+        // Export the composite
+        compositeCanvas.toBlob((blob) => {
+            if(!blob){return}
+            const url = URL.createObjectURL(blob)
+            const link = document.createElement('a')
+            link.download = 'browzarr-plot.png'
+            link.href = url
+            link.click()
+            URL.revokeObjectURL(url)
+        }, 'image/png')
+
+    },[exportImg])
+
+  return (
+    <>
+    </>
+  )
+  
+}
+
+export default ExportCanvas

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -99,8 +99,6 @@ export const useGlobalStore = create<StoreState>((set, get) => ({
   is4D: false,
   idx4D: null,
 
-
-
   setDataShape: (dataShape) => set({ dataShape}),
   setShape: (shape) => set({ shape }),
   setValueScales: (valueScales) => set({ valueScales }),
@@ -413,5 +411,29 @@ export const useErrorStore = create<ErrorState>((set) =>({
   setCors: (cors) => set({ cors }),
   setOom: (oom) => set({ oom }),
   setInvalidURL: (invalidURL) => set({ invalidURL })
-
 }))
+
+
+type ImageExportState = {
+  exportImg: boolean;
+  includeBackground: boolean;
+  includeColorbar: boolean;
+  doubleSize: boolean;
+
+  ExportImg: () => void;
+  setIncludeBackground: (includeBackground: boolean) => void;
+  setIncludeColorbar: (includeColorbar: boolean) => void;
+  setDoubleSize: (doubleSize: boolean) => void;
+}
+
+export const useImageExportStore = create<ImageExportState>((set, get) => ({
+  exportImg: false,
+  includeBackground: false,
+  includeColorbar: true,
+  doubleSize: false,
+
+  ExportImg: () => set({ exportImg: !get().exportImg }),
+  setIncludeBackground: (includeBackground) => set({ includeBackground }),
+  setIncludeColorbar: (includeColorbar) => set({ includeColorbar }),
+  setDoubleSize: (doubleSize) => set({ doubleSize })
+}));


### PR DESCRIPTION
You can now export view as Image.

It creates a composite of the render canvas as well as the colorbar canvas. 
It's a lot like matplotlib with arranging the output. Honestly, we could create a whole separate app to let people organize the colorbar location and stuff. 

<img width="1714" height="1285" alt="browzarr-plot" src="https://github.com/user-attachments/assets/df689eb2-3f47-4348-b5c7-cffb687dae72" />

<img width="255" height="264" alt="image" src="https://github.com/user-attachments/assets/a44442d8-d741-4b1d-8f25-36bba2176c2f" />
