### PR TITLE
Two var NaN-handling

### DIFF
--- a/src/components/computation/WGSLShaders.ts
+++ b/src/components/computation/WGSLShaders.ts
@@ -1,6 +1,8 @@
 export type Precision = 'f16' | 'f32';
 
+
 export const createShaders = (precision: Precision) => {
+    /// Install WGSL Literal extension in VS code for syntax highlighting
 
     const enableF16 = precision === 'f16' ? 'enable f16;' : '';
 
@@ -501,6 +503,11 @@ export const createShaders = (precision: Precision) => {
                 let cCoord = outX * xStride + outY * yStride;
                 for (var z: u32 = 0u; z < dimLength; z++) {
                     let inputIndex = cCoord + (z * zStride);
+                    let xi: f32 = f32(firstData[inputIndex]);
+                    let yi: f32 = f32(secondData[inputIndex]);
+                    if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     xSum += f32(firstData[inputIndex]);
                     ySum += f32(secondData[inputIndex]);
                 }
@@ -508,6 +515,11 @@ export const createShaders = (precision: Precision) => {
                 let cCoord = outX * xStride + outY * zStride;
                 for (var y: u32 = 0u; y < dimLength; y++) {
                     let inputIndex = cCoord + (y * yStride);
+                    let xi: f32 = f32(firstData[inputIndex]);
+                    let yi: f32 = f32(secondData[inputIndex]);
+                    if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     xSum += f32(firstData[inputIndex]);
                     ySum += f32(secondData[inputIndex]);
                 }
@@ -515,6 +527,11 @@ export const createShaders = (precision: Precision) => {
                 let cCoord = outX * yStride + outY * zStride;
                 for (var x: u32 = 0u; x < dimLength; x++) {
                     let inputIndex = cCoord + (x * xStride);
+                    let xi: f32 = f32(firstData[inputIndex]);
+                    let yi: f32 = f32(secondData[inputIndex]);
+                    if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     xSum += f32(firstData[inputIndex]);
                     ySum += f32(secondData[inputIndex]);
                 }
@@ -531,6 +548,9 @@ export const createShaders = (precision: Precision) => {
                     let inputIndex = cCoord + (z * zStride);
                     let xi: f32 = f32(firstData[inputIndex]);
                     let yi: f32 = f32(secondData[inputIndex]);
+                    if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     numSum += (xi - xMean)*(f32(yi) - yMean);
                     denomSum += (f32(yi) - yMean)*(f32(yi) - yMean);
                 }
@@ -540,6 +560,9 @@ export const createShaders = (precision: Precision) => {
                     let inputIndex = cCoord + (y * yStride);
                     let xi: f32 = f32(firstData[inputIndex]);
                     let yi: f32 = f32(secondData[inputIndex]);
+                    if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     numSum += (xi - xMean)*(f32(yi) - yMean);
                     denomSum += (f32(yi) - yMean)*(f32(yi) - yMean);
                 }
@@ -549,6 +572,9 @@ export const createShaders = (precision: Precision) => {
                     let inputIndex = cCoord + (x * xStride);
                     let xi: f32 = f32(firstData[inputIndex]);
                     let yi: f32 = f32(secondData[inputIndex]);
+                    if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     numSum += (xi - xMean)*(f32(yi) - yMean);
                     denomSum += (f32(yi) - yMean)*(f32(yi) - yMean);
                 }
@@ -615,6 +641,9 @@ export const createShaders = (precision: Precision) => {
                 let inputIndex = baseCoord + (i * iterStride);
                 let xi: f32 = f32(firstData[inputIndex]);
                 let yi: f32 = f32(secondData[inputIndex]);
+                if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                    continue;
+                }
                 xSum += xi;
                 ySum += yi;
             }
@@ -627,6 +656,9 @@ export const createShaders = (precision: Precision) => {
                 let inputIndex = baseCoord + (i * iterStride);
                 let xi: f32 = f32(firstData[inputIndex]);
                 let yi: f32 = f32(secondData[inputIndex]);
+                if (xi != xi || yi != yi){ //This only evaluates if a value is NaN
+                    continue;
+                }
                 numSum += (xi - xMean) * (yi - yMean);
             }
 
@@ -680,6 +712,9 @@ export const createShaders = (precision: Precision) => {
                     let inputIndex = cCoord + (z * zStride);
                     let xI = f32(firstData[inputIndex]);
                     let yI = f32(secondData[inputIndex]);
+                    if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     xSum += xI;
                     xxSum += xI * xI;
                     ySum += yI;
@@ -692,6 +727,9 @@ export const createShaders = (precision: Precision) => {
                     let inputIndex = cCoord + (y * yStride);
                     let xI = f32(firstData[inputIndex]);
                     let yI = f32(secondData[inputIndex]);
+                    if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     xSum += xI;
                     xxSum += xI * xI;
                     ySum += yI;
@@ -704,6 +742,9 @@ export const createShaders = (precision: Precision) => {
                     let inputIndex = cCoord + (x * xStride);
                     let xI = f32(firstData[inputIndex]);
                     let yI = f32(secondData[inputIndex]);
+                    if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                        continue;
+                    }
                     xSum += xI;
                     xxSum += xI * xI;
                     ySum += yI;
@@ -953,6 +994,9 @@ export const createShaders = (precision: Precision) => {
 
                             let xI = f32(firstData[newIdx]);
                             let yI = f32(secondData[newIdx]);
+                            if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                                continue;
+                            }
                             xSum += xI;
                             xxSum += xI * xI;
                             ySum += yI;
@@ -1053,6 +1097,9 @@ export const createShaders = (precision: Precision) => {
                             let newIdx = i32(globalIdx) + xOffset + yOffset + zOffset;
                             let xI = f32(firstData[newIdx]);
                             let yI = f32(secondData[newIdx]);
+                            if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                                continue;
+                            }
                             xSum += xI;    
                             ySum += yI;
                             count ++;
@@ -1078,6 +1125,9 @@ export const createShaders = (precision: Precision) => {
                             let newIdx = i32(globalIdx) + xOffset + yOffset + zOffset;
                             let xI = f32(firstData[newIdx]);
                             let yI = f32(secondData[newIdx]);
+                            if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                                continue;
+                            }
                             numSum += (xI - meanX) * (yI - meanY);
                             count ++;
                         }
@@ -1160,6 +1210,9 @@ export const createShaders = (precision: Precision) => {
                             let newIdx = i32(globalIdx) + xOffset + yOffset + zOffset;
                             let xI = f32(firstData[newIdx]);
                             let yI = f32(secondData[newIdx]);
+                            if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                                continue;
+                            }
                             xSum += xI;    
                             ySum += yI;
                             count ++;
@@ -1188,6 +1241,9 @@ export const createShaders = (precision: Precision) => {
                             let newIdx = i32(globalIdx) + xOffset + yOffset + zOffset;
                             let xI = f32(firstData[newIdx]);
                             let yI = f32(secondData[newIdx]);
+                            if (xI != xI || yI != yI){ //This only evaluates if a value is NaN
+                                continue;
+                            }
                             numSum += (xI - meanX)*(f32(yI) - meanY);
                             denomSum += (f32(yI) - meanY)*(f32(yI) - meanY);
                         }

--- a/src/components/ui/MainPanel/AnalysisOptions.tsx
+++ b/src/components/ui/MainPanel/AnalysisOptions.tsx
@@ -77,14 +77,15 @@ const webGPUError = <div className="m-0 p-5 font-sans flex-column justify-center
   </div>
 
 const AnalysisOptions = () => {
-  const {plotOn, variable, variables, dimNames, initStore, isFlat, setTimeSeries} = useGlobalStore(useShallow(state => ({
+  const {plotOn, variable, variables, dimNames, initStore, isFlat, setTimeSeries, setValueScales} = useGlobalStore(useShallow(state => ({
     plotOn: state.plotOn, 
     variable: state.variable,
     variables: state.variables,
     dimNames: state.dimNames,
     initStore: state.initStore,
     isFlat: state.isFlat,
-    setTimeSeries: state.setTimeSeries
+    setTimeSeries: state.setTimeSeries,
+    setValueScales: state.setValueScales
   })));
 
   const previousStore = useRef<string>(initStore)
@@ -93,7 +94,7 @@ const AnalysisOptions = () => {
   const {
     execute, operation, useTwo, kernelSize, kernelDepth,
     kernelOperation, axis, variable2, analysisMode,
-    reverseDirection,
+    reverseDirection, valueScalesOrig,
     setExecute, setAxis, setOperation, setUseTwo,
     setVariable2, setKernelSize, setKernelDepth,
     setKernelOperation, setAnalysisMode,
@@ -103,7 +104,7 @@ const AnalysisOptions = () => {
     execute: state.execute, operation: state.operation,
     useTwo: state.useTwo, kernelSize: state.kernelSize,
     kernelDepth: state.kernelDepth, kernelOperation: state.kernelOperation,
-    axis: state.axis, variable2: state.variable2,
+    axis: state.axis, variable2: state.variable2, valueScalesOrig: state.valueScalesOrig,
     analysisMode: state.analysisMode, reverseDirection: state.reverseDirection,
     setExecute: state.setExecute, setAxis: state.setAxis,
     setOperation: state.setOperation, setUseTwo: state.setUseTwo,
@@ -272,7 +273,7 @@ const AnalysisOptions = () => {
                             cursor: analysisMode ? 'pointer' : '',
                           }}
                           disabled={!analysisMode}
-                          onClick={e=>{useAnalysisStore.setState({ analysisMode: false, analysisDim: null })}}
+                          onClick={e=>{useAnalysisStore.setState({ analysisMode: false, analysisDim: null }); if(valueScalesOrig){setValueScales(valueScalesOrig)}}}
                         >
                           {analysisMode && <CiUndo 
                             size={20}


### PR DESCRIPTION
In the shaders, if a Nan is in an operation the result is Nan. For this reason I had told the shaders to ignore Nans.

However I didn't do this on the two var shaders.

So if I wanted to do a correlation of these two variables 

<img width="679" height="507" alt="image" src="https://github.com/user-attachments/assets/1c59b1d5-691a-4309-8b4a-eeddce073e77" />


<img width="583" height="512" alt="image" src="https://github.com/user-attachments/assets/3627c3c0-d8e6-40f8-a180-08d65880d8e2" />


Because kndvi has all NaNs for time steps. The entire output would be NaN.

But now you can analyze these two 

<img width="708" height="432" alt="image" src="https://github.com/user-attachments/assets/0d3f9130-2301-486d-8424-456df08e6db9" />


I also fixed a bug as the new faster reset method doesn't reset the colormap values. So that is sorted. 