### PR TITLE
Straight to Float16

### DIFF
--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -121,7 +121,6 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
             }     
         }
     }, [colors]);
-
     return (
         <>
         <div className='colorbar' >
@@ -131,8 +130,9 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
                     left: `0%`,
                     top:'100%',
                     position:'absolute',
-                    width:'45px',
+                    width:`${String(newMin).length*9}px`,
                     transform:'translateX(-50%)',
+                    textAlign:'right'
                 }}
                 value={newMin}
                 onChange={e=>setNewMin(parseFloat(e.target.value))}
@@ -158,7 +158,7 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
                     left: `100%`,
                     top:'100%',
                     position:'absolute',
-                    width:'45px',
+                    width:`${String(newMax).length*9}px`,
                     transform:'translateX(-50%)',
                 }}
                 value={newMax}

--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -130,9 +130,10 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
                     left: `0%`,
                     top:'100%',
                     position:'absolute',
-                    width:`${String(newMin).length*9}px`,
+                    width:`${String(newMin).length*8}px`,
                     transform:'translateX(-50%)',
-                    textAlign:'right'
+                    textAlign:'right',
+                    minWidth:'25px'
                 }}
                 value={newMin}
                 onChange={e=>setNewMin(parseFloat(e.target.value))}
@@ -158,8 +159,10 @@ const Colorbar = ({units, valueScales} : {units: string, valueScales: {maxVal: n
                     left: `100%`,
                     top:'100%',
                     position:'absolute',
-                    width:`${String(newMax).length*9}px`,
+                    width:`${String(newMax).length*8+1}px`,
                     transform:'translateX(-50%)',
+                    textAlign:'right',
+                    minWidth:'25px'
                 }}
                 value={newMax}
                 onChange={e=>setNewMax(parseFloat(e.target.value))}

--- a/src/components/ui/MainPanel/MetaDataInfo.tsx
+++ b/src/components/ui/MainPanel/MetaDataInfo.tsx
@@ -83,6 +83,8 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
     }else{return 0;}
   }, [meta, slice])
 
+  const smallCache = useMemo(()=>currentSize/2 > cacheSize, [currentSize, cacheSize])
+
   useEffect(()=>{
     const this4D = meta.shape.length == 4;
     setIs4D(this4D);
@@ -337,10 +339,10 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
                 <b>Total Size: </b>{formatBytes(currentSize)}<br />
                 {currentSize > maxSize && (
                   <>
-                  <div className={`flex items-center gap-2 p-2 ${currentSize > cacheSize ? "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800" : "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800"} rounded-md border`}>
-                        <div className={`w-2 h-2 ${currentSize > cacheSize ? "bg-red-500" : "bg-emerald-500"} rounded-full`}></div>
-                        <span className={`text-xs font-medium ${currentSize > cacheSize ? "text-red-800 dark:text-red-200" : "text-emerald-800 dark:text-emerald-200"}`}>
-                          {currentSize > cacheSize ? "Selection won't fit in Cache" : "Data Will Fit"}
+                  <div className={`flex items-center gap-2 p-2 ${smallCache ? "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800" : "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800"} rounded-md border`}>
+                        <div className={`w-2 h-2 ${smallCache ? "bg-red-500" : "bg-emerald-500"} rounded-full`}></div>
+                        <span className={`text-xs font-medium ${smallCache ? "text-red-800 dark:text-red-200" : "text-emerald-800 dark:text-emerald-200"}`}>
+                          {smallCache ? "Selection won't fit in Cache" : "Data Will Fit"}
                         </span>                  
                         </div>
                         <div className="">
@@ -425,7 +427,7 @@ const MetaDataInfo = ({ meta, setShowMeta, noCard = false }: { meta: any, setSho
             size="sm"
             
             className="cursor-pointer hover:scale-[1.05]"
-            disabled={((is4D && idx4D == null) || tooBig)}
+            disabled={((is4D && idx4D == null) || tooBig || smallCache)}
             onClick={() => {
               if (variable == meta.name){
                 setReFetch(!reFetch)

--- a/src/components/ui/MainPanel/PlayButton.tsx
+++ b/src/components/ui/MainPanel/PlayButton.tsx
@@ -28,7 +28,6 @@ const PlayInterFace = ({visible}:{visible : boolean}) =>{
         dimNames: state.dimNames,
         dimUnits: state.dimUnits 
     })))
-    // console.log(dimArrays[0].slice(0,5), dimArrays[1].slice(0,5))
     const timeLength = useMemo(()=>dimArrays[0].length,[dimArrays])
     const [timeStep, setTimeStep] = useState(0)
     


### PR DESCRIPTION
I had an epiphany this morning while trying to figure out how to avoid float32 data.

Now instead of creating the float32array and looping through it at the end to see if it clips float16 range; we start with float16.
We then check if the values in a chunk exceed the range of float16.

If it doesn't (which in most cases it doesn't) then we just convert it into float16 and add it to the main array.
However, if it does exceed the threshold then we just need to scale the currently existing float16 array to match the new scalingFactor if it's larger than the one used so far. We then scale the chunks based on the current greatest scalingFactor.

```ts
let newScalingFactor:number | null;
let chunkF16: Float16Array;
[chunkF16, newScalingFactor] = ToFloat16(chunk.data as Float32Array, scalingFactor)
if (newScalingFactor != null && newScalingFactor != scalingFactor){ // If the scalingFactor has changed, need to rescale main array
  if (scalingFactor == null || newScalingFactor > scalingFactor){ 
	  const thisScaling = scalingFactor ? newScalingFactor - scalingFactor : newScalingFactor
	  RescaleArray(typedArray, thisScaling)
	  scalingFactor = newScalingFactor
	  for (const id of rescaleIDs){ // Set new scalingFactor on the chunks
		  const tempName = replaceChunkNumber(cacheName, id)
		  const tempChunk = cache.get(tempName)
		  tempChunk.scaling = scalingFactor
		  cache.set(tempName, tempChunk)
	  }
  }
}
```

### Colorbar Nums

I also updated the input fields for the colorbar to scale with the length of the number inside of them.		

<img width="578" height="101" alt="image" src="https://github.com/user-attachments/assets/58a64ae7-8e5f-4176-a3fd-c9da9aff2ee1" />
