### PR TITLE
NC Units were always undefined in colorbar 

### DIFF
--- a/src/components/ui/MainPanel/Dataset.tsx
+++ b/src/components/ui/MainPanel/Dataset.tsx
@@ -126,7 +126,6 @@ const Dataset = ({setOpenVariables} : {setOpenVariables: React.Dispatch<React.Se
       }, 0);
     }
   }, []);
-  console.log(activeOption)
   return (
     <>
     <Popover>

--- a/src/components/ui/MainPanel/Variables.tsx
+++ b/src/components/ui/MainPanel/Variables.tsx
@@ -52,11 +52,6 @@ const Variables = ({
     }))
   );
 
-  const {useNC, ncModule} = useZarrStore(useShallow(state => ({
-    useNC:state.useNC,
-    ncModule:state.ncModule
-  })))
-
   const [dimArrays, setDimArrays] = useState([[0],[0],[0]]);
   const [dimUnits, setDimUnits] = useState([null,null,null]);
   const [dimNames, setDimNames] = useState<string[]>(["Default"]);
@@ -142,7 +137,6 @@ const Variables = ({
         GetAttributes(selectedVar).then(e=>setMetadata(e));
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedVar, variables, zMeta, dimArrays, dimNames, dimUnits]);
 
   useEffect(()=>{

--- a/src/components/zarr/NCGetters.ts
+++ b/src/components/zarr/NCGetters.ts
@@ -32,7 +32,7 @@ export async function GetNCDims(variable: string){
     return {dimNames, dimArrays, dimUnits};
 }
 
-export async function GetNCAttributes(thisVariable? : string){
+export async function GetNCMetadata(thisVariable? : string){
     const {ncModule} = useZarrStore.getState();
     const {cache} = useCacheStore.getState();
     const {initStore, variable} = useGlobalStore.getState();

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -2,7 +2,7 @@ import * as zarr from "zarrita";
 import {  ArrayMinMax } from "@/utils/HelperFuncs";
 import { useGlobalStore, useZarrStore, useErrorStore, useCacheStore } from "@/utils/GlobalStates";
 import { gzipSync, decompressSync } from 'fflate';
-import { GetNCArray, GetNCAttributes } from "./NCGetters";
+import { GetNCArray, GetNCMetadata } from "./NCGetters";
 import { GetZarrAttributes, GetZarrArray } from "./ZarrGetters";
 
 export const ZARR_STORES = {
@@ -220,12 +220,12 @@ export async function GetAttributes(thisVariable? : string){
 	const cacheName = `${initStore}_${thisVariable?? variable}_meta`
 	if (cache.has(cacheName)){
 		const meta = cache.get(cacheName)
-		return meta;
+		return useNC ? meta.attributes : meta;
 	}
 	else {
 		if (useNC){
-			const meta = GetNCAttributes(thisVariable)
-			return meta
+			const meta = await GetNCMetadata(thisVariable)
+			return meta.attributes
 		} else {
 			const meta = await GetZarrAttributes(thisVariable)
 			return meta

--- a/src/utils/ExportCanvas.tsx
+++ b/src/utils/ExportCanvas.tsx
@@ -9,6 +9,8 @@ import { useShallow } from 'zustand/shallow';
 import { lerp } from 'three/src/math/MathUtils.js';
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { deg2rad } from './HelperFuncs';
+
+
 const DrawComposite = (
     compositeCanvas: HTMLCanvasElement,
     gl: THREE.WebGLRenderer,
@@ -137,7 +139,7 @@ const DrawComposite = (
             ctx.fillStyle = textColor
             ctx.font = `${unitSize}px "Segoe UI" bold`
             ctx.textAlign = 'center'
-            const cbarString = `${cbarLabel?? variable} [${cbarUnits?? "undefined"}]`
+            const cbarString = `${cbarLabel?? variable} [${cbarUnits?? metadata?.units}]`
             ctx.fillText(cbarString, cbarStartPos+cbarWidth/2, cbarTop-unitSize-4)
         }
     }


### PR DESCRIPTION
The getter behavior for NC and Zarr was different which caused this. Also updated the export to properly use the correct valeus when left blank. 