### PR TITLE
update useTime in previews

### DIFF
--- a/src/components/plots/KeyFramePreviewer.tsx
+++ b/src/components/plots/KeyFramePreviewer.tsx
@@ -153,7 +153,10 @@ export const KeyFramePreviewer = () => {
 
     // PREVIEW ANIMATION
     useEffect(()=>{
-        if (!keyFrames || isAnimating.current) return;
+        if (!keyFrames || !previewKeyFrames){ 
+            isAnimating.current = false;
+            return;
+        }
         const {animProg, setAnimProg} = usePlotStore.getState()
         originalAnimProg.current = animProg
         const keyFrameList = Array.from(keyFrames.keys()).sort((a, b) => a - b)
@@ -167,6 +170,7 @@ export const KeyFramePreviewer = () => {
             if (frame > frames) {
                 clearInterval(intervalRef.current as NodeJS.Timeout);
                 isAnimating.current = false;
+                useImageExportStore.setState({previewKeyFrames:false})
                 setAnimProg(originalAnimProg.current)
                 return;
             }

--- a/src/components/ui/KeyFrames.tsx
+++ b/src/components/ui/KeyFrames.tsx
@@ -68,9 +68,9 @@ const KeyFrames = () => {
         animProg:state.animProg, setAnimProg:state.setAnimProg
     })))
 
-    const {keyFrames, frames, useTime, frameRate, timeRate, orbit, currentFrame, setCurrentFrame, setFrames} = useImageExportStore(useShallow(state=>({
+    const {keyFrames, frames, useTime, frameRate, timeRate, orbit, currentFrame, previewKeyFrames, setCurrentFrame, setFrames} = useImageExportStore(useShallow(state=>({
         keyFrames:state.keyFrames, frames:state.frames, orbit:state.orbit, currentFrame:state.currentFrame,
-        useTime:state.useTime, frameRate:state.frameRate, timeRate:state.timeRate, setCurrentFrame:state.setCurrentFrame, setFrames:state.setFrames
+        useTime:state.useTime, frameRate:state.frameRate, timeRate:state.timeRate, previewKeyFrames:state.previewKeyFrames, setCurrentFrame:state.setCurrentFrame, setFrames:state.setFrames
     })))
     const timeRatio = timeRate/frameRate
     const keyFrameList = keyFrames ? Array.from(keyFrames.keys()).sort((a, b) => a - b) : null;
@@ -199,7 +199,7 @@ const KeyFrames = () => {
                     variant="outline"
 					onClick={()=>{useImageExportStore.getState().PreviewKeyFrames()}}
 				>
-                    <MdPreview className='size-6'/> { MdLg === "lg" ? 'Preview' : ''}
+                    <MdPreview className='size-6'/> { MdLg === "lg" ? (previewKeyFrames ? 'Stop Preview' : "Preview") : ''}
 				</Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" align="start">


### PR DESCRIPTION
useTime was in a conditional it shouldn't have been in for the preview animation function. 

Also made preview behave as boolean instead of switch so it can be toggled off in the instances when someone accidentally previews very long animations at low framerates 