### PR TITLE
Refetched Remote stores

### DIFF
--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -94,10 +94,10 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
   const [showDescriptionDialog, setShowDescriptionDialog] = useState<boolean>(false)
   const [openDescriptionPopover, setOpenDescriptionPopover] = useState<boolean>(false)
   
-  const { setInitStore } = useGlobalStore(
+  const { initStore, setInitStore } = useGlobalStore(
     useShallow((state) => ({
       setInitStore: state.setInitStore,
-      setVariable: state.setVariable,
+      initStore: state.initStore,
     }))
   );
 
@@ -201,7 +201,12 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
                 onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
                   e.preventDefault();
                   const input = e.currentTarget.elements[0] as HTMLInputElement;
-                  setInitStore(input.value);
+                  if (initStore != input.value){
+                    setInitStore(input.value);
+                  } else {
+                    useGlobalStore.getState().setStatus(null)
+                  }
+                  
                   if (input.value) {
                     if (popoverSide === 'top') {
                       setShowDescriptionDialog(true);

--- a/src/components/ui/MainPanel/MetaDataInfo.tsx
+++ b/src/components/ui/MainPanel/MetaDataInfo.tsx
@@ -401,7 +401,7 @@ const MetaDataInfo = ({ meta, metadata, setShowMeta, setOpenVariables, popoverSi
             </span>
           </div>
         }
-        {true && <Button
+        {!tooBig && <Button
           variant="pink"        
           className="cursor-pointer hover:scale-[1.05]"
           disabled={((is4D && idx4D == null) || smallCache)}


### PR DESCRIPTION
When refetching the same store, since the state didn't change it doesn't trigger the GetStore() function which hides the Fetching overlay. Closes #386 