### PR TITLE
removed maps on large arrays

### DIFF
--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -171,12 +171,12 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
             let _scales;
             const thisShape = dataShape.length > 2 ? dataShape.filter((_, idx) => idx !== axis) : dataShape;
             const textureData = new Uint8Array(newArray.length)
+            const range = (maxVal - minVal)
             for (let i = 0; i < newArray.length; i++){
-                const val = newArray[i]
-                if (isNaN(val)){
+                const normed = (newArray[i] - minVal) / range;
+                if (isNaN(normed)){
                     textureData[i] = 255;
                 } else {
-                    const normed = (newArray[i] - minVal) / (maxVal - minVal);
                     textureData[i] = normed * 254;
                 }
             };
@@ -205,12 +205,12 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
             const newArray = await CustomShader(dataArray, shapeInfo, kernelParams, axis, customShader?? "") as Float16Array
             const {minVal, maxVal} = valueScales
             const textureData = new Uint8Array(newArray.length)
+            const range = (maxVal - minVal)
             for (let i = 0; i < newArray.length; i++){
-                const val = newArray[i]
-                if (isNaN(val)){
+                const normed = (newArray[i] - minVal) / range;
+                if (isNaN(normed)){
                     textureData[i] = 255;
                 } else {
-                    const normed = (newArray[i] - minVal) / (maxVal - minVal);
                     textureData[i] = normed * 254;
                 }
             };

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -13,12 +13,12 @@ function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number})
     const data = array.data;
     const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data )
     const textureData = new Uint8Array(data.length)
+    const range = (maxVal - minVal)
     for (let i = 0; i < data.length; i++){
-      const val = data[i]
-      if (isNaN(val)){
+      const normed = (data[i] - minVal) / range;
+      if (isNaN(normed)){
         textureData[i] = 255;
       } else {
-        const normed = (data[i] - minVal) / (maxVal - minVal);
         textureData[i] = normed * 254;
       }
     };


### PR DESCRIPTION
I did some reading and learned for loops are more efficient than mapping.

There were two places where I used a map on the data array. So I swapped those for for loops. There is a noticeable speed-up in texture creation for massive datasets. 