### PR TITLE
Even Points

### DIFF
--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -67,7 +67,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
     return new LineSegments2(geom, lineMat)},[yRange, shapeRatio, lineMat, globalScale])
 
   const zLine = useMemo(()=> {
-    const geom = new LineSegmentsGeometry().setPositions([0, 0, isPC ? zRange[0]*globalScale/2*depthRatio-tickLength/2 : zRange[0]-tickLength/2, 0, 0, isPC ? zRange[1]*globalScale/2*depthRatio+tickLength/2 : zRange[1]+tickLength/2]);
+    const geom = new LineSegmentsGeometry().setPositions([0, 0, isPC ? zRange[0]*globalScale*depthRatio-tickLength/2 : zRange[0]-tickLength/2, 0, 0, isPC ? zRange[1]*globalScale*depthRatio+tickLength/2 : zRange[1]+tickLength/2]);
     return new LineSegments2(geom, lineMat)},[zRange, depthRatio, isPC, lineMat, globalScale])
 
   const tickLine = useMemo(()=> {
@@ -85,7 +85,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
     {/* Horizontal Group */}
     <group position={[0, isPC ? shapeRatio*globalScale*yRange[0] : shapeRatio*yRange[0], 0]}  >
       {/* X Group */}
-      <group position={[0, 0, flipX ? isPC ? zRange[0]*depthRatio*(globalScale/2)-tickLength/2 : zRange[0]-tickLength/2 : isPC ? zRange[1] * (globalScale/2) * depthRatio +tickLength/2 : zRange[1]+tickLength/2]} rotation={[flipDown ? flipX ? -Math.PI/2 : Math.PI/2 : 0, 0, 0]}> 
+      <group position={[0, 0, flipX ? isPC ? zRange[0]*depthRatio*(globalScale)-tickLength/2 : zRange[0]-tickLength/2 : isPC ? zRange[1] * (globalScale) * depthRatio +tickLength/2 : zRange[1]+tickLength/2]} rotation={[flipDown ? flipX ? -Math.PI/2 : Math.PI/2 : 0, 0, 0]}> 
         <primitive key={'xLine'} object={xLine} />
         {Array(xResolution).fill(null).map((_val,idx)=>(
           (((xRange[0] + 1)/2) <= (idx*xDimScale)/xResolution &&
@@ -155,7 +155,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
           (((zRange[0] + 1)/2) <= (idx*zDimScale)/zResolution  &&
           ((zRange[1] + 1)/2) >= (idx*zDimScale)/zResolution )
           && 
-          <group key={`zGroup_${idx}`} position={[0, 0, isPC ? -depthRatio*globalScale/2 + idx*zDimScale/(zResolution/2)*depthRatio*(globalScale/2) : -1 + idx*zDimScale/(zResolution/2)]}>
+          <group key={`zGroup_${idx}`} position={[0, 0, isPC ? -depthRatio*globalScale + idx*zDimScale/(zResolution/2)*depthRatio*(globalScale) : -1 + idx*zDimScale/(zResolution/2)]}>
             <primitive key={idx} object={tickLine.clone()}  rotation={[0, flipY ? Math.PI/2 : -Math.PI/2 , 0]} />
             <Text 
               key={`textY_${idx}`}
@@ -214,7 +214,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
       </group>
     </group>
     {/* Vertical Group */}
-    <group position={[flipY ? xRange[0]*globalScale - tickLength/2 : xRange[1]*globalScale + tickLength/2, 0, flipX ? isPC ? zRange[0]*depthRatio*(globalScale/2) - tickLength/2 : zRange[0] - tickLength/2 : isPC ? zRange[1]*depthRatio*(globalScale/2) + tickLength/2 : zRange[1] +tickLength/2]}> 
+    <group position={[flipY ? xRange[0]*globalScale - tickLength/2 : xRange[1]*globalScale + tickLength/2, 0, flipX ? isPC ? zRange[0]*depthRatio*(globalScale) - tickLength/2 : zRange[0] - tickLength/2 : isPC ? zRange[1]*depthRatio*(globalScale) + tickLength/2 : zRange[1] +tickLength/2]}> 
       <primitive key={'yLine'} object={yLine} />
       {Array(yResolution).fill(null).map((_val,idx)=>(
            (((yRange[0] + 1)/2) <= (idx*yDimScale)/yResolution &&

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -13,11 +13,10 @@ import { useCSSVariable } from '../ui';
 import * as THREE from 'three'
 
 const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolean, flipDown: boolean}) =>{
-  const {dimArrays, dimNames, dimUnits, shape, dataShape} = useGlobalStore(useShallow(state => ({
+  const {dimArrays, dimNames, dimUnits, dataShape} = useGlobalStore(useShallow(state => ({
     dimArrays: state.dimArrays,
     dimNames: state.dimNames,
     dimUnits: state.dimUnits,
-    shape: state.shape,
     dataShape: state.dataShape
   })))
 
@@ -45,8 +44,8 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
   const isPC = useMemo(()=>plotType == 'point-cloud',[plotType])
   const globalScale = isPC ? dataShape[2]/500 : 1
 
-  const depthRatio = useMemo(()=>dataShape[0]/dataShape[1]*timeScale/2,[dataShape, timeScale]);
-  const shapeRatio = useMemo(()=>shape.y/shape.x, [shape])
+  const depthRatio = useMemo(()=>dataShape[0]/dataShape[2]*timeScale,[dataShape, timeScale]);
+  const shapeRatio = useMemo(()=>dataShape[1]/dataShape[2], [dataShape])
 
   const secondaryColor = useCSSVariable('--text-plot') //replace with needed variable
   const colorHex = useMemo(()=>{
@@ -169,7 +168,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
             >{parseLoc(dimArrays[0][(Math.floor((dimLengths[0]-1)*idx*zValDelta)+Math.floor(dimLengths[0]*animProg))%dimLengths[0]],dimUnits[0])}</Text>
           </group>
         ))}
-        <group rotation={[-Math.PI/2, 0, flipY ? Math.PI/2 : -Math.PI/2]} position={[flipY ? 0.2*globalScale : -0.2*globalScale, 0, isPC ? (zRange[0]+zRange[1])/2*depthRatio*(globalScale/2) : (zRange[0]+zRange[1])/2]}>
+        <group rotation={[-Math.PI/2, 0, flipY ? Math.PI/2 : -Math.PI/2]} position={[flipY ? 0.2*globalScale : -0.2*globalScale, 0, isPC ? (zRange[0]+zRange[1])/2*depthRatio*(globalScale) : (zRange[0]+zRange[1])/2]}>
           <Text 
             key={'zTitle'}
             anchorX={'center'}
@@ -220,7 +219,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
            (((yRange[0] + 1)/2) <= (idx*yDimScale)/yResolution &&
            ((yRange[1] + 1)/2) >= (idx*yDimScale)/yResolution)
            &&       
-          <group key={`yGroup_${idx}`} position={[0, isPC ?  (-shape.y/2*globalScale + idx*yDimScale/(yResolution/2)*shapeRatio*globalScale) : -shape.y/2 + idx*yDimScale/(yResolution/2)*shapeRatio, 0]}>
+          <group key={`yGroup_${idx}`} position={[0, isPC ?  (-shapeRatio*globalScale + idx*yDimScale/(yResolution/2)*shapeRatio*globalScale) : -shapeRatio + idx*yDimScale/(yResolution/2)*shapeRatio, 0]}>
             <primitive key={idx} object={tickLine.clone()}  rotation={[0, flipY ? -Math.PI/2 :Math.PI/2 , 0]} />
             <Text 
               key={`text_${idx}`}

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -59,11 +59,10 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
   const tickLength = 0.05;
 
   const xLine = useMemo(()=> {
-    const geom = new LineSegmentsGeometry().setPositions([(isPC ? xRange[0]*width/1000-tickLength/2 : xRange[0]-tickLength/2), 0, 0, (isPC ? xRange[1]*width/1000+tickLength/2 :xRange[1]+tickLength/2), 0, 0]);
+    const geom = new LineSegmentsGeometry().setPositions([(isPC ? xRange[0]*width/500-tickLength/2 : xRange[0]-tickLength/2), 0, 0, (isPC ? xRange[1]*width/500+tickLength/2 :xRange[1]+tickLength/2), 0, 0]);
     return new LineSegments2(geom, lineMat)},[xRange, lineMat])
-
   const yLine = useMemo(() =>{
-    const geom = new LineSegmentsGeometry().setPositions([0, isPC ? yRange[0]*height/1000 : yRange[0], 0, 0, isPC ? yRange[1]*height/1000+tickLength/2 : yRange[1]+tickLength/2, 0]);
+    const geom = new LineSegmentsGeometry().setPositions([0, isPC ? yRange[0]*height/500 : yRange[0]*shapeRatio, 0, 0, isPC ? yRange[1]*height/500+tickLength/2 : yRange[1]*shapeRatio+tickLength/2, 0]);
     return new LineSegments2(geom, lineMat)},[yRange, shapeRatio, lineMat])
 
   const zLine = useMemo(()=> {
@@ -80,18 +79,19 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
   const yValDelta = 1/(yResolution-1)
   const zDimScale = zResolution/(zResolution-1)
   const zValDelta = 1/(zResolution-1)
+
   return (
     <group visible={plotType != 'sphere' && plotType != 'flat' && !hideAxis}>
     {/* Horizontal Group */}
-    <group position={[0, shapeRatio*yRange[0], 0]}  >
+    <group position={[0, isPC ? yRange[0]*height/500 : shapeRatio*yRange[0], 0]}  >
       {/* X Group */}
-      <group position={[0, 0, flipX ? isPC ? zRange[0]*depthRatio-tickLength/2 : zRange[0]-tickLength/2 : isPC ? zRange[1] * depthRatio +tickLength/2 : zRange[1]+tickLength/2]} rotation={[flipDown ? flipX ? -Math.PI/2 : Math.PI/2 : 0, 0, 0]}> 
+      <group position={[0, 0, flipX ? isPC ? zRange[0]*depth/1000-tickLength/2 : zRange[0]-tickLength/2 : isPC ? zRange[1]*depth/1000 +tickLength/2 : zRange[1]+tickLength/2]} rotation={[flipDown ? flipX ? -Math.PI/2 : Math.PI/2 : 0, 0, 0]}> 
         <primitive key={'xLine'} object={xLine} />
         {Array(xResolution).fill(null).map((_val,idx)=>(
           (((xRange[0] + 1)/2) <= (idx*xDimScale)/xResolution &&
            ((xRange[1] + 1)/2) >= (idx*xDimScale)/xResolution)
            &&          
-          <group key={`xGroup_${idx}`} position={[-1 + idx*xDimScale/(xResolution/2), 0, 0]}>
+          <group key={`xGroup_${idx}`} position={[isPC ? -width/500 + idx*width/(xResolution-1)/250 : -1 + idx*xDimScale/(xResolution/2), 0, 0]}>
             <primitive key={idx} object={tickLine.clone()}  rotation={[0, flipX ? Math.PI : 0, 0]} />
             <Text 
               key={`textX_${idx}`}

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -43,6 +43,7 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
   const [zResolution, setZResolution] = useState<number>(7)
 
   const isPC = useMemo(()=>plotType == 'point-cloud',[plotType])
+  const [depth, height, width] = dataShape;
 
   const depthRatio = useMemo(()=>dataShape[0]/dataShape[1]*timeScale/2,[dataShape, timeScale]);
   const shapeRatio = useMemo(()=>shape.y/shape.x, [shape])
@@ -58,15 +59,15 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
   const tickLength = 0.05;
 
   const xLine = useMemo(()=> {
-    const geom = new LineSegmentsGeometry().setPositions([(xRange[0]-tickLength/2), 0, 0, (xRange[1]+tickLength/2), 0, 0]);
+    const geom = new LineSegmentsGeometry().setPositions([(isPC ? xRange[0]*width/1000-tickLength/2 : xRange[0]-tickLength/2), 0, 0, (isPC ? xRange[1]*width/1000+tickLength/2 :xRange[1]+tickLength/2), 0, 0]);
     return new LineSegments2(geom, lineMat)},[xRange, lineMat])
 
   const yLine = useMemo(() =>{
-    const geom = new LineSegmentsGeometry().setPositions([0, yRange[0]*shapeRatio, 0, 0, yRange[1]*shapeRatio+tickLength/2, 0]);
+    const geom = new LineSegmentsGeometry().setPositions([0, isPC ? yRange[0]*height/1000 : yRange[0], 0, 0, isPC ? yRange[1]*height/1000+tickLength/2 : yRange[1]+tickLength/2, 0]);
     return new LineSegments2(geom, lineMat)},[yRange, shapeRatio, lineMat])
 
   const zLine = useMemo(()=> {
-    const geom = new LineSegmentsGeometry().setPositions([0, 0, isPC ? zRange[0]*depthRatio-tickLength/2 : zRange[0]-tickLength/2, 0, 0, isPC ? zRange[1]*depthRatio+tickLength/2 : zRange[1]+tickLength/2]);
+    const geom = new LineSegmentsGeometry().setPositions([0, 0, isPC ? zRange[0]*depth/1000-tickLength/2 : zRange[0]-tickLength/2, 0, 0, isPC ? zRange[1]*depth/1000+tickLength/2 : zRange[1]+tickLength/2]);
     return new LineSegments2(geom, lineMat)},[zRange, depthRatio, isPC, lineMat])
 
   const tickLine = useMemo(()=> {

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -214,11 +214,9 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         dimWidth: {value: dimWidth},
         timeScale: {value: timeScale},
         animateProg: {value: animProg},
-        depthRatio: {value: depthRatio},
-        aspectRatio: {value: aspectRatio},
         shape: {value: new THREE.Vector3(depth, height, width)},
-        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0]*depthRatio/2, zRange[1]*depthRatio/2)},
-        vertBounds:{value: new THREE.Vector2(yRange[0]/aspectRatio, yRange[1]/aspectRatio)},
+        flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0], zRange[1])},
+        vertBounds:{value: new THREE.Vector2(yRange[0], yRange[1])},
       },
       vertexShader:pointVert,
       fragmentShader:pointFrag,
@@ -246,16 +244,15 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
       uniforms.dimWidth.value = dimWidth;
       uniforms.timeScale.value = timeScale;
       uniforms.animateProg.value = animProg;
-      uniforms.depthRatio.value = depthRatio;
       uniforms.flatBounds.value.set(
         xRange[0], xRange[1], 
-        zRange[0] * depthRatio / 2, zRange[1] * depthRatio / 2
+        zRange[0], zRange[1]
       );
       uniforms.vertBounds.value.set(
-        yRange[0] / aspectRatio, yRange[1] / aspectRatio
+        yRange[0], yRange[1]
       );
     }
-  }, [pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, pointIDs, stride, selectTS, animProg, timeScale, depthRatio, aspectRatio, xRange, yRange, zRange]);
+  }, [pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, pointIDs, stride, selectTS, animProg, timeScale, xRange, yRange, zRange]);
 
     return (
       <>

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -187,8 +187,7 @@ export const PointCloud = ({textures, ZarrDS} : {textures:PCProps, ZarrDS: ZarrD
         depth: texture.image.depth,
       };
     }, [texture]);
-    const aspectRatio = useMemo(()=>width/height,[width,height]);
-    const depthRatio = useMemo(()=>depth/height,[depth,height]);
+
     // Create buffer geometry
     const geometry = useMemo(() => {
       const geom = new THREE.BufferGeometry();

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -14,10 +14,8 @@ uniform int dimWidth;
 uniform bool showTransect;
 uniform float timeScale;
 uniform float animateProg;
-uniform float depthRatio;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
-uniform float aspectRatio;
 uniform vec3 shape;
 
 bool isValidPoint(){
@@ -51,16 +49,17 @@ vec3 computePosition(int vertexID) {
     float py = (float(y) - (float(height)/2.)) / 500.;
     float pz = (float(z) - (float(depth )/2.)) /500.;
 
-    return vec3(px * 2.0, py * 2.0, pz);
+    return vec3(px * 2.0, py * 2.0, pz * 2.0);
 }
 
 void main() {
     vValue = float(value)/255.;
     vec3 scaledPos = computePosition(gl_VertexID);
+    float depthSize = float(shape.x)/500.;
 
-    scaledPos.z += depthRatio/2.;
-    scaledPos.z = mod(scaledPos.z + animateProg*depthRatio, depthRatio);
-    scaledPos.z -= depthRatio/2.;
+    scaledPos.z += depthSize;
+    scaledPos.z = mod(scaledPos.z + animateProg*depthSize*2., depthSize*2.);
+    scaledPos.z -= depthSize;
 
     scaledPos.z *= timeScale;
     gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
@@ -79,17 +78,24 @@ void main() {
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     }
 
-    vec2 scaledZBounds = vec2(flatBounds.z,  flatBounds.w) * vec2(timeScale);
-    bool xCheck = scaledPos.x < flatBounds.x || scaledPos.x > flatBounds.y;
+    float scaleX = float(shape.z) / 500.0; //width scaling
+    float scaleY = float(shape.y) / 500.0; //height scaling
+    float scaleZ = float(shape.x) / 500.0; //depth scaling
+    
+    vec2 scaledXBounds = vec2(flatBounds.x, flatBounds.y) * scaleX;
+    vec2 scaledZBounds = vec2(flatBounds.z, flatBounds.w) * scaleZ * timeScale;
+    vec2 scaledYBounds = vec2(vertBounds.x, vertBounds.y) * scaleY;
+    
+    bool xCheck = scaledPos.x < scaledXBounds.x || scaledPos.x > scaledXBounds.y;
     bool zCheck = scaledPos.z < scaledZBounds.x || scaledPos.z > scaledZBounds.y;
-    bool yCheck = scaledPos.y < vertBounds.x || scaledPos.y> vertBounds.y;
+    bool yCheck = scaledPos.y < scaledYBounds.x || scaledPos.y > scaledYBounds.y;
 
     if (xCheck || zCheck || yCheck){ //Hide points that are clipped
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     }
     
     if (showTransect){
-        gl_PointSize = isValid ? max(pointScale*5. , pointScale+80./gl_Position.w) : pointScale;
+        gl_PointSize = isValid ? max(pointScale*5., pointScale+80./gl_Position.w) : pointScale;
     }
     else{
         gl_PointSize =  pointScale;

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -47,9 +47,9 @@ vec3 computePosition(int vertexID) {
     int y = (vertexID % sliceSize) / width;
     int x = vertexID % width;
 
-    float px = (float(x) / float(width - 1)) - 0.5;
-    float py = ((float(y) / float(height - 1)) - 0.5) / aspectRatio;
-    float pz = ((float(z) / float(depth - 1)) - 0.5) * depthRatio;
+    float px = (float(x) - (float(width)/2.)) / 500.;
+    float py = (float(y) - (float(height)/2.)) / 500.;
+    float pz = (float(z) - (float(depth )/2.)) /500.;
 
     return vec3(px * 2.0, py * 2.0, pz);
 }

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -7,6 +7,7 @@ import { Slider as UISlider } from '@/components/ui/slider';
 import { SliderThumbs } from '@/components/ui/SliderThumbs';
 import { Button } from '../button';
 import { LuSettings } from "react-icons/lu";
+import { RxReset } from "react-icons/rx";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Input } from '../input';
 import {
@@ -282,7 +283,11 @@ const PointOptions = () =>{
           value={[scaleIntensity]}
       onValueChange={(vals:number[]) => setScaleIntensity(vals[0])}
       /></>}
-      <b>Resize Time Dimension</b>
+      <div className='relative'>
+        {timeScale != 1 && <RxReset className='text-lg cursor-pointer absolute top-0 left-0 hover:scale-90 transition-transform duration-100 ease-out' onClick={e=> setTimeScale(1)}/>}
+        <b>Resize Time Dimension</b>
+      </div>
+      
         <UISlider
             className='w-full mb-2 mt-2'
             min={0.05}


### PR DESCRIPTION
I got tired of writing today. So I implemented dynamic scaling for point clouds. 

The issue was I was constraining all the points in 3D space. So with very high resolutions they were overlapping which forced the fragment shader to do a LOT of calculations for each point overlapping the other. This will increasingly become a problem when I add support for higher resolution data. 

I updated the shader and axis lines to scale based on the data resolution. Now the points are equally spread out. Here I am animating 100 million points

<img width="1566" height="1217" alt="image" src="https://github.com/user-attachments/assets/1d3576b6-8b34-4662-8476-e222e127950f" />

You can see I get ~34% better performance compared to last points update. 

#292

