### PR TITLE
Match Flat Analysis Logic

### DIFF
--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -72,7 +72,6 @@ const FlatMap = ({textures, infoSetters, ZarrDS} : {textures : THREE.DataTexture
         return dataShape[1]/dataShape[2]
       }
     }, [axis, analysisMode] )
-
     const geometry = useMemo(()=>new THREE.PlaneGeometry(2,2*shapeRatio),[shapeRatio])
     const infoRef = useRef<boolean>(false)
     const lastUV = useRef<THREE.Vector2>(new THREE.Vector2(0,0))
@@ -205,7 +204,6 @@ const FlatMap = ({textures, infoSetters, ZarrDS} : {textures : THREE.DataTexture
         uniforms.selectTS.value = selectTS
       }
     },[cScale, cOffset, textures, colormap, animProg, nanColor, nanTransparency, bounds, selectTS])
-
 
   return (
     <>

--- a/src/components/textures/shaders/flatBlocksVert.glsl
+++ b/src/components/textures/shaders/flatBlocksVert.glsl
@@ -10,7 +10,7 @@ uniform float animateProg;
 #define PI 3.1415926535
 
 vec3 givePosition(vec2 uv) {
-    return vec3(uv.x*aspect, uv.y, 0.);
+    return vec3(uv.x*2., uv.y/aspect*2., 0.);
 }
 
 

--- a/src/components/textures/shaders/flatBlocksVert3D.glsl
+++ b/src/components/textures/shaders/flatBlocksVert3D.glsl
@@ -13,7 +13,7 @@ uniform float animateProg;
 #define PI 3.1415926535
 
 vec3 givePosition(vec2 uv) {
-    return vec3(uv.x*aspect, uv.y, 0.);
+    return vec3(uv.x*2., uv.y/aspect*2., 0.);
 }
 
 


### PR DESCRIPTION
The new Flat Blocks component didn't scale properly in analysis mode and didn't rotate with the data. Added the logic to match the behavior of the normal FlatMap mode. 

