### PR TITLE
Bug Squashing

### DIFF
--- a/node_modules/@zarrita/storage/dist/src/fetch.js
+++ b/node_modules/@zarrita/storage/dist/src/fetch.js
@@ -1,0 +1,85 @@
+import { fetch_range, merge_init } from "./util.js";
+
+function resolve(root, path) {
+    const base = typeof root === "string" ? new URL(root) : root;
+    if (!base.pathname.endsWith("/")) {
+        // ensure trailing slash so that base is resolved as _directory_
+        base.pathname += "/";
+    }
+    const resolved = new URL(path.slice(1), base);
+    // copy search params to new URL
+    resolved.search = base.search;
+    return resolved;
+}
+async function handle_response(response) {
+    if (response.status === 404) {
+        return undefined;
+    }
+    if (response.status === 200 || response.status === 206) {
+        return new Uint8Array(await response.arrayBuffer());
+    }
+    throw new Error(`Unexpected response status ${response.status} ${response.statusText}`);
+}
+async function fetch_suffix(url, suffix_length, init, use_suffix_request) {
+    if (use_suffix_request) {
+        return fetch(url, {
+            ...init,
+            headers: { ...init.headers, Range: `bytes=-${suffix_length}` },
+        });
+    }
+    let response = await fetch(url, { ...init, method: "HEAD" });
+    if (!response.ok) {
+        // will be picked up by handle_response
+        return response;
+    }
+    let content_length = response.headers.get("Content-Length");
+    let length = Number(content_length);
+    return fetch_range(url, length - suffix_length, length, init);
+}
+/**
+ * Readonly store based in the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+ * Must polyfill `fetch` for use in Node.js.
+ *
+ * ```typescript
+ * import * as zarr from "zarrita";
+ * const store = new FetchStore("http://localhost:8080/data.zarr");
+ * const arr = await zarr.get(store, { kind: "array" });
+ * ```
+ */
+class FetchStore {
+    url;
+    #overrides;
+    #use_suffix_request;
+    constructor(url, options = {}) {
+        this.url = url;
+        this.#overrides = options.overrides ?? {};
+        this.#use_suffix_request = options.useSuffixRequest ?? false;
+    }
+    #merge_init(overrides) {
+        return merge_init(this.#overrides, overrides);
+    }
+    async get(key, options = {}) {
+        let href = resolve(this.url, key).href;
+        try{
+            let response = await fetch(href, this.#merge_init(options));
+            return handle_response(response);
+        } catch {
+            return null;
+        }
+    }
+    
+    async getRange(key, range, options = {}) {
+        let url = resolve(this.url, key);
+        let init = this.#merge_init(options);
+        let response;
+        if ("suffixLength" in range) {
+            response = await fetch_suffix(url, range.suffixLength, init, this.#use_suffix_request);
+        }
+        else {
+            response = await fetch_range(url, range.offset, range.length, init);
+        }
+        return handle_response(response);
+    }
+}
+export default FetchStore;
+//# sourceMappingURL=fetch.js.map

--- a/src/components/LandingHome.tsx
+++ b/src/components/LandingHome.tsx
@@ -46,7 +46,7 @@ export function LandingHome() {
   useEffect(() => {
     let isMounted = true;
 
-    GetTitleDescription(currentStore, initStore).then((result) => {
+    GetTitleDescription(currentStore).then((result) => {
       if (isMounted) setTitleDescription(result);
     });
 
@@ -57,7 +57,7 @@ export function LandingHome() {
     variables.then(e => setVariables(e))
 
     return () => { isMounted = false; };
-  }, [currentStore, initStore, setZMeta, setVariables, setTitleDescription])
+  }, [currentStore, setZMeta, setVariables, setTitleDescription])
 
   useEffect(() => { // Set maxtexture size to warn users if custom data is too big
     const renderer = new THREE.WebGLRenderer();

--- a/src/components/LandingHome.tsx
+++ b/src/components/LandingHome.tsx
@@ -37,6 +37,9 @@ export function LandingHome() {
   })))
 
   useEffect(() => { // Update store if URL changes
+    if (initStore.startsWith('local')){ // Don't fetch store if local 
+      return
+    }
     const newStore = GetStore(initStore)
     setCurrentStore(newStore)
   }, [initStore, setCurrentStore])

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -1,7 +1,7 @@
 "use cleint";
 
 import { useAnalysisStore, useGlobalStore, useImageExportStore, usePlotStore } from '@/utils/GlobalStates'
-import React, {useState, useMemo, useRef, useEffect} from 'react'
+import React, {useState, useMemo} from 'react'
 import { useShallow } from 'zustand/shallow'
 import { Text } from '@react-three/drei'
 import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -1,7 +1,7 @@
 "use cleint";
 
 import { useAnalysisStore, useGlobalStore, useImageExportStore, usePlotStore } from '@/utils/GlobalStates'
-import React, {useState, useMemo} from 'react'
+import React, {useState, useMemo, useRef, useEffect} from 'react'
 import { useShallow } from 'zustand/shallow'
 import { Text } from '@react-three/drei'
 import { LineSegmentsGeometry } from 'three/addons/lines/LineSegmentsGeometry.js';
@@ -301,17 +301,18 @@ const FlatAxis = () =>{
     analysisMode: state.analysisMode,
     axis: state.axis
   })))
+  const originallyFlat = dimArrays.length == 2;
 
   const dimLengths = useMemo(()=>{
-    if (analysisMode){
+    if (analysisMode && !originallyFlat){
       return dimArrays.filter((_val, idx )=> idx != axis)
       .map((val) => val.length )
     }else{
       return dimArrays.map((val) => val.length )
     }
   },[axis, dimArrays, analysisMode])
-
-  const swap = useMemo(() => (analysisMode && axis == 2),[axis, analysisMode]) // This is for the horrible case when users plot along the horizontal dimension i.e; Longitude. Everything swaps
+  
+  const swap = useMemo(() => (analysisMode && axis == 2 && !originallyFlat),[axis, analysisMode]) // This is for the horrible case when users plot along the horizontal dimension i.e; Longitude. Everything swaps
 
   const widthIdx = swap ? dimLengths.length-2 : dimLengths.length-1
   const heightIdx = swap ? dimLengths.length-1 : dimLengths.length-2
@@ -320,20 +321,20 @@ const FlatAxis = () =>{
   const [yResolution, setYResolution] = useState<number>(7)
 
   const { axisArrays, axisUnits, axisNames } = useMemo(() => {
-  if (analysisMode) {
-    return {
-      axisArrays: dimArrays.filter((_val, idx) => idx != axis),
-      axisUnits: dimUnits.filter((_val, idx) => idx != axis),
-      axisNames: dimNames.filter((_val, idx) => idx != axis),
-    };
-  } else {
-    return {
-      axisArrays: dimArrays,
-      axisUnits: dimUnits,
-      axisNames: dimNames,
-    };
-  }
-}, [analysisMode, dimArrays, dimUnits, dimNames]);
+    if (analysisMode && !originallyFlat) {
+      return {
+        axisArrays: dimArrays.filter((_val, idx) => idx != axis),
+        axisUnits: dimUnits.filter((_val, idx) => idx != axis),
+        axisNames: dimNames.filter((_val, idx) => idx != axis),
+      };
+    } else {
+      return {
+        axisArrays: dimArrays,
+        axisUnits: dimUnits,
+        axisNames: dimNames,
+      };
+    }
+  }, [analysisMode, dimArrays, dimUnits, dimNames]);
 
 
   const shapeRatio = useMemo(()=>{
@@ -353,7 +354,6 @@ const FlatAxis = () =>{
 
   const lineMat = useMemo(()=>new LineMaterial({color: colorHex ? colorHex : 0, linewidth: 2.0}),[colorHex])
   const tickLength = 0.05;
-  
   const xLine = useMemo(()=> {
     const geom = new LineSegmentsGeometry().setPositions( [(-1/(swap ? shapeRatio : 1)-tickLength/2), 0, 0, (1/((swap ? shapeRatio : 1))+tickLength/2), 0, 0]);
     return new LineSegments2(geom, lineMat)},[lineMat, swap, shapeRatio])

--- a/src/components/plots/CountryBorders.tsx
+++ b/src/components/plots/CountryBorders.tsx
@@ -177,11 +177,15 @@ const CountryBorders = () => {
     const [borders, setBorders] = useState<any>(null)
     const [swapSides, setSwapSides] = useState<boolean>(false)
 
-    const {zRange, plotType, showBorders} = usePlotStore(useShallow(state => ({
+    const {dataShape, is4D} = useGlobalStore(useShallow(state => ({
+        dataShape: state.dataShape,
+        is4D: state.is4D
+    })))
+    const {zRange, plotType, showBorders, timeScale} = usePlotStore(useShallow(state => ({
         zRange: state.zRange,
         plotType: state.plotType,
-        showBorders: state.showBorders
-
+        showBorders: state.showBorders,
+        timeScale: state.timeScale
     })))
     const {analysisMode, axis} = useAnalysisStore(useShallow(state => ({
         analysisMode: state.analysisMode,
@@ -220,8 +224,10 @@ const CountryBorders = () => {
         .then(data => setBorders(data.features));
     },[])
 
+    const isPC = plotType == 'point-cloud'
+    const depthScale = dataShape[0]/dataShape[2]*timeScale
     return(
-        <group visible={showBorders && plotType != 'point-cloud' && !(analysisMode && axis != 0)} position={spherize ? [0,0,0] : [0, 0, swapSides ? zRange[0] : zRange[1]]}>
+        <group visible={showBorders && !(analysisMode && axis != 0)} position={spherize ? [0,0,0] : [0, 0, swapSides ? zRange[0]*(isPC ? depthScale : 1) : zRange[1]*(isPC ? depthScale : 1)]}>
         {coastLines && <Borders features={coastLines} />}
         {borders && <Borders features={borders} />}
         </group>

--- a/src/components/plots/CountryBorders.tsx
+++ b/src/components/plots/CountryBorders.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, {useEffect, useState, useMemo} from 'react'
-import { useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
+import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
 import * as THREE from 'three'
 import { useShallow } from 'zustand/shallow';
 import { useFrame } from '@react-three/fiber';
@@ -183,6 +183,10 @@ const CountryBorders = () => {
         showBorders: state.showBorders
 
     })))
+    const {analysisMode, axis} = useAnalysisStore(useShallow(state => ({
+        analysisMode: state.analysisMode,
+        axis: state.axis
+    })))
 
     const [spherize, setSpherize] = useState<boolean>(false)
 
@@ -217,7 +221,7 @@ const CountryBorders = () => {
     },[])
 
     return(
-        <group visible={showBorders && plotType != 'point-cloud'} position={spherize ? [0,0,0] : [0, 0, swapSides ? zRange[0] : zRange[1]]}>
+        <group visible={showBorders && plotType != 'point-cloud' && !(analysisMode && axis != 0)} position={spherize ? [0,0,0] : [0, 0, swapSides ? zRange[0] : zRange[1]]}>
         {coastLines && <Borders features={coastLines} />}
         {borders && <Borders features={borders} />}
         </group>

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -45,7 +45,7 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
       analysisMode: state.analysisMode,
       analysisArray: state.analysisArray
     })))
-
+    
     const dataSource = texture.source.data
     const shapeRatio = useMemo(()=> dataSource.height/dataSource.width, [dataSource])
     const geometry = useMemo(()=>new THREE.PlaneGeometry(2,2*shapeRatio),[shapeRatio])

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -53,7 +53,7 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
     const lastUV = useRef<THREE.Vector2>(new THREE.Vector2(0,0))
     const rotateMap = analysisMode && axis == 2;
     const sampleArray = useMemo(()=> analysisMode ? analysisArray : GetCurrentArray(),[analysisMode, analysisArray])
-    const analysisDims = useMemo(()=>dimArrays.filter((_e,idx)=> idx != axis),[dimArrays,axis])
+    const analysisDims = useMemo(()=>dimArrays.length > 2 ? dimArrays.filter((_e,idx)=> idx != axis) : dimArrays,[dimArrays,axis])
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms:{
@@ -73,7 +73,7 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
     useEffect(()=>{
         geometry.dispose()
     },[geometry])
-
+    console.log(analysisDims)
     const eventRef = useRef<ThreeEvent<PointerEvent> | null>(null);
     const handleMove = useCallback((e: ThreeEvent<PointerEvent>) => {
       if (infoRef.current && e.uv) {
@@ -81,8 +81,8 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
         setLoc([e.clientX, e.clientY]);
         lastUV.current = e.uv;
         const { x, y } = e.uv;
-        const xSize = isFlat ? analysisMode ? analysisDims[1].length : dimArrays[1].length : dimArrays[2].length;
-        const ySize = isFlat ? analysisMode ? analysisDims[0].length : dimArrays[0].length : dimArrays[1].length;
+        const xSize = isFlat ? (analysisMode ? analysisDims[1].length : dimArrays[1].length) : dimArrays[2].length;
+        const ySize = isFlat ? (analysisMode ? analysisDims[0].length : dimArrays[0].length) : dimArrays[1].length;
         const xIdx = Math.round(x*xSize-.5)
         const yIdx = Math.round(y*ySize-.5)
         let dataIdx = xSize * yIdx + xIdx;

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -73,7 +73,6 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
     useEffect(()=>{
         geometry.dispose()
     },[geometry])
-    console.log(analysisDims)
     const eventRef = useRef<ThreeEvent<PointerEvent> | null>(null);
     const handleMove = useCallback((e: ThreeEvent<PointerEvent>) => {
       if (infoRef.current && e.uv) {

--- a/src/components/ui/ErrorList.ts
+++ b/src/components/ui/ErrorList.ts
@@ -15,4 +15,8 @@ export const ErrorList = {
         title: "Failed to Fetch Zarr Store",    
         description: "There was an error fetching the Zarr store. Please check the store path and your network connection."
     },
+    dataType: {
+        title: "Unsupported Data Type",    
+        description: "The data type of the array is not supported. Please use arrays with Float[16|32|64] or (u)Int[8|16|32] data types."  
+    }
 }

--- a/src/components/ui/ExportImageSettings.tsx
+++ b/src/components/ui/ExportImageSettings.tsx
@@ -30,6 +30,7 @@ const ExportImageSettings = () => {
         customRes,
         includeAxis,
         ExportImg, 
+        EnableExport,
         setIncludeBackground, 
         setIncludeColorbar, 
         setDoubleSize,
@@ -52,6 +53,7 @@ const ExportImageSettings = () => {
           includeAxis: state.includeAxis,
 
           ExportImg: state.ExportImg,
+          EnableExport: state.EnableExport,
           setIncludeBackground: state.setIncludeBackground,
           setIncludeColorbar: state.setIncludeColorbar,
           setDoubleSize: state.setDoubleSize,
@@ -84,6 +86,7 @@ const ExportImageSettings = () => {
                     variant="ghost"
                     size="icon"
                     className="cursor-pointer"
+                    onClick={e=>EnableExport()} // This just allows exporting to prevent the export module from firing when its loaded
                 >
                     <IoImage className="size-8"/>
                 </Button>

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, {useState, useEffect} from 'react'
-import { useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
+import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates';
 import '../css/MainPanel.css'
 import { useShallow } from 'zustand/shallow';
 import { Slider as UISlider } from '@/components/ui/slider';
@@ -281,6 +281,10 @@ const GlobalOptions = () =>{
     setNanColor: state.setNanColor,
     setNanTransparency: state.setNanTransparency
   })))
+  const {analysisMode, axis} = useAnalysisStore(useShallow(state =>({
+    analysisMode: state.analysisMode,
+    axis: state.axis
+  })))
 
   return (
     <div className='grid gap-y-[5px] items-center w-50 text-center'>
@@ -299,15 +303,21 @@ const GlobalOptions = () =>{
               value={nanColor}
           onChange={e => setNanColor(e.target.value)}
           />
-      <Button variant="pink" size="sm" className="w-[100%] cursor-[pointer] mb-2 mt-2" onClick={() => setShowBorders(!showBorders)}>{showBorders ? "Hide Borders" : "Show Borders" }</Button>
-      {showBorders && <div>
-      <b>Border Color</b>
-      <input type="color"
-          className='w-[100%] cursor-pointer'
-              value={borderColor}
-          onChange={e => setBorderColor(e.target.value)}
-          />
-      </div>}
+
+      {!(analysisMode && axis != 0) && // Hide if Analysismode and Axis != 0
+      <>
+        <Button variant="pink" size="sm" className="w-[100%] cursor-[pointer] mb-2 mt-2" onClick={() => setShowBorders(!showBorders)}>{showBorders ? "Hide Borders" : "Show Borders" }</Button>
+        {showBorders && 
+          <div>
+          <b>Border Color</b>
+          <input type="color"
+              className='w-[100%] cursor-pointer'
+                  value={borderColor}
+              onChange={e => setBorderColor(e.target.value)}
+              />
+          </div>
+        }</>
+      }
       <Popover>
         <PopoverTrigger asChild>
           <Button variant="pink" size="sm" className='w-[100%] cursor-pointer mb-2'>

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -271,11 +271,12 @@ const SpatialExtent = () =>{
 }
 
 const GlobalOptions = () =>{
-  const {showBorders, borderColor, nanColor, nanTransparency, setShowBorders, setBorderColor, setNanColor, setNanTransparency} = usePlotStore(useShallow(state => ({
+  const {showBorders, borderColor, nanColor, nanTransparency, plotType, setShowBorders, setBorderColor, setNanColor, setNanTransparency} = usePlotStore(useShallow(state => ({
     showBorders: state.showBorders,
     borderColor: state.borderColor,
     nanColor: state.nanColor,
     nanTransparency: state.nanTransparency,
+    plotType: state.plotType,
     setShowBorders: state.setShowBorders,
     setBorderColor: state.setBorderColor,
     setNanColor: state.setNanColor,
@@ -286,8 +287,11 @@ const GlobalOptions = () =>{
     axis: state.axis
   })))
 
+  const isPC = plotType == 'point-cloud'
   return (
     <div className='grid gap-y-[5px] items-center w-50 text-center'>
+      {!isPC &&
+        <>
       <b>NaN Transparency</b>
       <UISlider
               min={0}
@@ -303,7 +307,7 @@ const GlobalOptions = () =>{
               value={nanColor}
           onChange={e => setNanColor(e.target.value)}
           />
-
+      </>}
       {!(analysisMode && axis != 0) && // Hide if Analysismode and Axis != 0
       <>
         <Button variant="pink" size="sm" className="w-[100%] cursor-[pointer] mb-2 mt-2" onClick={() => setShowBorders(!showBorders)}>{showBorders ? "Hide Borders" : "Show Borders" }</Button>
@@ -393,7 +397,7 @@ const AdjustPlot = () => {
             {plotType === 'volume' && <VolumeOptions />}
             {plotType === 'point-cloud' && <PointOptions />}
             {(plotType === 'volume' || plotType === 'point-cloud') && <DimSlicer />}
-            {plotType != 'point-cloud' && <GlobalOptions />}
+            <GlobalOptions />
           </PopoverContent>
         </Popover>
       ) : (

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -252,7 +252,7 @@ const SpatialExtent = () =>{
           <Input value={latExtent[0]} onChange={e=>setLatExtent([parseFloat(e.target.value), latExtent[1]])} type='number'/>
         </div>
         <div className='flex-col justify-items-center'>
-          <h2>Min Lat</h2>
+          <h2>Max Lat</h2>
           <Input value={latExtent[1]} onChange={e=>setLatExtent([latExtent[0], parseFloat(e.target.value)])} type='number'/>
         </div>
       </div>

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -249,7 +249,7 @@ const AnalysisOptions = () => {
                             <div className='flex justify-around'>
                             Current
                               <Tooltip>
-                                <TooltipTrigger>
+                                <TooltipTrigger asChild>
                                   <BsFillQuestionCircleFill/>
                                 </TooltipTrigger>
                                 <TooltipContent>

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -23,7 +23,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-const operations = ['Mean', 'Min', 'Max', 'StDev', 'CUMSUM', 'LinearSlope'];
+const operations = ['Mean', 'Min', 'Max', 'StDev', 'LinearSlope'];
 const kernelOperations = ['Mean', 'Min', 'Max', 'StDev', 'CUMSUM3D'];
 const multivariate2DOps = ['Correlate2D', 'TwoVarLinearSlope2D']
 

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -8,7 +8,7 @@ import { Button } from '../button';
 // import { CgDatabase } from "react-icons/cg";
 import { TbDatabasePlus } from "react-icons/tb";
 import LocalZarr from './LocalZarr';
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Popover, PopoverTrigger, PopoverContent, PopoverAnchor } from "@/components/ui/popover";
 import {
   Tooltip,
   TooltipContent,
@@ -51,6 +51,7 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
   const [showLocalInput, setShowLocalInput] = useState(false);
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
   const [activeOption, setActiveOption] = useState<string>('ESDC')
+  const [openDescription, setOpenDescription] = useState<boolean>(false)
   
   const { setInitStore, setVariable } = useGlobalStore(
     useShallow((state) => ({
@@ -69,7 +70,7 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
   }, []);
 
   return (
-    <Popover>
+    <Popover >
       <PopoverTrigger asChild>
         <div>
           <Tooltip delayDuration={500} >
@@ -159,10 +160,8 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
               setShowStoreInput((prev) => !prev);
             }}
           >
-          
             Remote
           </Button>
-          
           {showStoreInput && (
             <form
               className="mt-2 flex items-center gap-2"
@@ -180,24 +179,34 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
             </form>
           )}
         </div>
-        <div>
-          <Button
-            variant={activeOption === 'local' ? "default" : "ghost"}
-            className='cursor-pointer'
-            onClick={() => {
-              setShowLocalInput((prev) => !prev);
-              setShowStoreInput(false);
-              setActiveOption('local')
-            }}
-          >
-            Local
-          </Button>
-          {showLocalInput && (
-            <div className="mt-2">
-              <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenVariables} setInitStore={setInitStore} />
+        <Popover open={false || openDescription} onOpenChange={setOpenDescription} >
+          <PopoverAnchor> 
+            <div>
+              <Button
+                variant={activeOption === 'local' ? "default" : "ghost"}
+                className='cursor-pointer'
+                onClick={() => {
+                  setShowLocalInput((prev) => !prev);
+                  setShowStoreInput(false);
+                  setActiveOption('local')
+                }}
+              >
+                Local
+              </Button>
+              {showLocalInput && (
+                <div className="mt-2">
+                  <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenDescription} />
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          </PopoverAnchor>
+          <PopoverContent 
+            className="flex flex-col items-start max-w-[300px] p-3 gap-3 w-auto mb-1"
+            side={'left'}
+          >
+            <DescriptionContent setOpenVariables={setOpenVariables} />
+          </PopoverContent>
+        </Popover>
       </PopoverContent>
     </Popover>
   );

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -179,7 +179,7 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
             </form>
           )}
         </div>
-        <Popover open={false || openDescription} onOpenChange={setOpenDescription} >
+        <Popover open={openDescription} onOpenChange={setOpenDescription} >
           <PopoverAnchor> 
             <div>
               <Button

--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -195,7 +195,7 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
               </Button>
               {showLocalInput && (
                 <div className="mt-2">
-                  <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenDescription} />
+                  <LocalZarr setShowLocal={setShowLocalInput} setOpenVariables={setOpenDescription} setInitStore={setInitStore} />
                 </div>
               )}
             </div>

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -8,10 +8,9 @@ import ZarrParser from '@/components/zarr/ZarrParser';
 interface LocalZarrType {
   setShowLocal: React.Dispatch<React.SetStateAction<boolean>>;
   setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>;
-  setInitStore: (store: string) => void;
 }
 
-const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
+const LocalZarr = ({setShowLocal, setOpenVariables}:LocalZarrType) => {
   const setCurrentStore = useZarrStore(state => state.setCurrentStore)
 
   const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -56,7 +55,6 @@ const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType)
       gs.then(e=>{setCurrentStore(e)})
       setShowLocal(false)
       setOpenVariables(true)
-      setInitStore(`local_$${baseDir}`)
     } catch (error) {
       if (error instanceof Error) {
         console.log(`Error opening Zarr store: ${error.message}`);

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -8,9 +8,10 @@ import ZarrParser from '@/components/zarr/ZarrParser';
 interface LocalZarrType {
   setShowLocal: React.Dispatch<React.SetStateAction<boolean>>;
   setOpenVariables: React.Dispatch<React.SetStateAction<boolean>>;
+  setInitStore: (store: string) => void;
 }
 
-const LocalZarr = ({setShowLocal, setOpenVariables}:LocalZarrType) => {
+const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
   const setCurrentStore = useZarrStore(state => state.setCurrentStore)
 
   const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -55,6 +56,7 @@ const LocalZarr = ({setShowLocal, setOpenVariables}:LocalZarrType) => {
       gs.then(e=>{setCurrentStore(e)})
       setShowLocal(false)
       setOpenVariables(true)
+      setInitStore(`local_${baseDir}`)
     } catch (error) {
       if (error instanceof Error) {
         console.log(`Error opening Zarr store: ${error.message}`);

--- a/src/components/ui/MainPanel/PlayButton.tsx
+++ b/src/components/ui/MainPanel/PlayButton.tsx
@@ -178,7 +178,7 @@ const PlayButton = () => {
           <PiPlayPauseFill className="size-8" />
         </Button>
       )}
-      <PlayInterFace visible={showOptions}/>
+      <PlayInterFace visible={(showOptions && enableCond)}/>
     </div>
   )
 }

--- a/src/components/zarr/GetMetadata.tsx
+++ b/src/components/zarr/GetMetadata.tsx
@@ -114,7 +114,6 @@ export async function GetVariableNames(variables: Promise<ZarrMetadata[]>): Prom
 
 export async function GetTitleDescription(
   groupStore: Promise<zarr.Group<zarr.FetchStore | zarr.Listable<zarr.FetchStore>>>, 
-  initStore: string
 ): Promise<ZarrTitleDescription> {
   
   const group = await groupStore;

--- a/src/components/zarr/GetMetadata.tsx
+++ b/src/components/zarr/GetMetadata.tsx
@@ -99,10 +99,15 @@ function isCoordinateVariable(name: string): boolean {
     return COORDINATE_VARS.some(coord => lowerName === coord);
 }
 
+function isOneDimensional(variable: any){
+    return variable.shape.length == 1;
+}
+
 export async function GetVariableNames(variables: Promise<ZarrMetadata[]>): Promise<string[]> {
     const metadata = await variables;
     return metadata
         .filter(variable => !isCoordinateVariable(variable.name))
+        .filter(variable => !isOneDimensional(variable))
         .map(variable => variable.name)
         .sort((a, b) => a.localeCompare(b));
 }

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -112,9 +112,9 @@ export class ZarrDataset{
 		this.variable = variable;
 		if (cache.has(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)){
 			const cachedChunk = cache.get(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)
-			const thisChunk = {...cachedChunk}
+			const thisChunk = {...cachedChunk} // Without this copy the decompressed data overwrites the cached compressed data
 			if (thisChunk.compressed){
-				thisChunk.data = DecompressArray(thisChunk.data)
+				thisChunk.data = DecompressArray(thisChunk.data) // This was overwriting the cached compressed data
 			}
 			return thisChunk;
 		}
@@ -152,8 +152,6 @@ export class ZarrDataset{
 						scaling: scalingFactor,
 						compressed: compress
 					}
-					console.log(compress)
-					console.log(cacheChunk)
 					cache.set(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`, cacheChunk)
 				}
 				setDownloading(false)

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -111,7 +111,8 @@ export class ZarrDataset{
 		//Check if cached
 		this.variable = variable;
 		if (cache.has(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)){
-			const thisChunk = cache.get(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)
+			const cachedChunk = cache.get(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`)
+			const thisChunk = {...cachedChunk}
 			if (thisChunk.compressed){
 				thisChunk.data = DecompressArray(thisChunk.data)
 			}
@@ -151,6 +152,8 @@ export class ZarrDataset{
 						scaling: scalingFactor,
 						compressed: compress
 					}
+					console.log(compress)
+					console.log(cacheChunk)
 					cache.set(is4D ? `${initStore}_${idx4D}_${variable}` : `${initStore}_${variable}`, cacheChunk)
 				}
 				setDownloading(false)

--- a/src/utils/ExportCanvas.tsx
+++ b/src/utils/ExportCanvas.tsx
@@ -15,6 +15,7 @@ const ExportCanvas = ({show}:{show: boolean}) => {
     })))
 
     const {exportImg, 
+        enableExport,
         includeBackground, 
         includeColorbar, 
         doubleSize, 
@@ -27,6 +28,7 @@ const ExportCanvas = ({show}:{show: boolean}) => {
     
     } = useImageExportStore(useShallow(state => ({
         exportImg: state.exportImg,
+        enableExport: state.enableExport,
         includeBackground: state.includeBackground,
         includeColorbar: state.includeColorbar,
         doubleSize: state.doubleSize,
@@ -39,7 +41,6 @@ const ExportCanvas = ({show}:{show: boolean}) => {
     })))
     
     const {gl, scene, camera} = useThree()
-    const hasMounted = useRef(false);
     const textColor = useCSSVariable('--text-plot')
     const bgColor = useCSSVariable('--background')
 
@@ -47,8 +48,7 @@ const ExportCanvas = ({show}:{show: boolean}) => {
         if (!show){
             return
         }
-        if (!hasMounted.current){ // It will try to render on first load. So this has to be here to stop it. 
-            hasMounted.current = true
+        if (!enableExport){ // It will try to render on first load. So this has to be here to stop it. 
             return
         }
         const domWidth = gl.domElement.width;

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -450,6 +450,7 @@ export const useErrorStore = create<ErrorState>((set) =>({
 
 type ImageExportState = {
   exportImg: boolean;
+  enableExport: boolean;
   includeBackground: boolean;
   includeColorbar: boolean;
   includeAxis: boolean;
@@ -462,6 +463,7 @@ type ImageExportState = {
   hideAxis: boolean;
 
   ExportImg: () => void;
+  EnableExport: () => void;
   setIncludeBackground: (includeBackground: boolean) => void;
   setIncludeColorbar: (includeColorbar: boolean) => void;
   setIncludeAxis: (includeAxis: boolean) => void;
@@ -482,6 +484,7 @@ type ImageExportState = {
 
 export const useImageExportStore = create<ImageExportState>((set, get) => ({
   exportImg: false,
+  enableExport: false,
   includeBackground: false,
   includeColorbar: true,
   doubleSize: false,
@@ -494,6 +497,7 @@ export const useImageExportStore = create<ImageExportState>((set, get) => ({
   hideAxis: false,
 
   ExportImg: () => set({ exportImg: !get().exportImg }),
+  EnableExport: () => set({ enableExport: true }),
   setIncludeBackground: (includeBackground) => set({ includeBackground }),
   setIncludeColorbar: (includeColorbar) => set({ includeColorbar }),
   setDoubleSize: (doubleSize) => set({ doubleSize }),

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -479,7 +479,6 @@ type ImageExportState = {
   setHideAxisControls: (hideAxisControls: boolean) => void;
   getHideAxisControls: () => boolean;
   setHideAxis: (hideAxis: boolean) => void;
-
 }
 
 export const useImageExportStore = create<ImageExportState>((set, get) => ({


### PR DESCRIPTION
- [x] AxisLines trimming dimensions on 2D data in Analysismode
- [x] ExportImage kept firing when switching to Seasfire
- [x] FlatMap  trimming dimensions on 2D data in Analysismode
- [x] Play interface staying visible when play button becomes  disabled
- [x] Tooltip was open when analysis options were opened in Analysismode 
- [x] Fail to Fetch propagates from Zarrita files 
- [x] Cached compressed data was being overwritten with uncompressed data. 
- [x] Hide Country Borders when regressing along a dimension that's not time
- [x] Removed CUMSUM from datareduction for now as it's values are greater than float16 and doesn't fit in the workflow at the moment. Will re-add later
- [x]  Added an error if the custom dataset uses incompatible data type
- [x] Added country borders to the point-cloud
- [x] Typo in Extent 
- [x] Exclude One dimensional variables from variable list
- [x] I broke localzarr functionality with #246 by changing initStore state. I did this for unique/persistent cache. Reverted that change. Will consider alternatives
- [x] Added popover info to localZarr option
- [x] included initSTore again for localzarr but just ignore it if it's from a localZarr. Achieves the unique cache items as desired but without breaking workflow 