### PR TITLE
Sphere Displace

### DIFF
--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -36,7 +36,6 @@ const HorizontalAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolea
 
   const dimLengths = [dimArrays[0].length, dimArrays[1].length, dimArrays[2].length]
 
-
   const [xResolution, setXResolution] = useState<number>(7)
   const [yResolution, setYResolution] = useState<number>(7)
   const [zResolution, setZResolution] = useState<number>(7)

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates'
 import { ZarrDataset } from '@/components/zarr/ZarrLoaderLRU';
 import { useShallow } from 'zustand/shallow'
-import { sphereVertex, sphereFrag, flatSphereFrag } from '../textures/shaders'
+import { sphereVertex, sphereVertexFlat, sphereFrag, flatSphereFrag } from '../textures/shaders'
 import { parseUVCoords, GetTimeSeries, GetCurrentArray } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 
@@ -131,7 +131,7 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
                 displaceZero: {value: -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)},
                 displacement: {value: sphereDisplacement}
             },
-            vertexShader: sphereVertex,
+            vertexShader: isFlat ? sphereVertexFlat : sphereVertex,
             fragmentShader: isFlat ? flatSphereFrag : sphereFrag,
             blending: THREE.NormalBlending,
             side:THREE.FrontSide,

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { useAnalysisStore, useGlobalStore, usePlotStore } from '@/utils/GlobalStates'
 import { ZarrDataset } from '@/components/zarr/ZarrLoaderLRU';
 import { useShallow } from 'zustand/shallow'
-import { vertexShader, sphereFrag, flatSphereFrag } from '../textures/shaders'
+import { sphereVertex, sphereFrag, flatSphereFrag } from '../textures/shaders'
 import { parseUVCoords, GetTimeSeries, GetCurrentArray } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 
@@ -32,10 +32,6 @@ function deg2rad(deg: number){
 }
 
 export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE.DataTexture | null, ZarrDS: ZarrDataset}) => {
-    const {colormap, isFlat} = useGlobalStore(useShallow(state=> ({
-        colormap: state.colormap,
-        isFlat: state.isFlat
-    })))
     const {setPlotDim,updateDimCoords, updateTimeSeries} = useGlobalStore(useShallow(state=>({
       setPlotDim:state.setPlotDim, 
       updateDimCoords:state.updateDimCoords,
@@ -46,10 +42,13 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
       analysisArray: state.analysisArray
     })))
 
-    const {dimArrays,dimNames,dimUnits, timeSeries, dataShape, strides, flipY} = useGlobalStore(useShallow(state=>({
+    const {colormap, isFlat, dimArrays, dimNames, dimUnits, valueScales, timeSeries, dataShape, strides, flipY} = useGlobalStore(useShallow(state=>({
+        colormap: state.colormap,
+        isFlat: state.isFlat,  
         dimArrays:state.dimArrays,
         dimNames:state.dimNames,
         dimUnits:state.dimUnits,
+        valueScales: state.valueScales,
         timeSeries: state.timeSeries,
         dataShape: state.dataShape,
         strides: state.strides,
@@ -57,7 +56,7 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
     })))
 
     const {animate, animProg, cOffset, cScale, selectTS, lonExtent, latExtent, 
-      lonResolution, latResolution, nanColor, nanTransparency,
+      lonResolution, latResolution, nanColor, nanTransparency, sphereDisplacement, sphereResolution,
       getColorIdx, incrementColorIdx} = usePlotStore(useShallow(state=> ({
         animate: state.animate,
         animProg: state.animProg,
@@ -70,6 +69,8 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
         latResolution: state.latResolution,
         nanColor: state.nanColor,
         nanTransparency: state.nanTransparency,
+        sphereDisplacement: state.sphereDisplacement,
+        sphereResolution: state.sphereResolution,
         getColorIdx: state.getColorIdx,
         incrementColorIdx: state.incrementColorIdx
     })))
@@ -111,8 +112,7 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
       return [newLonBounds, newLatBounds]
     },[latExtent, lonExtent, lonResolution, latResolution])
 
-    const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, 9), []);
-    
+    const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, sphereResolution), [sphereResolution]);
     const shaderMaterial = useMemo(()=>{
         const shader = new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
@@ -127,20 +127,24 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
                 latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
                 lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
                 nanColor: {value: new THREE.Color(nanColor)},
-                nanAlpha: {value: 1 - nanTransparency}
+                nanAlpha: {value: 1 - nanTransparency},
+                displaceZero: {value: -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)},
+                displacement: {value: sphereDisplacement}
             },
-            vertexShader,
+            vertexShader: sphereVertex,
             fragmentShader: isFlat ? flatSphereFrag : sphereFrag,
             blending: THREE.NormalBlending,
             side:THREE.FrontSide,
             transparent: true,
-            depthWrite:false,
+            depthWrite:true,
 
         })
         return shader
     },[isFlat])
+
     const backMaterial = shaderMaterial.clone()
     backMaterial.side = THREE.BackSide;
+
     useEffect(()=>{
       if (shaderMaterial){
         const uniforms = shaderMaterial.uniforms;
@@ -155,6 +159,8 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
         uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
         uniforms.nanColor.value =  new THREE.Color(nanColor)
         uniforms.nanAlpha.value =  1 - nanTransparency
+        uniforms.displaceZero.value = -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)
+        uniforms.displacement.value = sphereDisplacement
       }
       if (backMaterial){
         const uniforms = backMaterial.uniforms;
@@ -169,8 +175,10 @@ export const Sphere = ({texture, ZarrDS} : {texture: THREE.Data3DTexture | THREE
         uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
         uniforms.nanColor.value =  new THREE.Color(nanColor)
         uniforms.nanAlpha.value =  1 - nanTransparency
+        uniforms.displaceZero.value = -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)
+        uniforms.displacement.value = sphereDisplacement
       }
-    },[texture, animProg, colormap, cOffset, cScale, animate, bounds, selectTS, lonBounds, latBounds, nanColor, nanTransparency])
+    },[texture, animProg, colormap, cOffset, cScale, animate, bounds, selectTS, lonBounds, latBounds, nanColor, nanTransparency, sphereDisplacement, valueScales])
     
     
     function HandleTimeSeries(event: THREE.Intersection){

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -4,6 +4,7 @@ import vertexShader from './vertex.glsl';
 import fragmentShader from './volFragment.glsl';
 import sphereFrag from './sphereFrag.glsl';
 import sphereVertex from './sphereVertex.glsl';
+import sphereVertexFlat from './sphereVertexFlat.glsl';
 import fragOpt from './fragmentOpt.glsl';
 import flatSphereFrag from './flatSphereFrag.glsl'
 import bordersFrag from './bordersFrag.glsl'
@@ -16,6 +17,7 @@ export {
     fragmentShader,
     sphereFrag,
     sphereVertex,
+    sphereVertexFlat,
     fragOpt,
     flatSphereFrag,
     bordersFrag,

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -3,6 +3,7 @@ import pointVert from './pointVertex.glsl';
 import vertexShader from './vertex.glsl';
 import fragmentShader from './volFragment.glsl';
 import sphereFrag from './sphereFrag.glsl';
+import sphereVertex from './sphereVertex.glsl';
 import fragOpt from './fragmentOpt.glsl';
 import flatSphereFrag from './flatSphereFrag.glsl'
 import bordersFrag from './bordersFrag.glsl'
@@ -14,6 +15,7 @@ export {
     vertexShader,
     fragmentShader,
     sphereFrag,
+    sphereVertex,
     fragOpt,
     flatSphereFrag,
     bordersFrag,

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -5,6 +5,7 @@ precision highp sampler3D;
 out vec4 color;
 
 in vec3 aPosition;
+in vec2 Vuv;
 
 uniform sampler3D map;
 uniform sampler2D cmap;

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -5,7 +5,6 @@ precision highp sampler3D;
 out vec4 color;
 
 in vec3 aPosition;
-in vec2 Vuv;
 
 uniform sampler3D map;
 uniform sampler2D cmap;
@@ -68,7 +67,5 @@ void main(){
         color = vec4(nanColor, 1.); // Black
         color.a = nanAlpha;
     }
-    
-    // color = vec4(sampleCoord, 0., 1.0);
 
 }

--- a/src/components/textures/shaders/sphereVertex.glsl
+++ b/src/components/textures/shaders/sphereVertex.glsl
@@ -1,0 +1,32 @@
+ // by Jeran Poehls
+
+uniform sampler3D map;
+uniform float displaceZero;
+uniform float displacement;
+uniform vec2 latBounds;
+uniform vec2 lonBounds;
+uniform float animateProg;
+
+vec2 giveUV(vec3 position){
+    vec3 n = normalize(position);
+    float latitude = asin(n.y);
+    float longitude = atan(n.z, n.x);
+    latitude = (latitude - latBounds.x)/(latBounds.y - latBounds.x);
+    longitude = (longitude - lonBounds.x)/(lonBounds.y - lonBounds.x);
+
+    return vec2(1.-longitude, latitude);
+}
+
+out vec2 Vuv;
+out vec3 aPosition;
+
+void main() {
+    vec2 uv = giveUV(position);
+    vec3 normal = normalize(position);
+    float dispStrength = texture(map, vec3(uv, animateProg)).r;
+    vec3 newPos = position + (normal * dispStrength * displacement);
+    aPosition = position; //Pass out position for sphere frag
+    Vuv = uv;
+    vec4 worldPos = modelViewMatrix * vec4( newPos, 1.0 );
+    gl_Position = projectionMatrix * worldPos;
+}

--- a/src/components/textures/shaders/sphereVertexFlat.glsl
+++ b/src/components/textures/shaders/sphereVertexFlat.glsl
@@ -1,11 +1,10 @@
  // by Jeran Poehls
 
-uniform sampler3D map;
+uniform sampler2D map;
 uniform float displaceZero;
 uniform float displacement;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
-uniform float animateProg;
 
 vec2 giveUV(vec3 position){
     vec3 n = normalize(position);
@@ -22,7 +21,7 @@ out vec3 aPosition;
 void main() {
     vec2 uv = giveUV(position);
     vec3 normal = normalize(position);
-    float dispStrength = texture(map, vec3(uv, animateProg)).r;
+    float dispStrength = texture(map, uv).r;
     vec3 newPos = position + (normal * dispStrength * displacement);
     aPosition = position; //Pass out position for sphere frag
     vec4 worldPos = modelViewMatrix * vec4( newPos, 1.0 );

--- a/src/components/textures/shaders/vertex.glsl
+++ b/src/components/textures/shaders/vertex.glsl
@@ -8,7 +8,7 @@ out vec2 Vuv;
 
 void main() {
     vec4 worldPos = modelViewMatrix * vec4( position, 1.0 );
-
+    
     aPosition = position; //Pass out position for sphere frag
     vOrigin = vec3( inverse( modelMatrix ) * vec4( cameraPosition, 1.0 ) ).xyz;
     vDirection = position - vOrigin;

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -302,6 +302,38 @@ const PointOptions = () =>{
   )
 }
 
+const SphereOptions = () =>{
+  const {sphereResolution, sphereDisplacement, setSphereResolution, setSphereDisplacement} = usePlotStore(useShallow(state => ({
+    sphereResolution: state.sphereResolution,
+    sphereDisplacement: state.sphereDisplacement,
+    setSphereResolution: state.setSphereResolution,
+    setSphereDisplacement: state.setSphereDisplacement
+  })))
+
+  return(<>
+  <div className='grid gap-y-[5px] items-center w-50 text-center'>
+    <b>Displace Surface</b>
+    <UISlider
+      min={0}
+      max={2}
+      step={0.05}
+      value={[sphereDisplacement]}
+      className='w-full mb-2'
+      onValueChange={(vals:number[]) => (setSphereDisplacement(vals[0]))}
+    />
+    <b>Displacement Resolution</b>
+    <UISlider
+      min={4}
+      max={20}
+      step={1}
+      value={[sphereResolution]}
+      className='w-full mb-2'
+      onValueChange={(vals:number[]) => (setSphereResolution(vals[0]))}
+    />
+  </div>
+  </>)
+
+}
 
 const SpatialExtent = () =>{
 
@@ -495,7 +527,7 @@ const AdjustPlot = () => {
         >
           {plotType === 'volume' && <VolumeOptions />}
           {plotType === 'point-cloud' && <PointOptions />}
-
+          {plotType === 'sphere' && <SphereOptions/>}
           {(plotType === 'volume' || plotType === 'point-cloud') && <DimSlicer />}
           <GlobalOptions />
         </PopoverContent>

--- a/src/utils/GlobalStates.ts
+++ b/src/utils/GlobalStates.ts
@@ -198,6 +198,8 @@ type PlotState ={
   max3DTextureSize: number;
   vTransferRange: boolean;
   vTransferScale: number;
+  sphereResolution: number;
+  sphereDisplacement: number;
 
 
   setQuality: (quality: number) => void;
@@ -243,6 +245,8 @@ type PlotState ={
   setMax3DTextureSize: (max3DTextureSize: number) => void;
   setVTransferRange: (vTransferRange: boolean) => void;
   setVTransferScale: (vTransferScale: number) => void;
+  setSphereResolution: (sphereResolution: number) => void;
+  setSphereDisplacement: (sphereDisplacement: number) => void;
 }
 
 export const usePlotStore = create<PlotState>((set, get) => ({
@@ -288,6 +292,8 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   max3DTextureSize: 2048,
   vTransferRange: false,
   vTransferScale: 1,
+  sphereResolution: 10,
+  sphereDisplacement: 0,
 
   setVTransferRange: (vTransferRange) => set({ vTransferRange }),
   setVTransferScale: (vTransferScale) => set({ vTransferScale }),
@@ -334,6 +340,8 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   getColorIdx: () => get().colorIdx,
   setMaxTextureSize: (maxTextureSize) => set({ maxTextureSize }),
   setMax3DTextureSize: (max3DTextureSize) => set({ max3DTextureSize }),
+  setSphereResolution: (sphereResolution) => set({ sphereResolution }),
+  setSphereDisplacement: (sphereDisplacement) => set({ sphereDisplacement }),
 }))
 
 


### PR DESCRIPTION
Needed to take a break from the spatial slicing branch and wanted to implement displacement for the sphere

![displacement](https://github.com/user-attachments/assets/8fabe277-b393-4574-bbac-0d2ea4ed0edf)

So now in the sphere  options you can displace the sphere for more visually interesting results. Doesn't work great with NaNs as those stay motionless. 

<img width="230" height="354" alt="image" src="https://github.com/user-attachments/assets/53d7a6e5-878f-4cc2-9c28-73036c7244ff" />
