### PR TITLE
Analysis Fixes

### DIFF
--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -68,7 +68,7 @@ const FlatMap = ({texture, infoSetters} : {texture : THREE.DataTexture | THREE.D
             vertexShader: vertShader,
             fragmentShader: isFlat ? fragmentFlat : flatFrag3D,
             side: THREE.DoubleSide,
-        }),[])
+        }),[isFlat])
 
     useEffect(()=>{
       if(shaderMaterial){

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -210,7 +210,6 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
     coords,
     val
   }),[])
-  
   const Nav = useMemo(()=>Navbar,[])
   return (
     <div className='main-canvas'
@@ -246,7 +245,7 @@ const Plot = ({ZarrDS}:{ZarrDS: ZarrDataset}) => {
       </Canvas>
       </>}
 
-        {(isFlat || plotType == "flat") && <>
+        {(isFlat || (!isFlat && plotType == "flat")) && <>
         <Canvas id='main-canvas' camera={{ position: [0,0,5], zoom: 1000 }}
         orthographic frameloop="demand"
         >

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -137,8 +137,9 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
 
         })
         return shader
-    },[])
-
+    },[isFlat])
+    const backMaterial = shaderMaterial.clone()
+    backMaterial.side = THREE.BackSide;
     useEffect(()=>{
       if (shaderMaterial){
         const uniforms = shaderMaterial.uniforms;
@@ -154,9 +155,22 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
         uniforms.nanColor.value =  new THREE.Color(nanColor)
         uniforms.nanAlpha.value =  1 - nanTransparency
       }
+      if (backMaterial){
+        const uniforms = backMaterial.uniforms;
+        uniforms.map. value =  texture 
+        uniforms.selectTS.value =  selectTS
+        uniforms.selectBounds.value =  bounds
+        uniforms.cmap.value =  colormap
+        uniforms.cOffset.value =  cOffset
+        uniforms.cScale.value =  cScale
+        uniforms.animateProg.value =  animProg
+        uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
+        uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
+        uniforms.nanColor.value =  new THREE.Color(nanColor)
+        uniforms.nanAlpha.value =  1 - nanTransparency
+      }
     },[texture, animProg, colormap, cOffset, cScale, animate, bounds, selectTS, lonBounds, latBounds, nanColor, nanTransparency])
-    const backMaterial = shaderMaterial.clone()
-    backMaterial.side = THREE.BackSide;
+    
     
     function HandleTimeSeries(event: THREE.Intersection){
         const point = event.point.normalize();

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -126,6 +126,7 @@ export class ZarrDataset{
 			if (thisChunk.compressed){
 				thisChunk.data = DecompressArray(thisChunk.data)
 			}
+			setStrides(thisChunk.stride)
 			return thisChunk;
 		}
 


### PR DESCRIPTION
#282  introduced the bugs for #301 and #302 

Those were quick fixes.

#303 This one was a niche issue that only occurred when switching from datasets and loading a previously cached variable from ESDC. I forgot to setStrides for that operation.  