### PR TITLE
Dataset and Analysis Bug Squashing

### DIFF
--- a/src/components/LandingHome.tsx
+++ b/src/components/LandingHome.tsx
@@ -13,7 +13,6 @@ import { useShallow } from 'zustand/shallow';
 import { GetTitleDescription } from '@/components/zarr/GetMetadata';
 import ScrollableLinksTable from './ui/VariablesTable';
 
-
 export function LandingHome() {
 
   const {initStore, setZMeta} = useGlobalStore(useShallow(state=>({initStore: state.initStore, setZMeta: state.setZMeta})))
@@ -21,7 +20,18 @@ export function LandingHome() {
     currentStore: state.currentStore,
     setCurrentStore: state.setCurrentStore
   })))
-  
+
+  const {setVariables, setPlotOn, timeSeries, variable, metadata, plotOn  } = useGlobalStore(
+    useShallow(state => ({
+      setVariables: state.setVariables,
+      setPlotOn: state.setPlotOn,
+      timeSeries: state.timeSeries,
+      variable: state.variable,
+      metadata: state.metadata,
+      plotOn: state.plotOn
+    }))
+  );
+
   useEffect(()=>{ //Update store if URL changes
     const newStore = GetStore(initStore)
     setCurrentStore(newStore)
@@ -35,25 +45,13 @@ export function LandingHome() {
     GetTitleDescription(currentStore).then((result) => {
       if (isMounted) setTitleDescription(result);
     });
-    const store = currentStore;
-    const fullmetadata = GetZarrMetadata(store);
+    const fullmetadata = GetZarrMetadata(currentStore);
     const variables = GetVariableNames(fullmetadata);
     fullmetadata.then(e=>setZMeta(e))
     variables.then(e=> {setVariables(e)})
     return () => { isMounted = false; };
   }, [currentStore]);
 
-
-  const {   setVariables, setPlotOn, timeSeries, variable, metadata, plotOn  } = useGlobalStore(
-    useShallow(state => ({
-      setVariables: state.setVariables,
-      setPlotOn: state.setPlotOn,
-      timeSeries: state.timeSeries,
-      variable: state.variable,
-      metadata: state.metadata,
-      plotOn: state.plotOn
-    }))
-  );
 
   useEffect(()=>{
     if (variable === "Default"){

--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -18,7 +18,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
         setIsFlat: state.setIsFlat,
         setDownloading: state.setDownloading,
         setShowLoading: state.setShowLoading,
-        setValueScales: state.setValueScales
+        setValueScales: state.setValueScales,
     })))
 
     const setPlotType = usePlotStore(state => state.setPlotType)

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -209,7 +209,7 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       else{
         setMetadata(null)
       }
-  }, [variable, reFetch])
+  }, [reFetch])
 
   const infoSetters = useMemo(()=>({
     setLoc,

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -1,8 +1,8 @@
 import * as THREE from 'three'
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { ZarrDataset } from '@/components/zarr/ZarrLoaderLRU';
-import { parseUVCoords, getUnitAxis } from '@/utils/HelperFuncs';
-import { useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
+import { parseUVCoords, getUnitAxis, GetTimeSeries } from '@/utils/HelperFuncs';
+import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
 import { useShallow } from 'zustand/shallow';
 import { evaluate_cmap } from 'js-colormaps-es';
 
@@ -19,9 +19,17 @@ export const UVCube = ({ZarrDS} : {ZarrDS:ZarrDataset} )=>{
       updateDimCoords: state.updateDimCoords
     })))
 
-  const {shape,dimArrays,dimNames,dimUnits} = useGlobalStore(
+  const {analysisMode, analysisArray} = useAnalysisStore(useShallow(state=>({
+    analysisMode: state.analysisMode,
+    analysisArray: state.analysisArray
+  })))
+
+  const {shape, dataShape, dataArray, strides, dimArrays,dimNames,dimUnits} = useGlobalStore(
     useShallow(state=>({
       shape:state.shape,
+      dataShape: state.dataShape,
+      dataArray: state.dataArray,
+      strides: state.strides,
       dimArrays:state.dimArrays,
       dimNames:state.dimNames,
       dimUnits:state.dimUnits
@@ -47,7 +55,7 @@ export const UVCube = ({ZarrDS} : {ZarrDS:ZarrDataset} )=>{
     lastNormal.current = dimAxis;
     
     if(ZarrDS){
-      const tempTS = ZarrDS.GetTimeSeries({uv,normal})
+      const tempTS = GetTimeSeries({data: analysisMode ? analysisArray : dataArray, shape: dataShape, stride: strides},{uv,normal})
       const plotDim = (normal.toArray()).map((val, idx) => {
         if (Math.abs(val) > 0) {
           return idx;

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -107,6 +107,7 @@ const AnalysisOptions = () => {
     reFetch: state.reFetch,
     setReFetch: state.setReFetch
   })))
+
   const [showError, setShowError] = useState<boolean>(false);
   
   useEffect(() => {
@@ -126,15 +127,21 @@ const AnalysisOptions = () => {
 
     checkWebGPU();
     }, [plotOn]);
-    console.log(variable)
-  useEffect(()=>{ // Changing stores makes it so you can't use two variable operations. When you load a new variable from this dataset it will become compatible. 
+
+
+  useEffect(()=>{ // Changing stores makes it so you can't use two variable operations. 
     if(initStore != previousStore.current){
       setIncompatible(true)
-      previousStore.current = initStore // If you change stores, then change back. Then you still can't use Two. I'm thinking I will redo the cache and make it a global which will solve this eventually. 
-    }else{
+    }
+    else{
       setIncompatible(false)
     }
-  },[initStore, variable])
+  },[initStore])
+
+  useEffect(()=>{ // When data is downloaded (indicated by changes in refetch) The newly plotted and any future variables are compatible until initStore changes. 
+    setIncompatible(false);
+    previousStore.current = initStore
+  },[reFetch])
 
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
     useEffect(() => {

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -145,7 +145,7 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
           </Button>
           {showLocalInput && (
             <div className="mt-2">
-              <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenVariables} />
+              <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenVariables} setInitStore={setInitStore} />
             </div>
           )}
         </div>

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -8,7 +8,7 @@ import ZarrParser from '@/components/zarr/ZarrParser';
 interface LocalZarrType {
   setShowLocal: React.Dispatch<React.SetStateAction<boolean>>;
   setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>;
-  setInitStore: React.Dispatch<React.SetStateAction<string>>
+  setInitStore: (store: string) => void;
 }
 
 const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
@@ -53,7 +53,7 @@ const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType)
       gs.then(e=>{setCurrentStore(e)})
       setShowLocal(false)
       setOpenVariables(true)
-      setInitStore('local')
+      setInitStore(`local_$${baseDir}`)
     } catch (error) {
       if (error instanceof Error) {
         console.log(`Error opening Zarr store: ${error.message}`);

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -5,7 +5,13 @@ import { useZarrStore, useGlobalStore } from '@/utils/GlobalStates';
 import { Input } from '../input';
 import ZarrParser from '@/components/zarr/ZarrParser';
 
-const LocalZarr = ({setShowLocal, setOpenVariables}:{setShowLocal: React.Dispatch<React.SetStateAction<boolean>>, setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>}) => {
+interface LocalZarrType {
+  setShowLocal: React.Dispatch<React.SetStateAction<boolean>>;
+  setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>;
+  setInitStore: React.Dispatch<React.SetStateAction<string>>
+}
+
+const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
   const setCurrentStore = useZarrStore(state => state.setCurrentStore)
 
   const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -47,6 +53,7 @@ const LocalZarr = ({setShowLocal, setOpenVariables}:{setShowLocal: React.Dispatc
       gs.then(e=>{setCurrentStore(e)})
       setShowLocal(false)
       setOpenVariables(true)
+      setInitStore('local')
     } catch (error) {
       if (error instanceof Error) {
         console.log(`Error opening Zarr store: ${error.message}`);

--- a/src/components/ui/MainPanel/MetaDataInfo.tsx
+++ b/src/components/ui/MainPanel/MetaDataInfo.tsx
@@ -217,6 +217,7 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
                 }
                 else{
                   setVariable(meta.name)
+                  setReFetch(!reFetch)
                 }
                 setShowMeta(false)
               }}
@@ -308,6 +309,7 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
               }
               else{
                 setVariable(meta.name)
+                setReFetch(!reFetch)
               }
               setShowMeta(false)
             }}

--- a/src/components/ui/MainPanel/PlayButton.tsx
+++ b/src/components/ui/MainPanel/PlayButton.tsx
@@ -30,6 +30,7 @@ const PlayInterFace = ({visible}:{visible : boolean}) =>{
     })))
 
     const timeLength = useMemo(()=>dimArrays[0].length,[dimArrays])
+    const [timeStep, setTimeStep] = useState(0)
     
     const intervalRef = useRef<NodeJS.Timeout | null>(null);
     const previousVal = useRef<number>(0)
@@ -64,7 +65,7 @@ const PlayInterFace = ({visible}:{visible : boolean}) =>{
         
     }, [animate, fps]);
 
-    const currentLabel = parseLoc(dimArrays[0][Math.min(Math.round(animProg*timeLength),timeLength-1)], dimUnits[0], true)
+    const currentLabel = parseLoc(dimArrays[0][timeStep], dimUnits[0], true)
     const firstLabel = parseLoc(dimArrays[0][0], dimUnits[0], true)
     const lastLabel = parseLoc(dimArrays[0][timeLength-1], dimUnits[0], true)
 
@@ -80,12 +81,13 @@ const PlayInterFace = ({visible}:{visible : boolean}) =>{
                 <Slider
                   value={[Math.round(animProg * timeLength)]}
                   min={0}
-                  max={timeLength}
+                  max={timeLength-1}
                   step={1}
                   className='flex-1'
                   onValueChange={(vals: number[])=>{
                     const v = Array.isArray(vals) ? vals[0] : 0;
-                    setAnimProg(v / timeLength);
+                    setTimeStep(v)
+                    setAnimProg(v / (timeLength-1));
                   }}
                 />
                 <span className='text-xs'>{lastLabel}</span>

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -28,8 +28,10 @@ export async function GetStore(storePath: string): Promise<zarr.Group<zarr.Fetch
 			const gs = await d_store.then(store => zarr.open(store, {kind: 'group'}));
 			return gs;
 		} catch (error) {
+			if (storePath != 'local'){
 			useErrorStore.getState().setZarrFetch(true)
 			useGlobalStore.getState().setShowLoading(false)
+			}
 			throw new ZarrError(`Failed to initialize store at ${storePath}`, error);
 
 		}    

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -28,9 +28,9 @@ export async function GetStore(storePath: string): Promise<zarr.Group<zarr.Fetch
 			const gs = await d_store.then(store => zarr.open(store, {kind: 'group'}));
 			return gs;
 		} catch (error) {
-			if (storePath != 'local'){
-			useErrorStore.getState().setZarrFetch(true)
-			useGlobalStore.getState().setShowLoading(false)
+			if (storePath.slice(0,5) != 'local'){
+				useErrorStore.getState().setZarrFetch(true)
+				useGlobalStore.getState().setShowLoading(false)
 			}
 			throw new ZarrError(`Failed to initialize store at ${storePath}`, error);
 

--- a/src/utils/ExportCanvas.tsx
+++ b/src/utils/ExportCanvas.tsx
@@ -26,15 +26,16 @@ const ExportCanvas = ({show}:{show: boolean}) => {
     })))
     
     const {gl, scene, camera} = useThree()
-    const skipFirst = useRef<boolean>(true)
+    const hasMounted = useRef(false);
     const textColor = useCSSVariable('--text-plot')
     const bgColor = useCSSVariable('--background')
+
     useEffect(()=>{   
         if (!show){
             return
         }
-        if (skipFirst.current){ // It will try to render on first load. So this has to be here to stop it. Will retweak logic at some point cause it doesn't ALWAYS try. 
-            skipFirst.current = false
+        if (!hasMounted.current){ // It will try to render on first load. So this has to be here to stop it. Will retweak logic at some point cause it doesn't ALWAYS try. 
+            hasMounted.current = true
             return
         }
         const domWidth = gl.domElement.width;

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -218,3 +218,35 @@ export async function testCORSConfiguration(storePath: string): Promise<{
         }
     }
 }
+
+interface TimeSeriesInfo{
+  uv:THREE.Vector2,
+  normal:THREE.Vector3
+}
+interface arrayInfo{
+  data: Uint8Array<ArrayBufferLike> | Float32Array<ArrayBufferLike>,
+  shape:number[],
+  stride:number[]
+}
+
+export function GetTimeSeries(array : arrayInfo, TimeSeriesInfo:TimeSeriesInfo){
+  const {uv,normal} = TimeSeriesInfo
+  const {data, shape, stride} = array
+
+  //This is a complicated logic check but it works bb
+  const sliceSize = parseUVCoords({normal,uv})
+  const slice = sliceSize.map((value, index) =>
+    value === null || shape[index] === null ? null : Math.round(value * shape[index]-.5));
+  const mapDim = slice.indexOf(null);
+  const dimStride = stride[mapDim];
+  const pz = slice[0] == null ? 0 : stride[0]*slice[0]
+  const py = slice[1] == null ? 0 : stride[1]*slice[1]
+  const px = slice[2] == null ? 0 : stride[2]*slice[2]
+  const ts = [];
+
+  for (let i = 0; i < shape[mapDim] ; i++){
+    const idx = i*dimStride+pz+py+px
+    ts.push(data[idx])
+  }
+		return ts;
+}


### PR DESCRIPTION
There were a few bugs involving changing datasets. Changing the dataset wipes the cache and store. So if you tried to plot a timeseries or do 2-variable analysis this would crash the app. Also to avoid a 404 error, the local option didn't have an initStore. However, the initStore state is used to populate variables which wouldn't work when using local and switching back to the same remote dataset. 

- [x] Gave `local dataset` an initStore value so it properly updates variables when switching back
- [x] Moved the timeseries function to standalone.
- [x] Timeseries is now applied to the saved dataArray and not based on the LRU cache
- [x] Can now do timeseries on the analysis array.
- [x]  Clears timeSeries after an analysis
- [x] Prevents 2-variable analysis if initStore is incorrect.
