### PR TITLE
a Dialog for variables on mobile

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
       <body className="antialiased">
         <ClientRoot>
           {children}
-          <Toaster position="top-center" />
+          <Toaster position="top-center" duration={1500}/>
         </ClientRoot>
       </body>
     </html>

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -190,11 +190,15 @@ const AnalysisOptions = () => {
                   </Button>
                   </div>
                 </TooltipTrigger>
-                <TooltipContent side="left" align="start" className="flex flex-col">
-                  <div>
-                    Apply operations
-                  </div>
-                </TooltipContent>
+                {popoverSide === "left" ? (
+                  <TooltipContent side="left" align="start">
+                    <span>Apply operations</span>
+                  </TooltipContent>
+                ) : (
+                  <TooltipContent side="top" align="center">
+                    <span>Apply operations</span>
+                  </TooltipContent>
+                )}
               </Tooltip>
             </div>
           </PopoverTrigger>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -63,9 +63,15 @@ const Colormaps = () => {
                 }} /> 
             </div>
           </TooltipTrigger>
-          <TooltipContent side="left" align="start">
-            <span>Change Colormap</span>
-          </TooltipContent>
+          {popoverSide === "left" ? (
+            <TooltipContent side="left" align="start">
+              <span>Change Colormap</span>
+            </TooltipContent>
+          ) : (
+            <TooltipContent side="top" align="center">
+              <span>Change Colormap</span>
+            </TooltipContent>
+          )}
         </Tooltip>
         </div>
       </PopoverTrigger>

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -60,9 +60,15 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
                 </Button>
               </div>
             </TooltipTrigger>
-            <TooltipContent side="left" align="start" className="flex flex-col">
-              <span>Select dataset</span>
-            </TooltipContent>
+            {popoverSide === "left" ? (
+              <TooltipContent side="left" align="start">
+                <span>Select dataset</span>
+              </TooltipContent>
+            ) : (
+              <TooltipContent side="top" align="center">
+                <span>Select dataset</span>
+              </TooltipContent>
+            )}
           </Tooltip>
         </div>
 

--- a/src/components/ui/MainPanel/PlotType.tsx
+++ b/src/components/ui/MainPanel/PlotType.tsx
@@ -60,9 +60,15 @@ const PlotType = () => {
               </Button>
             </div>
             </TooltipTrigger>
-            <TooltipContent side="left" align="start" className="flex flex-col">
-              <span>Change plot type</span>
-            </TooltipContent>
+            {popoverSide === "left" ? (
+              <TooltipContent side="left" align="start">
+                <span>Change plot type</span>
+              </TooltipContent>
+            ) : (
+              <TooltipContent side="top" align="center">
+                <span>Change plot type</span>
+              </TooltipContent>
+            )}
           </Tooltip>
       </div>
       </PopoverTrigger>

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -6,17 +6,28 @@ import { useGlobalStore } from "@/utils/GlobalStates";
 import { useShallow } from "zustand/shallow";
 import { Separator } from "@/components/ui/separator";
 import MetaDataInfo from "./MetaDataInfo";
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { Input } from "../input";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-} from "@/components/ui/tooltip"
+} from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 
-const Variables = ({openVariables, setOpenVariables}:{openVariables: boolean, setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>}) => {
+const Variables = ({
+  openVariables,
+  setOpenVariables,
+}: {
+  openVariables: boolean;
+  setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
 
   const [showMeta, setShowMeta] = useState(false);
@@ -32,94 +43,118 @@ const Variables = ({openVariables, setOpenVariables}:{openVariables: boolean, se
   const [query, setQuery] = useState("");
 
   const filtered = useMemo(() => {
-      const q = query.toLowerCase().trim();
-      if (!q) return variables;
-      return variables.filter((variable) =>
-        variable.toLowerCase().includes(q)
-      );
-    }, [query, variables]);
+    const q = query.toLowerCase().trim();
+    if (!q) return variables;
+    return variables.filter((variable) =>
+      variable.toLowerCase().includes(q)
+    );
+  }, [query, variables]);
 
   useEffect(() => {
     if (variables && zMeta && selectedVar) {
       const relevant = zMeta.find((e: any) => e.name === selectedVar);
       setMeta(relevant);
     }
-  }, [selectedVar, variables]);
+  }, [selectedVar, variables, zMeta]);
 
   useEffect(() => {
-        const handleResize = () => {
-          setPopoverSide(window.innerWidth < 768 ? "top" : "left");
-        };
-        handleResize();
-        window.addEventListener("resize", handleResize);
-        return () => window.removeEventListener("resize", handleResize);
-      }, []);
+    const handleResize = () => {
+      setPopoverSide(window.innerWidth < 768 ? "top" : "left");
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const VariableList = (
+    <div className="overflow-y-auto flex-1 [&::-webkit-scrollbar]:hidden">
+      {filtered.map((val, idx) => (
+        <React.Fragment key={idx}>
+          <div
+            className="cursor-pointer pl-2 py-1 text-sm hover:bg-muted rounded"
+            style={{
+              background:
+                idx === selectedIndex ? "var(--muted-foreground)" : "",
+            }}
+            onClick={() => {
+              setSelectedIndex(idx);
+              setSelectedVar(val);
+              setShowMeta(true);
+            }}
+          >
+            {val}
+          </div>
+          {idx !== filtered.length - 1 && <Separator className="my-1" />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
 
   return (
-        <Popover open={openVariables} onOpenChange={setOpenVariables}>
-        <PopoverTrigger asChild>
-          <div>
-            <Tooltip delayDuration={500} >
-              <TooltipTrigger asChild>
-                <div>
-                  <Button
+    <Popover open={openVariables} onOpenChange={setOpenVariables}>
+      <PopoverTrigger asChild>
+        <div>
+          <Tooltip delayDuration={500}>
+            <TooltipTrigger asChild>
+              <div>
+                <Button
                   variant="ghost"
                   size="icon"
                   className="cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
                   tabIndex={0}
-                  aria-label="Select variable">
-                    <TbVariable className="size-8"/>
+                  aria-label="Select variable"
+                >
+                  <TbVariable className="size-8" />
                 </Button>
               </div>
-              </TooltipTrigger>
-              <TooltipContent side="left" align="start">
-                <span>Select Variable</span>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        </PopoverTrigger>
-        <PopoverContent
-          side={popoverSide}
-          className="max-h-[50vh] overflow-hidden flex flex-col"
-        >
-          <div className="flex items-center gap-2 mb-4 justify-center max-w-[240px] md:max-w-sm mx-auto flex-shrink-0">
-            <Input
-              placeholder="Search variable..."
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              className="flex-1"
-            />
-            <Button variant="secondary" onClick={() => setQuery("")}>Clear</Button>
-          </div>
-          <div className="overflow-y-auto flex-1 [&::-webkit-scrollbar]:hidden">
-            {filtered.map((val, idx) => (
-              <React.Fragment key={idx}>
-                <div
-                  className="cursor-pointer pl-2 py-1 text-sm hover:bg-muted rounded "
-                  style={{background: idx == selectedIndex ? '#d6d6d6ff' : ''}}
-                  onClick={() => {
-                    setSelectedIndex(idx);
-                    setSelectedVar(val)
-                    setShowMeta(true);
-                  }}
-                >
-                  {val}
-                </div>
-                {idx != filtered.length-1 && <Separator className="my-1" />} 
-              </React.Fragment>
-            ))}
-          </div>
-          {showMeta && meta && (
-            <div className="meta-options w-[300px]">
-              <MetaDataInfo
-                meta={meta}
-                setShowMeta={ setShowMeta }
-              />
-            </div>
-          )}
-        </PopoverContent>
-      </Popover>
+            </TooltipTrigger>
+            <TooltipContent side="left" align="start">
+              <span>Select Variable</span>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </PopoverTrigger>
 
+      <PopoverContent
+        side={popoverSide}
+        className="max-h-[50vh] overflow-hidden flex flex-col"
+      >
+        <div className="flex items-center gap-2 mb-4 justify-center max-w-[240px] md:max-w-sm mx-auto flex-shrink-0">
+          <Input
+            placeholder="Search variable..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="flex-1"
+          />
+          <Button variant="secondary" onClick={() => setQuery("")}>
+            Clear
+          </Button>
+        </div>
+
+        {VariableList}
+
+        {popoverSide === "left" && showMeta && meta && (
+          <div className="meta-options w-[300px]">
+            <MetaDataInfo meta={meta} setShowMeta={setShowMeta} />
+          </div>
+        )}
+      </PopoverContent>
+
+      {popoverSide === "top" && (
+        <Dialog open={showMeta} onOpenChange={setShowMeta}>
+          <DialogContent className="max-w-[85%] md:max-w-2xl max-h-[80vh] overflow-y-auto">
+            <DialogTitle className="text-center text-lg font-semibold">
+              {selectedVar}
+            </DialogTitle>
+            <div className="mt-4">
+              {meta && (
+                <MetaDataInfo meta={meta} setShowMeta={setShowMeta} noCard />
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </Popover>
   );
 };
 

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -116,9 +116,15 @@ const Variables = ({
                 </Button>
               </div>
             </TooltipTrigger>
-            <TooltipContent side="left" align="start">
-              <span>Select Variable</span>
-            </TooltipContent>
+            {popoverSide === "left" ? (
+              <TooltipContent side="left" align="start">
+                <span>Select Variable</span>
+              </TooltipContent>
+            ) : (
+              <TooltipContent side="top" align="center">
+                <span>Select Variable</span>
+              </TooltipContent>
+            )}
           </Tooltip>
         </div>
       </PopoverTrigger>

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -68,25 +68,33 @@ const Variables = ({
 
   const VariableList = (
     <div className="overflow-y-auto flex-1 [&::-webkit-scrollbar]:hidden">
-      {filtered.map((val, idx) => (
-        <React.Fragment key={idx}>
-          <div
-            className="cursor-pointer pl-2 py-1 text-sm hover:bg-muted rounded"
-            style={{
-              background:
-                idx === selectedIndex ? "var(--muted-foreground)" : "",
-            }}
-            onClick={() => {
-              setSelectedIndex(idx);
-              setSelectedVar(val);
-              setShowMeta(true);
-            }}
-          >
-            {val}
-          </div>
-          {idx !== filtered.length - 1 && <Separator className="my-1" />}
-        </React.Fragment>
-      ))}
+      {filtered.length > 0 ? (
+        filtered.map((val, idx) => (
+          <React.Fragment key={idx}>
+            <div
+              className="cursor-pointer pl-2 py-1 text-sm hover:bg-muted rounded"
+              style={{
+                background:
+                  idx === selectedIndex ? "var(--muted-foreground)" : "",
+              }}
+              onClick={() => {
+                setSelectedIndex(idx);
+                setSelectedVar(val);
+                setShowMeta(true);
+              }}
+            >
+              {val}
+            </div>
+            {idx !== filtered.length - 1 && <Separator className="my-1" />}
+          </React.Fragment>
+        ))
+      ) : (
+        <div className="text-center text-muted-foreground py-2">
+          {query
+            ? "No variables found matching your search."
+            : "No variables available."}
+        </div>
+      )}
     </div>
   );
 


### PR DESCRIPTION
This PR adds 

- [x] a `Dialog` option when selecting variable on Mobile. The popover element is unchanged. 
- [x] enhances the input search by showing when your research doesn't match anything.
- [x] reduces the duration of Toasters
- [x] updated some tooltip content positions from `left` to `top` depending on device. Some are not updated, `settings` and `animation controls`, they don't have `popoverSide` variable. TODO