### PR TITLE
Crispy Text

### DIFF
--- a/src/utils/ExportCanvas.tsx
+++ b/src/utils/ExportCanvas.tsx
@@ -16,7 +16,6 @@ const DrawComposite = (
     height: number,
     colors: {bgColor: string, textColor: string},
     animate=false,
-    preview=true,
 ): HTMLCanvasElement | undefined => {
 
     const {bgColor, textColor} = colors;


### PR DESCRIPTION
After trying an SVG implementation which also looked awful. I realized I could just render the text as a separate image in really high definition and then overlay that onto the animation. 

This now render text separately if it's an animation.

Additionally, the custom resolution and double resolution wasn't working so I fixed those so you can have more flexible resolutions for animations.