### PR TITLE
Jp/fetch retry

### DIFF
--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -139,8 +139,8 @@ export class ZarrDataset{
 			_chunkSize /=  outVar.shape[0] //Don't need to use this but Lint is being a whiner
 		}
 		const hasTimeChunks = is4D ? outVar.shape[1]/chunkShape[0] > 1 : outVar.shape[0]/chunkShape[0] > 1
-		// Type check using zarr.Array.is
 
+		// Type check using zarr.Array.is
 		if (outVar.is("number") || outVar.is("bigint")) {
 			let chunk;
 			let typedArray;


### PR DESCRIPTION
Added 10 retries (5 seconds total) to each instance of zarr fetching so the error doesn't pop up as often as it was. This confused some people.

Also Rescaled the chunk arrays in cache. Was an issue I knew about but was low priority due to rarity of actually being an issue 