### PR TITLE
Borders should now work with custom datasets as well.

### DIFF
--- a/src/components/plots/CountryBorders.tsx
+++ b/src/components/plots/CountryBorders.tsx
@@ -240,7 +240,7 @@ const CountryBorders = () => {
     return(
         <group
             rotation={[rotateFlat ? -Math.PI/2 : 0, 0, 0]}
-            scale={[globalScale, globalScale * (spherize ? 1 : aspectRatio), globalScale]}
+            scale={[globalScale, globalScale * (spherize ? 1 : 2 / aspectRatio), globalScale]}
         >
             <group 
                 visible={showBorders && !(analysisMode && axis != 0)} 


### PR DESCRIPTION
I had been playing around with adjusting borders to work with custom extents but forgot to revert the changes.

I needed to "square" the borders before applying the aspect ratio. 

<img width="690" height="752" alt="image" src="https://github.com/user-attachments/assets/966cbed4-48de-4b04-8280-9f96ff143d23" />

<img width="726" height="655" alt="image" src="https://github.com/user-attachments/assets/00a4d672-1e55-40c7-ab69-fd75aa555678" />
