### PR TITLE
local prod fix

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ import path from 'path';
 const isProd = process.env.NODE_ENV === 'production';
 const basePath = isProd ? (process.env.BASE_PATH || '') : '';
 // const targetFolder = process.env.TARGET_FOLDER || '';
-const assetPrefix = isProd ? (basePath ? `${basePath.replace(/\/$/, '')}/` : './') : '';
+const assetPrefix = isProd ? (basePath ? `${basePath.replace(/\/$/, '')}/` : '') : '';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/src/components/ui/MainPanel/LocalNetCDF.tsx
+++ b/src/components/ui/MainPanel/LocalNetCDF.tsx
@@ -45,7 +45,7 @@ const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
           data.getFullMetadata()
         ])
         useGlobalStore.setState({variables: Object.keys(variables), zMeta: metadata, initStore:`local_${file.name}`})
-        useZarrStore.setState({useNC: true, ncModule: data})
+        useZarrStore.setState({ fetchNC:true, useNC: true, ncModule: data})
         const titleDescription = {
           title: attrs.title?? file.name,
           description: attrs.history?? ''


### PR DESCRIPTION
You can inspect `production` by doing

- `npm run build`
- `npx serve@latest out` 

without `fetchNC:true` attributes for netcdf are void. Using it gives 
<img width="694" height="607" alt="Screenshot 2026-03-02 at 11 42 25" src="https://github.com/user-attachments/assets/4426967e-9a1b-4bf0-b19c-d39a1a39c851" />

even though is still looking for the Attributes in the zarr path

<img width="1262" height="176" alt="Screenshot 2026-03-02 at 11 41 23" src="https://github.com/user-attachments/assets/97ca1004-87db-4e0f-b423-ddb82ae06fac" />

the logic for `fetchNC:true, useNC: true` maybe could be unified? somehow? It seems like is not consistent in the sense of which one comes first or when should they be triggered, hence the logs.
