### PR TITLE
MemoryLRU

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lucide-react": "^0.503.0",
     "next": "15.4.3",
     "next-themes": "^0.4.6",
-    "quick-lru": "^7.0.1",
     "radix-ui": "latest",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -159,9 +159,9 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
         const shapeRatio = result.shape[1] / result.shape[2] * 2;
         setShape(new THREE.Vector3(2, shapeRatio, 2));
         setDataShape(result.shape)
-        setShowLoading(false)
         setShow(true)
         setPlotOn(true)
+        setShowLoading(false)
       })
       }catch{
         setShowLoading(false);

--- a/src/components/ui/MainPanel/MetaDataInfo.tsx
+++ b/src/components/ui/MainPanel/MetaDataInfo.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "../input"
 import { BsFillQuestionCircleFill } from "react-icons/bs";
+
 import {
   Tooltip,
   TooltipContent,
@@ -39,7 +40,9 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
     setVariable: state.setVariable,
   })))
   const setAnalysisMode = useAnalysisStore.getState().setAnalysisMode
-
+  const {maxSize, setMaxSize} = useCacheStore.getState()
+  const [cacheSize, setCacheSize] = useState(maxSize)
+  
   const { slice, reFetch, compress, setSlice, setReFetch, setCompress } = useZarrStore(useShallow(state => ({
     reFetch: state.reFetch,
     slice: state.slice,
@@ -84,7 +87,6 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
     const this4D = meta.shape.length == 4;
     setIs4D(this4D);
   })
-
   useEffect(()=>{
     setSlice([0,null]);
     setCompress(false)
@@ -106,7 +108,8 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
   },[meta, maxTextureSize])
 
   return (
-    <>
+      // Don't put any more work in the landing page version. Since it won't be visible in the future
+    <> 
       {noCard ? (
         <div className="space-y-6">
           {/* Header Section */}
@@ -332,7 +335,42 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
                   </>
                 )}
                 <b>Total Size: </b>{formatBytes(currentSize)}<br />
-                {currentSize < 1e8 && (
+                {currentSize > maxSize && (
+                  <>
+                  <div className={`flex items-center gap-2 p-2 ${currentSize > cacheSize ? "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800" : "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800"} rounded-md border`}>
+                        <div className={`w-2 h-2 ${currentSize > cacheSize ? "bg-red-500" : "bg-emerald-500"} rounded-full`}></div>
+                        <span className={`text-xs font-medium ${currentSize > cacheSize ? "text-red-800 dark:text-red-200" : "text-emerald-800 dark:text-emerald-200"}`}>
+                          {currentSize > cacheSize ? "Selection won't fit in Cache" : "Data Will Fit"}
+                        </span>                  
+                        </div>
+                        <div className="">
+                          Decrease selection or Increase cache size <br/>
+                          <div className="flex justify-center">
+                            <p>Expand Cache: <b>{cacheSize/(1024*1024)}MB</b>
+                              <Tooltip>
+                                <TooltipTrigger>
+                                <BsFillQuestionCircleFill/>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Increasing this too far can cause crashes. Mobile users beware 
+                                </TooltipContent>
+                              </Tooltip>
+                            </p>
+                          </div>
+                          
+                          <SliderThumbs 
+                            id="newCache-size"
+                            min={0}
+                            max={1000}
+                            step={10}
+                            onValueChange={e=>setCacheSize(maxSize+e[0]*(1024*1024))}
+                        />
+                  </div>
+                  </>
+                )
+
+                }
+                {/* {currentSize < 1e8 && (
                   <>
                   <div className="flex items-center gap-2 p-2 bg-emerald-50 dark:bg-emerald-950/30 rounded-md border border-emerald-200 dark:border-emerald-800">
                         <div className="w-2 h-2 bg-emerald-500 rounded-full"/>
@@ -357,8 +395,8 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
                       Data will not fit in memory
                     </span>
                   </div>
-                )}
-                <div className="grid grid-cols-[auto_40%] items-center gap-2">
+                )} */}
+                <div className="grid grid-cols-[auto_40%] items-center gap-2 mt-2">
                   <div>
                   <label htmlFor="compress-data">Compress Data </label>
                   <Tooltip>
@@ -393,6 +431,7 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
                 setReFetch(!reFetch)
               }
               else{
+                setMaxSize(cacheSize)
                 setVariable(meta.name)
                 setReFetch(!reFetch)
               }

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -123,7 +123,7 @@ export class ZarrDataset{
 						typedArray = new Float16Array(typedArray)
 					}
 					const cacheChunk = {
-						data: compress ? CompressArray(typedArray, 6) : typedArray,
+						data: compress ? CompressArray(typedArray, 7) : typedArray,
 						shape: chunk.shape,
 						stride: chunk.stride,
 						scaling: scalingFactor,
@@ -202,7 +202,7 @@ export class ZarrDataset{
 						}
 						const newTyped = new Float16Array(newData)
 						const newChunk = {
-							data: compress ? CompressArray(newTyped, 6) : newTyped,
+							data: compress ? CompressArray(newTyped, 7) : newTyped,
 							shape: chunk.shape,
 							stride: chunk.stride,
 							scaling: scalingFactor,
@@ -214,7 +214,7 @@ export class ZarrDataset{
 						chunk = cache.get(cacheName)
 						const newTyped = new Float16Array(chunk.data)
 						const newChunk = {
-							data: compress ? CompressArray(newTyped, 6) : newTyped,
+							data: compress ? CompressArray(newTyped, 7) : newTyped,
 							shape: chunk.shape,
 							stride: chunk.stride,
 							scaling: null
@@ -226,7 +226,6 @@ export class ZarrDataset{
 				setDownloading(false)
 				setProgress(0) // Reset progress for next load
 			}
-			console.log(cache)
 			return {
 				data: typedArray,
 				shape: shape,

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -1,6 +1,6 @@
 import * as zarr from "zarrita";
 import * as THREE from 'three';
-import QuickLRU from 'quick-lru';
+import MemoryLRU from "@/utils/MemoryLRU";
 import { parseUVCoords, ArrayMinMax } from "@/utils/HelperFuncs";
 import { GetSize } from "./GetMetadata";
 import { useGlobalStore, useZarrStore, useErrorStore, useCacheStore } from "@/utils/GlobalStates";
@@ -59,7 +59,7 @@ interface TimeSeriesInfo{
 export class ZarrDataset{
 	private groupStore: Promise<zarr.Group<zarr.FetchStore | zarr.Listable<zarr.FetchStore>>>;
 	private variable: string;
-	private cache: QuickLRU<string,any>;
+	private cache: MemoryLRU<string,any>;
 	private dimNames: string[];
 	private chunkIDs: number[];
 
@@ -226,6 +226,7 @@ export class ZarrDataset{
 				setDownloading(false)
 				setProgress(0) // Reset progress for next load
 			}
+			console.log(cache)
 			return {
 				data: typedArray,
 				shape: shape,

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { GetColorMapTexture } from "@/components/textures";
 import { GetStore } from "@/components/zarr/ZarrLoaderLRU";
 import QuickLRU from 'quick-lru';
+import MemoryLRU from "./MemoryLRU";
 
 
 const ESDC = 'https://s3.bgc-jena.mpg.de:9000/esdl-esdc-v3.0.2/esdc-16d-2.5deg-46x72x1440-3.0.2.zarr'
@@ -409,13 +410,13 @@ export const useZarrStore = create<ZarrState>((set, get) => ({
 }))
 
 type CacheState = {
-  cache: QuickLRU<string, any>;
+  cache: MemoryLRU<string, any>;
   clearCache: () => void;
 }
 
 
 export const useCacheStore = create<CacheState>((set, get) => ({
-  cache: new QuickLRU({ maxSize: 2000 }),
+  cache: new MemoryLRU({ maxSize: 200 * 1024 * 1024 }), // 200 MB
   // Cache operations
   clearCache: () => {
     const { cache } = get()

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -2,7 +2,6 @@ import { create } from "zustand";
 import * as THREE from 'three';
 import { GetColorMapTexture } from "@/components/textures";
 import { GetStore } from "@/components/zarr/ZarrLoaderLRU";
-import QuickLRU from 'quick-lru';
 import MemoryLRU from "./MemoryLRU";
 
 

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -410,16 +410,24 @@ export const useZarrStore = create<ZarrState>((set, get) => ({
 
 type CacheState = {
   cache: MemoryLRU<string, any>;
+  maxSize: number;
   clearCache: () => void;
+  setMaxSize: (maxSize: number) => void;
 }
 
 
 export const useCacheStore = create<CacheState>((set, get) => ({
   cache: new MemoryLRU({ maxSize: 200 * 1024 * 1024 }), // 200 MB
+  maxSize: 200 * 1024 * 1024,
   // Cache operations
   clearCache: () => {
     const { cache } = get()
     cache.clear()
+  },
+  setMaxSize: (maxSize) => {
+    const { cache } = get()
+    cache.resize(maxSize)
+    set({ maxSize })
   }
 }))
 

--- a/src/utils/MemoryLRU.ts
+++ b/src/utils/MemoryLRU.ts
@@ -32,7 +32,7 @@ export class MemoryLRU<K, V> {
     private cache = new Map<K, V>();
     private order: K[] = [];
     private totalSize = 0;
-    private readonly maxSize: number;
+    private maxSize: number;
     private readonly sizeCalculator: SizeCalculator<V>;
     private sizes = new Map<K, number>();
 
@@ -66,6 +66,23 @@ export class MemoryLRU<K, V> {
         this.order.push(key);
 
         // Evict least recently used until under maxSize
+        while (this.totalSize > this.maxSize && this.order.length > 0) {
+            const oldestKey = this.order[0];
+            this.order.shift();
+            const oldestSize = this.sizes.get(oldestKey) ?? 0;
+            this.cache.delete(oldestKey);
+            this.sizes.delete(oldestKey);
+            this.totalSize -= oldestSize;
+        }
+    }
+
+    resize(newSize: number): void {
+        if (newSize < 0) {
+            throw new Error("Cache size cannot be negative.");
+        }
+        this.maxSize = newSize;
+
+        // Evict least recently used until under new maxSize
         while (this.totalSize > this.maxSize && this.order.length > 0) {
             const oldestKey = this.order[0];
             this.order.shift();

--- a/src/utils/MemoryLRU.ts
+++ b/src/utils/MemoryLRU.ts
@@ -1,0 +1,120 @@
+// Made by Gemini
+
+type SizeCalculator<T> = (value: T) => number;
+
+function defaultSizeCalculator<T>(value: T): number {
+    if (value instanceof ArrayBuffer) {
+        return value.byteLength;
+    }
+    if (ArrayBuffer.isView(value)) {
+        return value.byteLength;
+    }
+    if (typeof value === 'object' && value !== null && 'data' in value) {
+        const data = (value as any).data;
+        if (ArrayBuffer.isView(data)) {
+            return data.byteLength;
+        }
+    }
+    // Fallback: use JSON.stringify
+    try {
+        return JSON.stringify(value).length;
+    } catch {
+        return 0;
+    }
+}
+
+interface MemoryLRUOptions<T> {
+    maxSize: number;
+    sizeCalculator?: SizeCalculator<T>;
+}
+
+export class MemoryLRU<K, V> {
+    private cache = new Map<K, V>();
+    private order: K[] = [];
+    private totalSize = 0;
+    private readonly maxSize: number;
+    private readonly sizeCalculator: SizeCalculator<V>;
+    private sizes = new Map<K, number>();
+
+    constructor(options: MemoryLRUOptions<V>) {
+        this.maxSize = options.maxSize;
+        this.sizeCalculator = options.sizeCalculator ?? defaultSizeCalculator;
+    }
+
+    get(key: K): V | undefined {
+        if (!this.cache.has(key)) return undefined;
+        // Move key to end (most recently used)
+        this.order = this.order.filter(k => k !== key);
+        this.order.push(key);
+        return this.cache.get(key);
+    }
+
+    set(key: K, value: V): void {
+        const valueSize = this.sizeCalculator(value);
+
+        if (this.cache.has(key)) {
+            // Remove old size
+            this.totalSize -= this.sizes.get(key) ?? 0;
+        }
+
+        this.cache.set(key, value);
+        this.sizes.set(key, valueSize);
+        this.totalSize += valueSize;
+
+        // Move key to end (most recently used)
+        this.order = this.order.filter(k => k !== key);
+        this.order.push(key);
+
+        // Evict least recently used until under maxSize
+        while (this.totalSize > this.maxSize && this.order.length > 0) {
+            const oldestKey = this.order[0];
+            this.order.shift();
+            const oldestSize = this.sizes.get(oldestKey) ?? 0;
+            this.cache.delete(oldestKey);
+            this.sizes.delete(oldestKey);
+            this.totalSize -= oldestSize;
+        }
+    }
+
+    has(key: K): boolean {
+        return this.cache.has(key);
+    }
+
+    delete(key: K): boolean {
+        if (!this.cache.has(key)) return false;
+        this.totalSize -= this.sizes.get(key) ?? 0;
+        this.cache.delete(key);
+        this.sizes.delete(key);
+        this.order = this.order.filter(k => k !== key);
+        return true;
+    }
+
+    clear(): void {
+        this.cache.clear();
+        this.sizes.clear();
+        this.order = [];
+        this.totalSize = 0;
+    }
+
+    get size(): number {
+        return this.cache.size;
+    }
+
+    get volume(): number {
+        return this.totalSize;
+    }
+
+    keys(): IterableIterator<K> {
+        return this.cache.keys();
+    }
+
+    values(): IterableIterator<V> {
+        return this.cache.values();
+    }
+
+    entries(): IterableIterator<[K, V]> {
+        return this.cache.entries();
+    }
+}
+
+export default MemoryLRU;


### PR DESCRIPTION
After realizing `Quick-LRU` is kinda useless for our usecase. I had Gemini write a quick-lru clone but using a maximum size.

It's funny, now that it actually works. My current method for dealing with chunked data would fail because they are originally loaded as float32 to check if they are out of range, and then they are loaded again afterwards and converted to float16. However, they are now deleted if it's a lot of data. This is a new problem now.

<img width="764" height="342" alt="image" src="https://github.com/user-attachments/assets/97e81625-0583-427f-8874-b8934aacd293" />

You can see here the nextChunk would exceed the 200MB limit. I don't know if I want to mess with logic. Will probably add a check on the data select screen that the selected data is greater than current cachesize. 

Edit:

Alright. Changed the logic so that users are warned if the size is larger than allocated cache. They can expand the cache if needed

<img width="241" height="429" alt="image" src="https://github.com/user-attachments/assets/279b9fa0-e4a9-42dc-9d31-197828126d28" />

<img width="399" height="459" alt="image" src="https://github.com/user-attachments/assets/57e7a8f7-3b37-4888-a138-25d57195cafb" />

This is still not perfect as after converting to Float16 and compressing this selection from the dataset, the final size in the cache was ~60MB vs the 400MB. 
This crazy compression is cause seasfire has a crazy amount of repeating values though. 
