### PR TITLE
Jp/better points

### DIFF
--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -224,7 +224,7 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
       fragmentShader:pointFrag,
       depthWrite: true,
       depthTest: true,
-      transparent: true,
+      transparent: false,
       blending:THREE.NormalBlending,
       side:THREE.DoubleSide,
     })

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -188,43 +188,15 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
     }, [texture]);
     const aspectRatio = useMemo(()=>width/height,[width,height]);
     const depthRatio = useMemo(()=>depth/height,[depth,height]);
-
-    const { positions, values } = useMemo(() => {
-      let positions;
-      try{
-        positions = new Float32Array(depth*height*width*3);
-      }catch{
-        setError('oom') // Set out of memeory error
-        return {positions: [], values: []};
-      }
-      const values = new Uint8Array(depth*height*width);
-      //Generate grid points based on texture shape
-      for (let z = 0; z < depth; z++) {
-        for (let y = 0; y < height; y++) {
-          for (let x = 0; x < width; x++) {
-            const index = x + y * width + z * width * height;
-            const value = (data as number[])[index] || 0;
-              // Normalize coordinates acceptable range
-            const px = ((x / (width - 1)) - 0.5) ; 
-            const py = ((y / (height - 1)) - 0.5)/aspectRatio;
-            const pz = ((z / (depth - 1)) - 0.5) * depthRatio ;
-            const posIdx = index*3;
-            positions[posIdx] = px * 2;
-            positions[posIdx + 1] = py *2 ;
-            positions[posIdx + 2] = pz ;
-            values[index] = value;
-          }
-        }
-      }
-      return { positions, values };
-    }, [data, width, height, depth]);
     // Create buffer geometry
     const geometry = useMemo(() => {
       const geom = new THREE.BufferGeometry();
-      geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-      geom.setAttribute('value', new THREE.Float32BufferAttribute(values, 1));
+      geom.setAttribute('value', new THREE.Uint8BufferAttribute(data as number[], 1));
+
+      const positions = new Uint8Array(depth * height * width * 3); 
+      geom.setAttribute('position', new THREE.BufferAttribute(positions, 3, true));
       return geom;
-    }, [positions, values]);
+    }, [data]);
     const shaderMaterial = useMemo(()=> (new THREE.ShaderMaterial({
       glslVersion: THREE.GLSL3,
       uniforms: {
@@ -242,6 +214,8 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         timeScale: {value: timeScale},
         animateProg: {value: animProg},
         depthRatio: {value: depthRatio},
+        aspectRatio: {value: aspectRatio},
+        shape: {value: new THREE.Vector3(depth, height, width)},
         flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio/2, zRange[1]*depthRatio/2)},
         vertBounds:{value: new THREE.Vector2(yRange[0]/aspectRatio, yRange[1]/aspectRatio)},
       },
@@ -253,7 +227,7 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
       side:THREE.DoubleSide,
     })
     ),[]);
-
+    console.log(geometry)
    useEffect(() => {
     if (shaderMaterial) {
       const uniforms = shaderMaterial.uniforms;

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -18,5 +18,5 @@ export {
     flatSphereFrag,
     bordersFrag,
     fragmentFlat,
-    flatFrag3D
+    flatFrag3D,
 }

--- a/src/components/textures/shaders/pointFrag.glsl
+++ b/src/components/textures/shaders/pointFrag.glsl
@@ -22,5 +22,5 @@ void main() {
     else{
         Color = color;
     }
-
+    Color = vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/components/textures/shaders/pointFrag.glsl
+++ b/src/components/textures/shaders/pointFrag.glsl
@@ -10,7 +10,6 @@ uniform float cOffset;
 uniform bool showTransect;
 
 void main() {
-
     float sampLoc = vValue == 1. ? vValue : (vValue - 0.5)*cScale + 0.5;
     sampLoc = vValue == 1. ? vValue : min(sampLoc+cOffset,0.99);
     vec4 color = texture(cmap, vec2(sampLoc, 0.5));
@@ -22,5 +21,4 @@ void main() {
     else{
         Color = color;
     }
-    Color = vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -1,4 +1,4 @@
-attribute int value;
+attribute float value;
 
 out float vValue;
 
@@ -57,43 +57,42 @@ vec3 computePosition(int vertexID) {
 void main() {
     vValue = float(value)/255.;
     vec3 scaledPos = computePosition(gl_VertexID);
-    gl_PointSize = 10.;
 
-    gl_Position = vec4(0.0, 0.1, 0.1, 1.0);
-    // scaledPos.z += depthRatio/2.;
-    // scaledPos.z = mod(scaledPos.z + animateProg*depthRatio, depthRatio);
-    // scaledPos.z -= depthRatio/2.;
+    scaledPos.z += depthRatio/2.;
+    scaledPos.z = mod(scaledPos.z + animateProg*depthRatio, depthRatio);
+    scaledPos.z -= depthRatio/2.;
 
-    // scaledPos.z *= timeScale;
-    // gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
-    // float pointScale = pointSize/gl_Position.w;
-    // pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
+    scaledPos.z *= timeScale;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
 
-    // bool isValid = isValidPoint();
-    // highlight = isValid ? 1 : 0;
+    float pointScale = pointSize/gl_Position.w;
+    pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
+
+    bool isValid = isValidPoint();
+    highlight = isValid ? 1 : 0;
     
-    // if (value == 255 || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scalled
-    //     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    // }
+    if (value == 255. || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scalled
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    }
 
-    // if (vValue < valueRange.x || vValue > valueRange.y){ //Hide points that are outside of value range
-    //     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    // }
+    if (vValue < valueRange.x || vValue > valueRange.y){ //Hide points that are outside of value range
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    }
 
-    // vec2 scaledZBounds = vec2(flatBounds.z,  flatBounds.w) * vec2(timeScale);
-    // bool xCheck = scaledPos.x < flatBounds.x || scaledPos.x > flatBounds.y;
-    // bool zCheck = scaledPos.z < scaledZBounds.x || scaledPos.z > scaledZBounds.y;
-    // bool yCheck = scaledPos.y < vertBounds.x || scaledPos.y> vertBounds.y;
+    vec2 scaledZBounds = vec2(flatBounds.z,  flatBounds.w) * vec2(timeScale);
+    bool xCheck = scaledPos.x < flatBounds.x || scaledPos.x > flatBounds.y;
+    bool zCheck = scaledPos.z < scaledZBounds.x || scaledPos.z > scaledZBounds.y;
+    bool yCheck = scaledPos.y < vertBounds.x || scaledPos.y> vertBounds.y;
 
-    // if (xCheck || zCheck || yCheck){ //Hide points that are clipped
-    //     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    // }
+    if (xCheck || zCheck || yCheck){ //Hide points that are clipped
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    }
     
-    // if (showTransect){
-    //     gl_PointSize = isValid ? max(pointScale*5. , pointScale+80./gl_Position.w) : pointScale;
-    // }
-    // else{
-    //     gl_PointSize =  pointScale;
-    // }
+    if (showTransect){
+        gl_PointSize = isValid ? max(pointScale*5. , pointScale+80./gl_Position.w) : pointScale;
+    }
+    else{
+        gl_PointSize =  pointScale;
+    }
 
 }

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -1,4 +1,5 @@
-attribute float value;
+attribute int value;
+
 out float vValue;
 
 flat out int highlight;
@@ -16,6 +17,8 @@ uniform float animateProg;
 uniform float depthRatio;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
+uniform float aspectRatio;
+uniform vec3 shape;
 
 bool isValidPoint(){
     for (int i = 0; i < 10; i++){
@@ -33,43 +36,64 @@ bool isValidPoint(){
     return false;
 }
 
+vec3 computePosition(int vertexID) {
+    int depth = int(shape.x);
+    int height = int(shape.y);
+    int width = int(shape.z);
+
+    int sliceSize = width * height;
+
+    int z = vertexID / sliceSize;
+    int y = (vertexID % sliceSize) / width;
+    int x = vertexID % width;
+
+    float px = (float(x) / float(width - 1)) - 0.5;
+    float py = ((float(y) / float(height - 1)) - 0.5) / aspectRatio;
+    float pz = ((float(z) / float(depth - 1)) - 0.5) * depthRatio;
+
+    return vec3(px * 2.0, py * 2.0, pz);
+}
+
 void main() {
-    vValue = value/255.;
-    vec3 scaledPos = position;
-    scaledPos.z += depthRatio/2.;
-    scaledPos.z = mod(scaledPos.z + animateProg*depthRatio, depthRatio);
-    scaledPos.z -= depthRatio/2.;
+    vValue = float(value)/255.;
+    vec3 scaledPos = computePosition(gl_VertexID);
+    gl_PointSize = 10.;
 
-    scaledPos.z *= timeScale;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
-    float pointScale = pointSize/gl_Position.w;
-    pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
+    gl_Position = vec4(0.0, 0.1, 0.1, 1.0);
+    // scaledPos.z += depthRatio/2.;
+    // scaledPos.z = mod(scaledPos.z + animateProg*depthRatio, depthRatio);
+    // scaledPos.z -= depthRatio/2.;
 
-    bool isValid = isValidPoint();
-    highlight = isValid ? 1 : 0;
+    // scaledPos.z *= timeScale;
+    // gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
+    // float pointScale = pointSize/gl_Position.w;
+    // pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
+
+    // bool isValid = isValidPoint();
+    // highlight = isValid ? 1 : 0;
     
-    if (value == 255. || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scalled
-        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    }
+    // if (value == 255 || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scalled
+    //     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    // }
 
-    if (vValue < valueRange.x || vValue > valueRange.y){ //Hide points that are outside of value range
-        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    }
+    // if (vValue < valueRange.x || vValue > valueRange.y){ //Hide points that are outside of value range
+    //     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    // }
 
-    vec2 scaledZBounds = vec2(flatBounds.z,  flatBounds.w) * vec2(timeScale);
-    bool xCheck = scaledPos.x < flatBounds.x || scaledPos.x > flatBounds.y;
-    bool zCheck = scaledPos.z < scaledZBounds.x || scaledPos.z > scaledZBounds.y;
-    bool yCheck = scaledPos.y < vertBounds.x || scaledPos.y> vertBounds.y;
+    // vec2 scaledZBounds = vec2(flatBounds.z,  flatBounds.w) * vec2(timeScale);
+    // bool xCheck = scaledPos.x < flatBounds.x || scaledPos.x > flatBounds.y;
+    // bool zCheck = scaledPos.z < scaledZBounds.x || scaledPos.z > scaledZBounds.y;
+    // bool yCheck = scaledPos.y < vertBounds.x || scaledPos.y> vertBounds.y;
 
-    if (xCheck || zCheck || yCheck){ //Hide points that are clipped
-        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    }
+    // if (xCheck || zCheck || yCheck){ //Hide points that are clipped
+    //     gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+    // }
     
-    if (showTransect){
-        gl_PointSize = isValid ? max(pointScale*5. , pointScale+80./gl_Position.w) : pointScale;
-    }
-    else{
-        gl_PointSize =  pointScale;
-    }
+    // if (showTransect){
+    //     gl_PointSize = isValid ? max(pointScale*5. , pointScale+80./gl_Position.w) : pointScale;
+    // }
+    // else{
+    //     gl_PointSize =  pointScale;
+    // }
 
 }


### PR DESCRIPTION
The Point Cloud now creates it's positions in the Vertex shader. So switching to the point-cloud doesn't hitch/freeze the way it used to.

This also means it doesn't run into the memory issues of before so the only limit to number of points is performance.

Here I have plotted 103 million points and have it animating along time with a serviceable 30FPS

<img width="1012" height="1084" alt="image" src="https://github.com/user-attachments/assets/5e02e584-1d05-48aa-b3d3-9f5ca15e3514" />

This wasn't even possible before as the positions array would max out the browsers memory. 

I tried an implementation for #291 but it didn't seem to work as expected. I kinda think the shader as is, is doing depth testing. So I don't know if we can improve this anymore except by moving to webGPU eventually. 

