### PR TITLE
Compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "fflate": "^0.8.2",
     "js-colormaps-es": "^0.0.5",
     "lucide-react": "^0.503.0",
     "next": "15.4.3",

--- a/src/components/computation/ComputeModule.tsx
+++ b/src/components/computation/ComputeModule.tsx
@@ -8,6 +8,7 @@ import { useThree } from '@react-three/fiber';
 import { useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
 import { useShallow } from 'zustand/shallow';
 import { ThreeEvent } from '@react-three/fiber';
+import { GetCurrentArray } from '@/utils/HelperFuncs';
 
 interface Array{
     data:number[],
@@ -54,7 +55,7 @@ const ComputeModule = ({arrays,values, setters}:ComputeModule) => {
     const [planeShape,setPlaneShape] = useState<number[]>(shape.filter((_val,idx)=> idx !== axis))
     const {gl} = useThree()
     const infoRef = useRef<boolean>(false)
-    const dataArray = useRef<Float32Array>(new Float32Array(0));
+    const dataArray = useRef<Float32Array>(new Float32Array(GetCurrentArray()));
 
     const {cScale, cOffset} = usePlotStore(useShallow(state => ({
       cScale: state.cScale,

--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ArrayMinMax } from '@/utils/HelperFuncs';
+import { ArrayMinMax, GetCurrentArray } from '@/utils/HelperFuncs';
 import * as THREE from 'three'
 import React, { useEffect, useRef } from 'react'
 import { DataReduction, Convolve, Multivariate2D, Multivariate3D, CUMSUM3D, Convolve2D } from '../computation/webGPU'
@@ -10,8 +10,7 @@ import { ZarrDataset } from '../zarr/ZarrLoaderLRU';
 
 const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.SetStateAction<THREE.Data3DTexture | THREE.DataTexture | null>>, ZarrDS: ZarrDataset}) => {
     
-    const {dataArray, strides, dataShape, valueScales, isFlat, setIsFlat, setDownloading, setShowLoading, setValueScales} = useGlobalStore(useShallow(state=>({
-        dataArray : state.dataArray,
+    const { strides, dataShape, valueScales, isFlat, setIsFlat, setDownloading, setShowLoading, setValueScales} = useGlobalStore(useShallow(state=>({
         strides: state.strides,
         dataShape: state.dataShape,
         valueScales: state.valueScales,
@@ -45,6 +44,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
 
     // 3D Computations
     useEffect(()=>{ 
+        const dataArray = GetCurrentArray()
         if (dataArray.length <= 1 || isFlat){
             return;
         }
@@ -197,6 +197,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
     },[execute])
 
     useEffect(()=>{
+        const dataArray = GetCurrentArray()
         if (dataArray.length <= 1 || !isFlat){
             return;
         }

--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -23,7 +23,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
 
     const setPlotType = usePlotStore(state => state.setPlotType)
     const {axis, execute, operation, useTwo, variable2, 
-        valueScalesOrig, kernelSize, kernelDepth, kernelOperation, reverseDirection, 
+        valueScalesOrig, kernelSize, kernelDepth, kernelOperation, reverseDirection, analysisStore,
         setValueScalesOrig, setAnalysisArray} = useAnalysisStore(useShallow(state => ({
         axis: state.axis,
         execute: state.execute,
@@ -35,6 +35,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
         kernelDepth: state.kernelDepth,
         kernelOperation: state.kernelOperation,
         reverseDirection: state.reverseDirection,
+        analysisStore: state.analysisStore,
         setValueScalesOrig: state.setValueScalesOrig,
         setAnalysisArray: state.setAnalysisArray,
     })))
@@ -44,7 +45,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
 
     // 3D Computations
     useEffect(()=>{ 
-        const dataArray = GetCurrentArray()
+        const dataArray = GetCurrentArray(analysisStore)
         if (dataArray.length <= 1 || isFlat){
             return;
         }
@@ -147,7 +148,6 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
                 variable2Array.current = await ZarrDS.GetArray(variable2, zarrSlice)
                 setDownloading(false)
                 if (['TwoVarLinearSlope2D', 'Correlation2D', 'Covariance2D'].includes(operation)){ //These are 2D operations
-                    console.log("calling this")
                     const thisShape = dataShape.filter((e, idx) => idx != axis)
                     //@ts-expect-error It won't be undefined here as Multivariate2D only outputs undefined if webGPU disabled. However, impossible to call if webGPU disabled so moot point
                     const newArray: Float32Array = await Multivariate2D(dataArray, variable2Array.current.data, {shape:dataShape, strides}, axis, operation)
@@ -174,6 +174,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
                     if (!valueScalesOrig){
                             setValueScalesOrig(valueScales)
                     }
+
                     let [minVal, maxVal] = [-1, 1];
                     if (['TwoVarLinearSlope3D', 'CovarianceConvolution'].includes(operation)){
                         [minVal, maxVal] = ArrayMinMax(newArray) //If slope get actual bounds
@@ -197,7 +198,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
     },[execute])
 
     useEffect(()=>{
-        const dataArray = GetCurrentArray()
+        const dataArray = GetCurrentArray(analysisStore)
         if (dataArray.length <= 1 || !isFlat){
             return;
         }
@@ -239,6 +240,7 @@ const AnalysisWG = ({setTexture, ZarrDS} : {setTexture : React.Dispatch<React.Se
             }
         }
     },[execute])
+
   return null
     
 }

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -7,6 +7,7 @@ import { vertShader } from '@/components/computation/shaders'
 import { flatFrag3D, fragmentFlat } from '../textures/shaders';
 import { useShallow } from 'zustand/shallow'
 import { ThreeEvent } from '@react-three/fiber';
+import { GetCurrentArray } from '@/utils/HelperFuncs';
 
 interface InfoSettersProps{
   setLoc: React.Dispatch<React.SetStateAction<number[]>>;
@@ -23,10 +24,9 @@ function Rescale(value: number, scales: {minVal: number, maxVal: number}){
 
 const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.Data3DTexture, infoSetters : InfoSettersProps}) => {
     const {setLoc, setShowInfo, val, coords} = infoSetters;
-    const {flipY, colormap, dataArray, valueScales, dimArrays, isFlat} = useGlobalStore(useShallow(state => ({
+    const {flipY, colormap, valueScales, dimArrays, isFlat} = useGlobalStore(useShallow(state => ({
       flipY: state.flipY, 
       colormap: state.colormap, 
-      dataArray: state.dataArray,
       valueScales: state.valueScales,
       dimArrays: state.dimArrays,
       isFlat: state.isFlat
@@ -45,13 +45,14 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
       analysisMode: state.analysisMode,
       analysisArray: state.analysisArray
     })))
+
     const dataSource = texture.source.data
     const shapeRatio = useMemo(()=> dataSource.height/dataSource.width, [dataSource])
     const geometry = useMemo(()=>new THREE.PlaneGeometry(2,2*shapeRatio),[shapeRatio])
     const infoRef = useRef<boolean>(false)
     const lastUV = useRef<THREE.Vector2>(new THREE.Vector2(0,0))
     const rotateMap = analysisMode && axis == 2;
-    const sampleArray = useMemo(()=> analysisMode ? analysisArray : dataArray,[analysisMode, dataArray, analysisArray])
+    const sampleArray = useMemo(()=> analysisMode ? analysisArray : GetCurrentArray(),[analysisMode, analysisArray])
     const analysisDims = useMemo(()=>dimArrays.filter((_e,idx)=> idx != axis),[dimArrays,axis])
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -14,7 +14,6 @@ import AnalysisWG from './AnalysisWG';
 import { ParseExtent } from '@/utils/HelperFuncs';
 import ExportCanvas from '@/utils/ExportCanvas';
 
-
 const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
   const {resetCamera} = usePlotStore(useShallow(state => ({
       resetCamera: state.resetCamera
@@ -100,7 +99,7 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
           setShowLoading: state.setShowLoading  
         }
         )))
-    const {colormap, variable, isFlat, metadata, valueScales, is4D, setIsFlat, setDataArray} = useGlobalStore(useShallow(state=>({
+    const {colormap, variable, isFlat, metadata, valueScales, is4D, setIsFlat} = useGlobalStore(useShallow(state=>({
       colormap: state.colormap, 
       variable: state.variable, 
       isFlat: state.isFlat, 
@@ -108,7 +107,6 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       valueScales: state.valueScales,
       is4D: state.is4D,
       setIsFlat: state.setIsFlat, 
-      setDataArray: state.setDataArray
     })))
 
     const {plotType} = usePlotStore(useShallow(state => ({
@@ -161,7 +159,6 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
         else{
           setIsFlat(false)
         }
-        setDataArray(result.data)
         const shapeRatio = result.shape[1] / result.shape[2] * 2;
         setShape(new THREE.Vector3(2, shapeRatio, 2));
         setDataShape(result.shape)

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -134,7 +134,7 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       setShow(false)
       try{
         ZarrDS.GetArray(variable, slice).then((result) => {
-        // result now contains: { data: TypedArray, shape: number[], dtype: string }
+          console.log(result)
         const [texture, scaling] = ArrayToTexture({
           data: result.data,
           shape: result.shape
@@ -145,13 +145,11 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
           console.error("Invalid texture type returned from ArrayToTexture");
           setTexture(null);
         }
-        if (
-          typeof scaling === 'object' &&
-          'maxVal' in scaling &&
-          'minVal' in scaling
-        ) {
+        if (result.scalingFactor){
+          const {maxVal, minVal} = scaling
+          setValueScales({ maxVal: maxVal*(Math.pow(10,result.scalingFactor)), minVal: minVal*(Math.pow(10,result.scalingFactor)) });
+        }else{
           setValueScales(scaling as { maxVal: number; minVal: number });
-          
         }
         if (result.shape.length == 2){
           setIsFlat(true)

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -134,7 +134,6 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       setShow(false)
       try{
         ZarrDS.GetArray(variable, slice).then((result) => {
-          console.log(result)
         const [texture, scaling] = ArrayToTexture({
           data: result.data,
           shape: result.shape

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -5,7 +5,7 @@ import { pointFrag, pointVert } from '@/components/textures/shaders'
 import { useAnalysisStore, useErrorStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
 import { useShallow } from 'zustand/shallow';
 import { ZarrDataset } from '../zarr/ZarrLoaderLRU';
-import { parseUVCoords, getUnitAxis, GetTimeSeries } from '@/utils/HelperFuncs';
+import { parseUVCoords, getUnitAxis, GetTimeSeries, GetCurrentArray } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 interface PCProps {
   texture: THREE.Data3DTexture | THREE.DataTexture | null,
@@ -32,13 +32,12 @@ const MappingCube = ({dimensions, ZarrDS, setters} : {dimensions: dimensionsProp
 
   const aspectRatio = width/height;
   const depthRatio = depth/height;
-  const {dimArrays, dimUnits, dimNames, strides, dataShape, dataArray, setPlotDim, setTimeSeries, updateTimeSeries, setDimCoords, updateDimCoords} = useGlobalStore(useShallow(state => ({
+  const {dimArrays, dimUnits, dimNames, strides, dataShape, setPlotDim, setTimeSeries, updateTimeSeries, setDimCoords, updateDimCoords} = useGlobalStore(useShallow(state => ({
     dimArrays: state.dimArrays,
     dimUnits: state.dimUnits,
     dimNames: state.dimNames,
     strides: state.strides,
     dataShape: state.dataShape,
-    dataArray: state.dataArray,
     setPlotDim: state.setPlotDim,
     setTimeSeries: state.setTimeSeries,
     updateTimeSeries: state.updateTimeSeries,
@@ -73,7 +72,7 @@ const MappingCube = ({dimensions, ZarrDS, setters} : {dimensions: dimensionsProp
       lastNormal.current = dimAxis;
       
       if(ZarrDS){
-        const tempTS = GetTimeSeries({data: analysisMode? analysisArray : dataArray, shape: dataShape, stride: strides},{uv,normal})
+        const tempTS = GetTimeSeries({data: analysisMode? analysisArray : GetCurrentArray(), shape: dataShape, stride: strides},{uv,normal})
         const plotDim = (normal.toArray()).map((val, idx) => {
           if (Math.abs(val) > 0) {
             return idx;

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -4,7 +4,7 @@ import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalSt
 import { ZarrDataset } from '@/components/zarr/ZarrLoaderLRU';
 import { useShallow } from 'zustand/shallow'
 import { vertexShader, sphereFrag, flatSphereFrag } from '../textures/shaders'
-import { parseUVCoords, GetTimeSeries } from '@/utils/HelperFuncs';
+import { parseUVCoords, GetTimeSeries, GetCurrentArray } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 
 
@@ -46,13 +46,12 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
       analysisArray: state.analysisArray
     })))
 
-    const {dimArrays,dimNames,dimUnits, timeSeries, dataShape, dataArray, strides} = useGlobalStore(useShallow(state=>({
+    const {dimArrays,dimNames,dimUnits, timeSeries, dataShape, strides} = useGlobalStore(useShallow(state=>({
         dimArrays:state.dimArrays,
         dimNames:state.dimNames,
         dimUnits:state.dimUnits,
         timeSeries: state.timeSeries,
         dataShape: state.dataShape,
-        dataArray: state.dataArray,
         strides: state.strides
     })))
 
@@ -153,7 +152,7 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
         const normal = new THREE.Vector3(0,0,1)
     
         if(ZarrDS){
-          const tempTS = GetTimeSeries({data:analysisMode ? analysisArray : dataArray, shape:dataShape, stride:strides},{uv,normal})
+          const tempTS = GetTimeSeries({data:analysisMode ? analysisArray : GetCurrentArray(), shape:dataShape, stride:strides},{uv,normal})
           const plotDim = (normal.toArray()).map((val, idx) => {
             if (Math.abs(val) > 0) {
               return idx;

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import { useMemo, useState, useEffect, useRef } from 'react';
 import { ZarrDataset } from '@/components/zarr/ZarrLoaderLRU';
-import { parseUVCoords, getUnitAxis, GetTimeSeries } from '@/utils/HelperFuncs';
+import { parseUVCoords, getUnitAxis, GetTimeSeries, GetCurrentArray } from '@/utils/HelperFuncs';
 import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
 import { useShallow } from 'zustand/shallow';
 import { evaluate_cmap } from 'js-colormaps-es';
@@ -24,11 +24,10 @@ export const UVCube = ({ZarrDS} : {ZarrDS:ZarrDataset} )=>{
     analysisArray: state.analysisArray
   })))
 
-  const {shape, dataShape, dataArray, strides, dimArrays,dimNames,dimUnits} = useGlobalStore(
+  const {shape, dataShape, strides, dimArrays,dimNames,dimUnits} = useGlobalStore(
     useShallow(state=>({
       shape:state.shape,
       dataShape: state.dataShape,
-      dataArray: state.dataArray,
       strides: state.strides,
       dimArrays:state.dimArrays,
       dimNames:state.dimNames,
@@ -55,7 +54,7 @@ export const UVCube = ({ZarrDS} : {ZarrDS:ZarrDataset} )=>{
     lastNormal.current = dimAxis;
     
     if(ZarrDS){
-      const tempTS = GetTimeSeries({data: analysisMode ? analysisArray : dataArray, shape: dataShape, stride: strides},{uv,normal})
+      const tempTS = GetTimeSeries({data: analysisMode ? analysisArray : GetCurrentArray(), shape: dataShape, stride: strides},{uv,normal})
       const plotDim = (normal.toArray()).map((val, idx) => {
         if (Math.abs(val) > 0) {
           return idx;

--- a/src/components/plots/plotarea/LinePlot.tsx
+++ b/src/components/plots/plotarea/LinePlot.tsx
@@ -32,6 +32,7 @@ function PointInfo({pointID,pointLoc,showPointInfo, plotUnits}:pointInfo){
   );
   let pointY = 0;
   let pointX = 0;
+  console.log(timeSeries)
   if (Object.entries(pointID).length > 0 && Object.entries(timeSeries).length > 0){
     const [tsID, idx] = Object.entries(pointID)[0];
     pointY = timeSeries[tsID][idx];

--- a/src/components/plots/plotarea/LinePlot.tsx
+++ b/src/components/plots/plotarea/LinePlot.tsx
@@ -12,7 +12,7 @@ import { DimCoords } from '@/utils/GlobalStates'
 
 
 interface pointInfo{
-  pointID:Record<string,number>,
+  pointID:[string, number],
   pointLoc:number[],
   showPointInfo:boolean
   plotUnits:string
@@ -20,7 +20,6 @@ interface pointInfo{
 const MIN_HEIGHT = 10;
 
 function PointInfo({pointID,pointLoc,showPointInfo, plotUnits}:pointInfo){
-
   const {plotDim, dimArrays, dimNames, dimUnits, timeSeries} = useGlobalStore(
     useShallow(state=>({
       plotDim:state.plotDim,
@@ -32,12 +31,12 @@ function PointInfo({pointID,pointLoc,showPointInfo, plotUnits}:pointInfo){
   );
   let pointY = 0;
   let pointX = 0;
-  console.log(timeSeries)
   if (Object.entries(pointID).length > 0 && Object.entries(timeSeries).length > 0){
-    const [tsID, idx] = Object.entries(pointID)[0];
-    pointY = timeSeries[tsID][idx];
+    const [tsID, idx] = pointID;
+    pointY = timeSeries[tsID]['data'][idx];
     pointX = dimArrays[plotDim][idx];
   }
+
   const [divX,divY] = pointLoc;
   const [show,setShow] = useState(false);
 
@@ -161,7 +160,7 @@ function PointCoords(){
 }
 
 export function PlotArea() {
-  const [pointID, setPointID] = useState<Record<string, number>>({});
+  const [pointID, setPointID] = useState<[string, number]>(['',0]);
   const [pointLoc, setPointLoc] = useState<number[]>([0,0])
   const [showPointInfo,setShowPointInfo] = useState<boolean>(false)
   const [height, setHeight] = useState<number>(Math.round(window.innerHeight-(window.innerHeight*0.25)))
@@ -174,7 +173,7 @@ export function PlotArea() {
   const pointSetters ={
     setPointID,
     setPointLoc,
-    setShowPointInfo
+    setShowPointInfo,
   }
 
   // Handle orientation changes

--- a/src/components/plots/plotarea/PlotPoints.tsx
+++ b/src/components/plots/plotarea/PlotPoints.tsx
@@ -3,7 +3,6 @@ import * as THREE from 'three'
 import { useFrame } from '@react-three/fiber'
 import { useGlobalStore, usePlotStore } from '@/utils/GlobalStates'
 import { useShallow } from 'zustand/shallow'
-import { evaluate_cmap } from 'js-colormaps-es'
 
 interface pointSetters{
   setPointID:React.Dispatch<React.SetStateAction<[string,number]>>,
@@ -30,7 +29,7 @@ function PlotPoints({ points, tsID, pointSetters, scalers }: { points: THREE.Vec
   })))
   const [r, g, b] = timeSeries[tsID]['color']
   const geometry = useMemo(() => new THREE.SphereGeometry(pointSize), [pointSize])
-  const material = useMemo(()=> new THREE.MeshBasicMaterial({color: new THREE.Color().setRGB(r/300, g/300, b/300).convertSRGBToLinear()}),[pointColor, useCustomPointColor])  // It was converting to sRGB colorspace while the line shader uses linear
+  const material = useMemo(()=> new THREE.MeshBasicMaterial({color: new THREE.Color().setRGB(r/300, g/300, b/300).convertSRGBToLinear()}),[pointColor, useCustomPointColor, timeSeries])  // It was converting to sRGB colorspace while the line shader uses linear
 
 
   useEffect(() => {

--- a/src/components/plots/plotarea/PlotPoints.tsx
+++ b/src/components/plots/plotarea/PlotPoints.tsx
@@ -6,7 +6,7 @@ import { useShallow } from 'zustand/shallow'
 import { evaluate_cmap } from 'js-colormaps-es'
 
 interface pointSetters{
-  setPointID:React.Dispatch<React.SetStateAction<Record<string,number>>>,
+  setPointID:React.Dispatch<React.SetStateAction<[string,number]>>,
   setPointLoc:React.Dispatch<React.SetStateAction<number[]>>,
   setShowPointInfo:React.Dispatch<React.SetStateAction<boolean>>,
 }
@@ -74,7 +74,7 @@ function PlotPoints({ points, tsID, pointSetters, colIDX, scalers }: { points: T
       ref.current.setMatrixAt(e.instanceId, dummy.matrix);
       ref.current.instanceMatrix.needsUpdate = true;
       setreRender((x) => !x);
-      setPointID({[tsID] : e.instanceId})
+      setPointID([tsID, e.instanceId])
       setPointLoc([e.clientX,e.clientY])
       setShowPointInfo(true)
     }

--- a/src/components/plots/plotarea/PlotPoints.tsx
+++ b/src/components/plots/plotarea/PlotPoints.tsx
@@ -1,7 +1,7 @@
 import React, {useRef, useMemo, useEffect, useState} from 'react'
 import * as THREE from 'three'
 import { useFrame } from '@react-three/fiber'
-import { usePlotStore } from '@/utils/GlobalStates'
+import { useGlobalStore, usePlotStore } from '@/utils/GlobalStates'
 import { useShallow } from 'zustand/shallow'
 import { evaluate_cmap } from 'js-colormaps-es'
 
@@ -11,7 +11,7 @@ interface pointSetters{
   setShowPointInfo:React.Dispatch<React.SetStateAction<boolean>>,
 }
 
-function PlotPoints({ points, tsID, pointSetters, colIDX, scalers }: { points: THREE.Vector3[]; tsID: string, pointSetters:pointSetters; colIDX: number, scalers:{xScale:number,yScale:number} }) {
+function PlotPoints({ points, tsID, pointSetters, scalers }: { points: THREE.Vector3[]; tsID: string, pointSetters:pointSetters; scalers:{xScale:number,yScale:number} }) {
   const ref = useRef<THREE.InstancedMesh | null>(null);
   const count = points.length;
   const lastID = useRef<number | null>(null);
@@ -25,9 +25,13 @@ function PlotPoints({ points, tsID, pointSetters, colIDX, scalers }: { points: T
     useCustomPointColor: state.useCustomPointColor
   })))
   const {xScale, yScale} = scalers;
-  const [r, g, b] = useMemo(()=>evaluate_cmap(colIDX/10, "Paired"),[colIDX])
+  const {timeSeries} = useGlobalStore(useShallow(state =>({
+    timeSeries: state.timeSeries
+  })))
+  const [r, g, b] = timeSeries[tsID]['color']
   const geometry = useMemo(() => new THREE.SphereGeometry(pointSize), [pointSize])
-  const material = useMemo(()=> new THREE.MeshBasicMaterial({color: useCustomPointColor ? pointColor : new THREE.Color().setRGB(r/500, g/500, b/500)}),[pointColor, useCustomPointColor])
+  const material = useMemo(()=> new THREE.MeshBasicMaterial({color: new THREE.Color().setRGB(r/300, g/300, b/300).convertSRGBToLinear()}),[pointColor, useCustomPointColor])  // It was converting to sRGB colorspace while the line shader uses linear
+
 
   useEffect(() => {
     if (ref.current){

--- a/src/components/plots/plotarea/ThickLine.tsx
+++ b/src/components/plots/plotarea/ThickLine.tsx
@@ -163,9 +163,9 @@ const ThickLine = ({height, xScale, yScale, pointSetters} : ThickLineProps) => {
 		<group>
       {Object.keys(timeSeries).map((val, idx)=>(
         <mesh key={`lineMesh_${idx}`} geometry={geometries[val]} material={ materials[val]} />))}
-      {/* {showPoints && Object.keys(timeSeries).map((val, idx)=> 
+      {showPoints && Object.keys(timeSeries).map((val, idx)=> 
         <PlotPoints key={`plotPoints_${idx}`} points={instancePoints[val]} tsID={val} colIDX={idx} pointSetters={pointSetters} scalers={{xScale,yScale}}/>
-      )} */}
+      )}
 		</group>
 		</>
   )

--- a/src/components/plots/plotarea/ThickLine.tsx
+++ b/src/components/plots/plotarea/ThickLine.tsx
@@ -8,7 +8,6 @@ import vertexShader from '@/components/textures/shaders/thickLineVert.glsl'
 import { PlotPoints } from './PlotPoints';
 import { useThree } from '@react-three/fiber';
 import { invalidate } from '@react-three/fiber';
-import { evaluate_cmap } from 'js-colormaps-es';
 
 
 function linspace(start: number, stop: number, num: number): number[] {
@@ -17,7 +16,7 @@ function linspace(start: number, stop: number, num: number): number[] {
   }
 
 interface pointSetters{
-  setPointID:React.Dispatch<React.SetStateAction<Record<string, number>>>,
+  setPointID:React.Dispatch<React.SetStateAction<[string, number]>>,
   setPointLoc:React.Dispatch<React.SetStateAction<number[]>>,
   setShowPointInfo:React.Dispatch<React.SetStateAction<boolean>>,
 }

--- a/src/components/plots/plotarea/ThickLine.tsx
+++ b/src/components/plots/plotarea/ThickLine.tsx
@@ -156,14 +156,13 @@ const ThickLine = ({height, xScale, yScale, pointSetters} : ThickLineProps) => {
   useEffect(()=>{
     invalidate()
   },[showPoints])
-
   return (
     <>
 		<group>
       {Object.keys(timeSeries).map((val, idx)=>(
         <mesh key={`lineMesh_${idx}`} geometry={geometries[val]} material={ materials[val]} />))}
       {showPoints && Object.keys(timeSeries).map((val, idx)=> 
-        <PlotPoints key={`plotPoints_${idx}`} points={instancePoints[val]} tsID={val} colIDX={idx} pointSetters={pointSetters} scalers={{xScale,yScale}}/>
+        <PlotPoints key={`plotPoints_${idx}`} points={instancePoints[val]} tsID={val}  pointSetters={pointSetters} scalers={{xScale,yScale}}/>
       )}
 		</group>
 		</>

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -9,14 +9,13 @@ interface Array {
 
 
 // ? Please, try when possible to define the types of your variables. Otherwise building will fail.
-function ArrayTo2D(array: Array){
+function ArrayTo2D(array: Array): [ THREE.DataTexture, {minVal: number, maxVal: number}]{
     //We assume there is no slicing here. That will occur in the ZarrLoader stage. This is just pure data transfer
     const shape = array.shape;
     const data = array.data;
     const width = shape[1];
     const height = shape[0];
     const [minVal,maxVal] = ArrayMinMax(data)
-
     const normed = data.map((i)=>(i-minVal)/(maxVal-minVal))
 
     const textureData = new Uint8Array(normed.map((i)=>isNaN(i) ? 255 : i*254))
@@ -33,12 +32,13 @@ function ArrayTo2D(array: Array){
     return [texture, {maxVal,minVal}]
 }
 
-export function ArrayTo3D(array: Array){
+export function ArrayTo3D(array: Array) : [ THREE.Data3DTexture, {minVal: number, maxVal: number}]{
     const shape = array.shape;
     const data = array.data;
     const [lz,ly,lx] = shape
 
     const [minVal,maxVal] = ArrayMinMax(data)
+    
     const normed = data.map((i)=>(i-minVal)/(maxVal-minVal))
     const textureData = new Uint8Array(normed.map((i)=>isNaN(i) ? 255 : i*254));   
     const volTexture = new THREE.Data3DTexture(textureData, lx, ly, lz);
@@ -49,7 +49,7 @@ export function ArrayTo3D(array: Array){
     return [volTexture, {maxVal,minVal}]
 }
 
-export function ArrayToTexture(array: Array){
+export function ArrayToTexture(array: Array): [ THREE.Data3DTexture | THREE.DataTexture, {minVal: number, maxVal: number}]{
     const shape = array.shape;
     const [texture,scales] = shape.length == 3 ? ArrayTo3D(array) : ArrayTo2D(array);
     return [texture, scales];

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { ArrayMinMax} from '@/utils/HelperFuncs';
 
 interface Array {
-    data: Float32Array | Float64Array | Int32Array | Uint32Array;
+    data: Float32Array | Float64Array | Int32Array | Uint32Array | Float32Array;
     shape: number[];
 }
 

--- a/src/components/textures/shaders/fragment.glsl
+++ b/src/components/textures/shaders/fragment.glsl
@@ -73,7 +73,7 @@ void main() {
         texCoord.z = mod(texCoord.z + animateProg, 1.0001);
         float d = sample1(texCoord);
 
-        bool cond = nanAlpha == 0. ? (d > threshold.x) && (d < threshold.y) : (d > threshold.x) && (d < threshold.y+.01); //We skip over nans if the transparency is enabled
+        bool cond = nanAlpha == 0. ? (d >= threshold.x) && (d <= threshold.y) : (d >= threshold.x) && (d <= threshold.y); //We skip over nans if the transparency is enabled
         
         if (cond) {
             if (d == 1.){

--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -106,6 +106,11 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
 
     },[newMin, newMax])
 
+    useEffect(()=>{ // Update internal vals when global vals change
+        setNewMin(valueScales.minVal)
+        setNewMax(valueScales.maxVal)
+    },[valueScales])
+
     useEffect(() => {
         if (canvasRef.current) {
         const canvas = canvasRef.current;

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -80,7 +80,8 @@ const AnalysisOptions = () => {
     setKernelDepth,
     setKernelOperation,
     setAnalysisMode,
-    setReverseDirection
+    setReverseDirection,
+    setAnalysisStore
   } = useAnalysisStore(useShallow(state => ({
     execute: state.execute,
     operation: state.operation,
@@ -102,6 +103,7 @@ const AnalysisOptions = () => {
     setKernelOperation: state.setKernelOperation,
     setAnalysisMode: state.setAnalysisMode,
     setReverseDirection: state.setReverseDirection,
+    setAnalysisStore: state.setAnalysisStore
     })));
 
   const {reFetch, setReFetch} = useZarrStore(useShallow(state => ({
@@ -142,6 +144,7 @@ const AnalysisOptions = () => {
   useEffect(()=>{ // When data is downloaded (indicated by changes in refetch) The newly plotted and any future variables are compatible until initStore changes. 
     setIncompatible(false);
     previousStore.current = initStore
+    setAnalysisStore(initStore)
   },[reFetch])
 
   useEffect(()=>{
@@ -368,8 +371,7 @@ const AnalysisOptions = () => {
                       )}
                     {['Convolution', 'Correlation3D', 'Covariance3D', 'TwoVarLinearSlope3D'].includes(operation) && ( //Show if IN left arrays
                       <>
-                        
-                        <tr>
+                        {/* <tr>
                           <th>Kernel Op.</th>
                           <td>
                             <Select onValueChange={setKernelOperation}>
@@ -397,7 +399,7 @@ const AnalysisOptions = () => {
                               </SelectContent>
                             </Select>
                           </td>
-                        </tr>
+                        </tr> */}
                         <tr>
                           <th style={{padding:'0px 12px'}}>Kernel Size</th>
                           <td>

--- a/src/components/ui/MainPanel/PlayButton.tsx
+++ b/src/components/ui/MainPanel/PlayButton.tsx
@@ -28,7 +28,7 @@ const PlayInterFace = ({visible}:{visible : boolean}) =>{
         dimNames: state.dimNames,
         dimUnits: state.dimUnits 
     })))
-
+    // console.log(dimArrays[0].slice(0,5), dimArrays[1].slice(0,5))
     const timeLength = useMemo(()=>dimArrays[0].length,[dimArrays])
     const [timeStep, setTimeStep] = useState(0)
     

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -226,7 +226,6 @@ export class ZarrDataset{
 				setDownloading(false)
 				setProgress(0) // Reset progress for next load
 			}
-			console.log(typedArray)
 			return {
 				data: typedArray,
 				shape: shape,

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -1,9 +1,10 @@
 import * as zarr from "zarrita";
 import * as THREE from 'three';
 import QuickLRU from 'quick-lru';
-import { parseUVCoords } from "@/utils/HelperFuncs";
+import { parseUVCoords, ArrayMinMax } from "@/utils/HelperFuncs";
 import { GetSize } from "./GetMetadata";
 import { useGlobalStore, useZarrStore, useErrorStore, useCacheStore } from "@/utils/GlobalStates";
+import { gzipSync, decompressSync } from 'fflate';
 
 export const ZARR_STORES = {
     ESDC: 'https://s3.bgc-jena.mpg.de:9000/esdl-esdc-v3.0.2/esdc-16d-2.5deg-46x72x1440-3.0.2.zarr',
@@ -36,6 +37,20 @@ export async function GetStore(storePath: string): Promise<zarr.Group<zarr.Fetch
 		}    
 }
 
+function CompressArray(array: Float16Array, level: number){
+	const uint8View = new Uint8Array(array.buffer);
+	const compressed = gzipSync(uint8View, { level: level as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined })
+	return compressed
+}
+// Infer compressed type
+function DecompressArray(compressed : Uint8Array){
+	const decompressed = decompressSync(compressed)
+	const floatArray = new Float16Array(decompressed.buffer)
+	return floatArray
+}
+
+
+
 interface TimeSeriesInfo{
 	uv:THREE.Vector2,
 	normal:THREE.Vector3
@@ -58,14 +73,18 @@ export class ZarrDataset{
 
 	async GetArray(variable: string, slice: [number, number | null]){
 
-		const {is4D, idx4D, setProgress, setStrides, setDownloading} = useGlobalStore.getState();
+		const {is4D, idx4D, initStore, setProgress, setStrides, setDownloading} = useGlobalStore.getState();
 		const {compress, setCurrentChunks, setArraySize} = useZarrStore.getState()
 		const {cache} = useCacheStore.getState();
 
 		//Check if cached
 		this.variable = variable;
-		if (cache.has(is4D ? `${idx4D}_${variable}` : variable)){
-			return cache.get(variable)
+		if (cache.has(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)){
+			const thisChunk = cache.get(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)
+			if (thisChunk.compressed){
+				thisChunk.data = DecompressArray(thisChunk.data)
+			}
+			return thisChunk;
 		}
 
 		const group = await this.groupStore;
@@ -82,47 +101,73 @@ export class ZarrDataset{
 			let chunk;
 			let typedArray;
 			let shape;
-			if (totalSize < 1e8 || !hasTimeChunks){ //Check if total is less than 100MB or no chunks along time
+			let scalingFactor = null;
+			if (totalSize < 1e8 || !hasTimeChunks){ // Check if total is less than 100MB or no chunks along time
 				setDownloading(true)
 				chunk = is4D ? await zarr.get(outVar, [idx4D, null , null, null]) :  await zarr.get(outVar) ;
 				shape = is4D ? outVar.shape.slice(1) : outVar.shape;
-				setStrides(chunk.stride) //Need strides for the point cloud
+				setStrides(chunk.stride) // Need strides for the point cloud
 				if (chunk.data instanceof BigInt64Array || chunk.data instanceof BigUint64Array) {
 							throw new Error("BigInt arrays are not supported for conversion to Float32Array.");
 				} else {
 					typedArray = new Float32Array(chunk.data)
-					cache.set(is4D ? `${idx4D}_${variable}` : variable, chunk)
+					const [minVal, maxVal] = ArrayMinMax(typedArray)
+					if (maxVal <= 65504 && minVal >= -65504){ // If values fit in Float16, use that to save memory
+						typedArray = new Float16Array(chunk.data)
+					}
+					else{
+						scalingFactor = Math.ceil(Math.log10(maxVal/65504))
+						console.log(scalingFactor)
+						for (let i = 0; i < typedArray.length; i++) {
+							typedArray[i] /= Math.pow(10,scalingFactor);
+						}
+						typedArray = new Float16Array(typedArray)
+					}
+					const cacheChunk = {
+						data: compress ? CompressArray(typedArray, 6) : typedArray,
+						shape: chunk.shape,
+						stride: chunk.stride,
+						scaling: scalingFactor,
+						compressed: compress
+					}
+					cache.set(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`, cacheChunk)
 				}
 				setDownloading(false)
 			}
 			else { 
 				setDownloading(true)
 				setProgress(0)
+
 				const startIdx = Math.floor(slice[0]/chunkShape[0])
 				const endIdx = slice[1] ? Math.ceil(slice[1]/chunkShape[0]) : is4D ? Math.ceil(outVar.shape[1]/chunkShape[0]) : Math.ceil(outVar.shape[0]/chunkShape[0]) //If Slice[1] is null, use the end of the array
 				const chunkCount = endIdx-startIdx
 				const timeSize = is4D ? outVar.shape[2]*outVar.shape[3] : outVar.shape[1]*outVar.shape[2]
 				const arraySize = (endIdx-startIdx)*chunkShape[0]*timeSize
-				shape = is4D ? [(endIdx-startIdx)*chunkShape[0], outVar.shape[2],outVar.shape[3]]
-				: [(endIdx-startIdx)*chunkShape[0], outVar.shape[1],outVar.shape[2]]
 				setArraySize(arraySize) // This is used for the getcurrentarray function
-				typedArray = compress ? new Uint8Array(arraySize) : new Float32Array(arraySize);
+
+				shape = is4D ? [(endIdx-startIdx)*chunkShape[0], outVar.shape[2],outVar.shape[3]] :
+				[(endIdx-startIdx)*chunkShape[0], outVar.shape[1],outVar.shape[2]]
+
+				typedArray = new Float32Array(arraySize);
 				let accum = 0;
 				let iter = 1;
 				const chunkIDs = []
-				for (let i= startIdx ; i < endIdx ; i++){
-					const cacheName = is4D ? `${idx4D}_${variable}_chunk_${i}` : `${variable}_chunk_${i}`
-					chunkIDs.push(i) //identify which chunks to use when recombining cache for timeseries
+				const rescaleIDs = [] // These are the downloaded chunks that need to be rescaled
+
+				for (let i= startIdx ; i < endIdx ; i++){ // Iterate through chunks we need
+					const cacheName = is4D ? `${initStore}_${idx4D}_${variable}_chunk_${i}` : `${initStore}_${variable}_chunk_${i}`
+					chunkIDs.push(i) // identify which chunks to use when recombining cache for getcurrentarray function
 					if (this.cache.has(cacheName)){
-						//Add a check and throw error here if user set compress but the local files are not compressed
 						chunk = cache.get(cacheName)
 						setStrides(chunk.stride)
-						typedArray.set(chunk.data,accum)
+						const chunkData = chunk.compressed ? DecompressArray(chunk.data) : chunk.data // Decompress if needed
+						typedArray.set(chunkData,accum)
 						setProgress(Math.round(iter/chunkCount*100))
 						accum += chunk.data.length;
 						iter ++;
 					}
 					else{
+						rescaleIDs.push(i)
 						chunk = await zarr.get(outVar, is4D ? [idx4D , zarr.slice(i*chunkShape[0], (i+1)*chunkShape[0]), null, null] : [zarr.slice(i*chunkShape[0], (i+1)*chunkShape[0]), null, null])
 						if (chunk.data instanceof BigInt64Array || chunk.data instanceof BigUint64Array) {
 							throw new Error("BigInt arrays are not supported for conversion to Float32Array.");
@@ -136,14 +181,58 @@ export class ZarrDataset{
 						}
 					}
 				}
+				const [minVal, maxVal] = ArrayMinMax(typedArray)
+				if (maxVal <= 65504 && minVal >= -65504){ // If values fit in Float16, use that to save memory
+					typedArray = new Float16Array(typedArray)
+				}
+				else{
+					scalingFactor = Math.ceil(Math.log10(maxVal/65504))
+					for (let i = 0; i < typedArray.length; i++) {
+						typedArray[i] /= Math.pow(10,scalingFactor);
+					}
+					typedArray = new Float16Array(typedArray)
+				}
+
+				for (const id of rescaleIDs){ // Rescale the chunks that were just downloaded. This isn't great logic as it assumes the scaling factor will be roughly the same as previous chunks. Will need to revisit
+					const cacheName = is4D ? `${initStore}_${idx4D}_${variable}_chunk_${id}` : `${initStore}_${variable}_chunk_${id}`
+					if (scalingFactor){
+						chunk = cache.get(cacheName)
+						const newData = new Float32Array(chunk.data.length)
+						for (let i = 0; i < chunk.data.length; i++) {
+							newData[i] = chunk.data[i]/Math.pow(10,scalingFactor);
+						}
+						const newTyped = new Float16Array(newData)
+						const newChunk = {
+							data: compress ? CompressArray(newTyped, 6) : newTyped,
+							shape: chunk.shape,
+							stride: chunk.stride,
+							scaling: scalingFactor,
+							compressed: compress
+						}
+						cache.set(cacheName,newChunk)
+					}
+					else{
+						chunk = cache.get(cacheName)
+						const newTyped = new Float16Array(chunk.data)
+						const newChunk = {
+							data: compress ? CompressArray(newTyped, 6) : newTyped,
+							shape: chunk.shape,
+							stride: chunk.stride,
+							scaling: null
+						}
+						cache.set(cacheName,newChunk)
+					}
+				}
 				setCurrentChunks(chunkIDs) // These are used for the Getcurrentarray 
 				setDownloading(false)
-				setProgress(0)
+				setProgress(0) // Reset progress for next load
 			}
+			console.log(typedArray)
 			return {
 				data: typedArray,
 				shape: shape,
-				dtype: outVar.dtype
+				dtype: outVar.dtype,
+				scalingFactor
 			}
 		} else {
 			throw new Error(`Unsupported data type: Only numeric arrays are supported. Got: ${outVar.dtype}`)
@@ -152,9 +241,12 @@ export class ZarrDataset{
 
 	async GetAttributes(variable:string){
 		const {cache} = useCacheStore.getState();
-		const cacheName = `${variable}_meta`
+		const {initStore} = useGlobalStore.getState();
+		const cacheName = `${initStore}_${variable}_meta`
 		if (cache.has(cacheName)){
-			return cache.get(cacheName)
+			const meta = cache.get(cacheName)
+			this.dimNames = meta._ARRAY_DIMENSIONS as string[]
+			return meta;
 		}
 		const group = await this.groupStore;
 		const outVar = await zarr.open(group.resolve(variable), {kind:"array"});
@@ -167,22 +259,24 @@ export class ZarrDataset{
 						.then((result) => zarr.get(result));
 					const dimMeta = await zarr.open(group.resolve(dim), {kind:"array"})
 						.then((result) => result.attrs)
-					cache.set(dim, dimArray.data);
-					cache.set(`${dim}_meta`, dimMeta)
+					cache.set(`${initStore}_${dim}`, dimArray.data);
+					cache.set(`${initStore}_${dim}_meta`, dimMeta)
 				}
 				dims.push(dim)
 		}
+		
 		this.dimNames = dims;
 		return meta;
 	}
 
 	GetDimArrays(){
+		const {initStore} = useGlobalStore.getState();
+		const {cache} = useCacheStore.getState();
 		const dimArr = [];
 		const dimMetas = []
-
 		for (const dim of this.dimNames){
-			dimArr.push(this.cache.get(dim));
-			dimMetas.push(this.cache.get(`${dim}_meta`))
+			dimArr.push(cache.get(`${initStore}_${dim}`));
+			dimMetas.push(cache.get(`${initStore}_${dim}_meta`))
 		}
 		return [dimArr,dimMetas, this.dimNames];
 	}

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -117,7 +117,6 @@ export class ZarrDataset{
 					}
 					else{
 						scalingFactor = Math.ceil(Math.log10(maxVal/65504))
-						console.log(scalingFactor)
 						for (let i = 0; i < typedArray.length; i++) {
 							typedArray[i] /= Math.pow(10,scalingFactor);
 						}

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -329,6 +329,7 @@ type AnalysisState = {
   kernelOperation: string;
   analysisArray: Uint8Array | Float32Array;
   reverseDirection: number;
+  analysisStore: string;
 
   setAnalysisMode: (analysisMode: boolean) => void;
   setAxis: (axis: number) => void;
@@ -342,6 +343,7 @@ type AnalysisState = {
   setKernelOperation: (kernelOperation: string) => void;
   setAnalysisArray: (analysisArray: Uint8Array | Float32Array) => void;
   setReverseDirection: (reverseDirection: number) => void;
+  setAnalysisStore: (analysisStore: string) => void;
 }
 
 export const useAnalysisStore = create<AnalysisState>((set) => ({
@@ -357,6 +359,7 @@ export const useAnalysisStore = create<AnalysisState>((set) => ({
   kernelOperation: 'Default',
   analysisArray: new Uint8Array(1),
   reverseDirection: 0,
+  analysisStore: ESDC,
 
   setAnalysisMode: (analysisMode) => set({ analysisMode }),
   setAxis: (axis) => set({ axis }),
@@ -369,7 +372,8 @@ export const useAnalysisStore = create<AnalysisState>((set) => ({
   setKernelDepth: (kernelDepth) => set({ kernelDepth }),
   setKernelOperation: (kernelOperation) => set({ kernelOperation}),
   setAnalysisArray: (analysisArray) => set({ analysisArray }),
-  setReverseDirection: (reverseDirection) => set( { reverseDirection} )
+  setReverseDirection: (reverseDirection) => set( { reverseDirection} ),
+  setAnalysisStore: (analysisStore) => set({ analysisStore })
 }));
 
 type ZarrState = {

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -252,19 +252,20 @@ export function GetTimeSeries(array : arrayInfo, TimeSeriesInfo:TimeSeriesInfo){
 		return ts;
 }
 
-export function GetCurrentArray(){
-  const { variable, is4D, idx4D }= useGlobalStore.getState()
+export function GetCurrentArray(overrideStore?:string){
+  const { variable, is4D, idx4D, initStore }= useGlobalStore.getState()
   const { arraySize, currentChunks }= useZarrStore.getState()
   const {cache} = useCacheStore.getState();
+  const store = overrideStore ? overrideStore : initStore
   
-  if (cache.has(is4D ? `${idx4D}_${variable}` : variable)){
-			return cache.get(variable).data
+  if (cache.has(is4D ? `${store}_${idx4D}_${variable}` : `${store}_${variable}`)){
+			return cache.get(is4D ? `${store}_${idx4D}_${variable}` : `${store}_${variable}`).data
   }
   else{
     const typedArray = new Float32Array(arraySize)
     let accum = 0;
 				for (const i of currentChunks){
-					const cacheName = is4D ? `${idx4D}_${variable}_chunk_${i}` : `${variable}_chunk_${i}`
+					const cacheName = is4D ? `${store}_${idx4D}_${variable}_chunk_${i}` : `${store}_${variable}_chunk_${i}`
 						//Add a check and throw error here if user set compress but the local files are not compressed
 						const chunk = cache.get(cacheName)
 						typedArray.set(chunk.data,accum)

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -1,6 +1,7 @@
 'use client';
 import * as THREE from 'three'
-import { useGlobalStore, usePlotStore } from './GlobalStates';
+import { useGlobalStore, usePlotStore, useZarrStore, useCacheStore } from './GlobalStates';
+
 
 export function parseTimeUnit(units: string | undefined): number {
     if (units === "Default"){
@@ -108,7 +109,7 @@ export function getUnitAxis(vec: THREE.Vector3) { //Takes the normal of a cube i
   return null;
 }
 
-export function ArrayMinMax(array:number[] | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike>){
+export function ArrayMinMax(array:number[] | Uint8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike>){
   let minVal = Infinity;
   let maxVal = -Infinity;
   for (let i = 0; i < array.length; i++){
@@ -249,4 +250,26 @@ export function GetTimeSeries(array : arrayInfo, TimeSeriesInfo:TimeSeriesInfo){
     ts.push(data[idx])
   }
 		return ts;
+}
+
+export function GetCurrentArray(){
+  const { variable, is4D, idx4D }= useGlobalStore.getState()
+  const { arraySize, currentChunks }= useZarrStore.getState()
+  const {cache} = useCacheStore.getState();
+  
+  if (cache.has(is4D ? `${idx4D}_${variable}` : variable)){
+			return cache.get(variable).data
+  }
+  else{
+    const typedArray = new Float32Array(arraySize)
+    let accum = 0;
+				for (const i of currentChunks){
+					const cacheName = is4D ? `${idx4D}_${variable}_chunk_${i}` : `${variable}_chunk_${i}`
+						//Add a check and throw error here if user set compress but the local files are not compressed
+						const chunk = cache.get(cacheName)
+						typedArray.set(chunk.data,accum)
+						accum += chunk.data.length;
+        }
+      return typedArray
+  }
 }


### PR DESCRIPTION
Beefy update with a slight sidetrack.

## Global Cache

Moved the cache to a global state. Also added the `initstore` as a prefix for the variables so the cache doesn't automatically wipe when changing stores. This will make it so you don't reload data again if you switch and then comeback.

## Removed dataArray

I had the data from a plot saved in a separate array for analysis and getting values from hovering. This was convenient for the chunked data since that needed to be recombined. But that's not good for memory. So I have created a function that grabs the array from cache and rebuilds from chunks if needed. 

## Float16

I've moved all of the cache and plotting data to Float16 where possible (I wish I could make pointcloud float16 but not possible). To account for boundary issues. I first load the data as float32 and see if it clips outside float16. If not, then its simply converted to float16. If it does clip, then I find out how many orders of magnitude greater it is than float16 max (65504) and then round that value up. I then divide the values by the scaling factor and store the scaling factor along with the cache. That way if data is loaded from cache it can safely go directly into float16 and we can communicate the scaling factor for propoer labels/coloring.

```ts
	const [minVal, maxVal] = ArrayMinMax(typedArray)
	if (maxVal <= 65504 && minVal >= -65504){ // If values fit in Float16, use that to save memory
		typedArray = new Float16Array(chunk.data)
	}
	else{
		scalingFactor = Math.ceil(Math.log10(maxVal/65504))
		for (let i = 0; i < typedArray.length; i++) {
			typedArray[i] /= Math.pow(10,scalingFactor);
		}
		typedArray = new Float16Array(typedArray)
	}
```

### Float16 chunking
This is a bit more difficult. Since we don't know for each chunk if they need to be converted until everything is downloaded. For now everything is downloaded in float32. We check if it clips outside. If it doesn't then we just convert the chunks into float16. Otherwise, we again do the same operation as above with orders of magnitude. 

However this is bad logic because it assumes the order of magnitude hasn't changed from the previous downloaded batch. 
So if you request a slice of data. And its outside float 16 and say by 100 times. Then you select a new slice and this new area contains values 1000x out of range, then they will be scaled to 1000 while the previous were only scaled to 100. But this is such a rare circumstance I will worry about it later

## gZip Compression
I implement compression of the arrays using gZip. Atm I've added a hardcoded compression level of 6. This can be chosen by the user in the future. But for now it's functional. I've also added a compression attribute to the cache object

<img width="234" height="266" alt="image" src="https://github.com/user-attachments/assets/d7013fdc-e1d0-4abf-8b4b-b7f5570c91a4" />

```ts
	const cacheChunk = {
		data: compress ? CompressArray(typedArray, 6) : typedArray,
		shape: chunk.shape,
		stride: chunk.stride,
		scaling: scalingFactor,
		compressed: compress
	}
```
When grabbing from cache it simply checks if it's compressed

```ts
if (cache.has(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)){
	const thisChunk = cache.get(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)
	if (thisChunk.compressed){
		thisChunk.data = DecompressArray(thisChunk.data)
	}
	return thisChunk;
}
```

## Fix plot Points
These were disabled as moving the lines to an Object broke the logic. So I've worked that logic into them. So now they work as expected
<img width="296" height="209" alt="image" src="https://github.com/user-attachments/assets/11fc69b5-dbdf-47fa-aa8c-f38346115fc4" />



