### PR TITLE
Cam Tweak and Other Tweaks

### DIFF
--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -69,7 +69,7 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
         xSlice: state.xSlice
     })));
     const isMounted = useRef(false)
-    
+
     useEffect(() => {
         if (!plotOn){
             return
@@ -198,6 +198,9 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
     }, [execute]); 
 
     useEffect(()=>{
+        if (!plotOn){
+            return
+        }
         const shapeInfo = { dataShape, outputShape, strides};
         const kernelParams = { kernelDepth, kernelSize };
 

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -127,8 +127,8 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
       controls.update() //Need this extra update to clear the internal inertia buffer. Cant seem to access it in code. 
       invalidate()
       cam.position.copy(cameraPosition)
-      cam.lookAt(new THREE.Vector3(0, 0, 0))
-      //@ts-ignore the check means it is ortho
+      controls.target.copy(new THREE.Vector3(0, 0, 0))
+      //@ts-ignore the check means cam will have that method
       if (useOrtho) cam.updateProjectionMatrix()
       else cam.updateMatrix()
       controls.update()

--- a/src/components/zarr/ZarrLoaderLRU.ts
+++ b/src/components/zarr/ZarrLoaderLRU.ts
@@ -152,21 +152,20 @@ const maxRetries = 10;
 const retryDelay = 500; // 0.5 seconds in milliseconds
 
 export async function GetStore(storePath: string): Promise<zarr.Group<zarr.FetchStore | zarr.Listable<zarr.FetchStore>> | undefined>{
-		const {setStatus} = useGlobalStore.getState();
 		for (let attempt = 0; attempt <= maxRetries; attempt++) {
 			try {
 				const d_store = zarr.tryWithConsolidated(
 					new zarr.FetchStore(storePath)
 				);
 				const gs = await d_store.then(store => zarr.open(store, {kind: 'group'}));
-				setStatus(null)
+				useGlobalStore.setState({ status: null })
 				return gs;
 			} catch (error) {
 				// If this is the final attempt, handle the error
 				if (attempt === maxRetries) {
 					if (storePath.slice(0,5) != 'local'){
 						useErrorStore.getState().setError('zarrFetch')
-						setStatus(null)
+						useGlobalStore.setState({ status: null })
 					}
 					throw new ZarrError(`Failed to initialize store at ${storePath}`, error);
 				}


### PR DESCRIPTION
The axis selector of the camera was telling the camera to look at 0,0,0 which is actually the orbit point of the controller. So if you panned the camera at all, when selecting an axis viewpoint it would look at the new instead of the global center. Fixed that

There was a weird issue in dev that popped up, the `GetStore` method is called in `Zarrstore` which imports from the `globalstore`. So initializing `Zarrstore` tried to pull from `Globalstore` too early. I removed the `useglobalstore` import from `Getstore` which seems to have provided enough of a  buffer for `globalstore` to initialize. 

Another weird issue was that now the custom shader webGPU logic was being fired and causing a crash. So simply added the same check that the non custom hook uses. 