### PR TITLE
Scale UV Cube

### DIFF
--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -7,6 +7,7 @@ import { useShallow } from 'zustand/shallow';
 import { invalidate, useFrame } from '@react-three/fiber';
 import { deg2rad } from '@/utils/HelperFuncs';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
+import { UVCube } from '@/components/plots'
 
 interface DataCubeProps {
   volTexture: THREE.Data3DTexture[] | THREE.DataTexture[] | null,
@@ -109,10 +110,9 @@ export const DataCube = ({ volTexture }: DataCubeProps ) => {
           .invert();
     })
   return (
-    <>
-    <mesh ref={meshRef} geometry={geometry} scale={[1,flipY ? -1: 1,1]}>
-      <primitive attach="material" object={shaderMaterial} />
-    </mesh>
-    </>
+    <group>
+      <mesh ref={meshRef} geometry={geometry} material={shaderMaterial} scale={[1,flipY ? -1: 1,1]}/>
+      <UVCube />
+    </group>
   )
 }

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -230,10 +230,7 @@ const Plot = () => {
         <ExportCanvas show={show}/>
         {show && <AxisLines />}
         {plotType == "volume" && show && 
-          <>
             <DataCube volTexture={textures}/>
-            <UVCube />
-          </>
         }
         {plotType == "point-cloud" && show &&
           <>

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -8,135 +8,33 @@ import { useShallow } from 'zustand/shallow';
 import { parseUVCoords, getUnitAxis, GetTimeSeries, GetCurrentArray, deg2rad } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
+import { UVCube } from './UVCube';
 
 interface PCProps {
   texture: THREE.Data3DTexture[] | null,
   colormap: THREE.DataTexture
 }
 
-interface dimensionsProps{
-  width: number;
-  height: number;
-  depth: number;
-}
+const MappingCube = () =>{
 
-interface pointSetters{
-  setPoints: React.Dispatch<React.SetStateAction<Record<string, number>>>;
-  setStride: React.Dispatch<React.SetStateAction<number>>;
-  setDimWidth: React.Dispatch<React.SetStateAction<number>>;
-}
-
-const MappingCube = ({dimensions, setters} : {dimensions: dimensionsProps, setters:pointSetters}) =>{
-  const {width, height, depth} = dimensions;
-  const {setPoints, setStride, setDimWidth} = setters;
-  const selectTS = usePlotStore(state => state.selectTS)
-
-  const {dimArrays, dimUnits, dimNames, strides, dataShape, setPlotDim, setTimeSeries, updateTimeSeries, setDimCoords, updateDimCoords} = useGlobalStore(useShallow(state => ({
-    dimArrays: state.dimArrays,
-    dimUnits: state.dimUnits,
-    dimNames: state.dimNames,
-    strides: state.strides,
+  const {dataShape} = useGlobalStore(useShallow(state => ({
     dataShape: state.dataShape,
-    setPlotDim: state.setPlotDim,
-    setTimeSeries: state.setTimeSeries,
-    updateTimeSeries: state.updateTimeSeries,
-    setDimCoords: state.setDimCoords,
-    updateDimCoords: state.updateDimCoords
-  })))
-  const {analysisMode, analysisArray} = useAnalysisStore(useShallow(state=> ({
-    analysisMode: state.analysisMode,
-    analysisArray: state.analysisArray
   })))
 
-  const {timeScale, zSlice, ySlice, xSlice, getColorIdx, incrementColorIdx} = usePlotStore(useShallow(state=> ({
+  const {timeScale} = usePlotStore(useShallow(state=> ({
     timeScale: state.timeScale,
-    zSlice: state.zSlice,
-    ySlice: state.ySlice,
-    xSlice: state.xSlice,
-    getColorIdx: state.getColorIdx,
-    incrementColorIdx: state.incrementColorIdx
   })))
 
-  const dimSlices = [
-    dimArrays[0].slice(zSlice[0], zSlice[1] ? zSlice[1] : undefined),
-    dimArrays[1].slice(ySlice[0], ySlice[1] ? ySlice[1] : undefined),
-    dimArrays.length > 2 ? dimArrays[2].slice(xSlice[0], xSlice[1] ? xSlice[1] : undefined) : [],
-  ]
-  const lastNormal = useRef<number | null> ( null )
   const globalScale = dataShape[2]/500
   const offset = 1/500; //I don't really understand that. But the cube is off by one pixel in each dimension
   
   const depthRatio = useMemo(()=>dataShape[0]/dataShape[2]*timeScale,[dataShape, timeScale]);
   const shapeRatio = useMemo(()=>dataShape[1]/dataShape[2], [dataShape])
-  function HandleTimeSeries(event: THREE.Intersection){
-      if (!selectTS){
-        return
-      }
-      const uv = event.uv!;
-      const normal = event.normal!;
-      const dimAxis = getUnitAxis(normal);
-      if (dimAxis != lastNormal.current){
-        setTimeSeries({}); //Clear timeseries if new axis
-        setDimCoords({});
-        setPoints({})
-      }
-      lastNormal.current = dimAxis;
-      const tempTS = GetTimeSeries({data: analysisMode? analysisArray : GetCurrentArray(), shape: dataShape, stride: strides},{uv,normal})
-      const plotDim = (normal.toArray()).map((val, idx) => {
-        if (Math.abs(val) > 0) {
-          return idx;
-        }
-        return null;}).filter(idx => idx !== null);
-      setPlotDim(2-plotDim[0]) //I think this 2 is only if there are 3-dims. Need to rework the logic
-      const coordUV = parseUVCoords({normal:normal,uv:uv})
-      let dimCoords = coordUV.map((val,idx)=>val ? dimSlices[idx][Math.round(val*dimSlices[idx].length-.5)] : null)
-      const thisDimNames = dimNames.filter((_,idx)=> dimCoords[idx] !== null)
-      const thisDimUnits = dimUnits.filter((_,idx)=> dimCoords[idx] !== null)
-      dimCoords = dimCoords.filter(val => val !== null)
-      const tsID = `${dimCoords[0]}_${dimCoords[1]}`
-      const tsObj = {
-        color:evaluate_cmap(getColorIdx()/10,"Paired"),
-        data:tempTS
-      }
-      incrementColorIdx();
-      updateTimeSeries({ [tsID] : tsObj})
-      const dimObj = {
-        first:{
-          name:thisDimNames[0],
-          loc:dimCoords[0] ?? 0,
-          units:thisDimUnits[0]
-        },
-        second:{
-          name:thisDimNames[1],
-          loc:dimCoords[1] ?? 0,
-          units:thisDimUnits[1]
-        },
-        plot:{
-          units:dimUnits[2-plotDim[0]]
-        }
-      }
-      updateDimCoords({[tsID] : dimObj})
-      const dims = [depth, height, width].filter((_,idx)=> coordUV[idx] != null)
-      const dimWidth = [depth, height, width].filter((_,idx)=> coordUV[idx] == null)
-      const newUV = coordUV.filter((v)=> v != null)
-      const thisStride = strides.filter((_,idx)=> coordUV[idx] != null)
-      const uIdx = Math.round((newUV[0])*dims[0]-.5)
-      const vIdx = Math.round(newUV[1]*dims[1]-.5)
-      const newIdx = uIdx * thisStride[0] + vIdx * thisStride[1]
-      const dimStride = strides.filter((_,idx)=> coordUV[idx] == null)
-      setDimWidth(dimWidth[0])
-      setPoints(prevItems => {
-            const newEntry = {[tsID] : newIdx}
-            const updated = {...newEntry, ...prevItems};
-            return updated; // keep only first 10 items
-          })
-      setStride(dimStride[0])        
-    }
+
   return(
-    <mesh scale={[2*globalScale, 2*shapeRatio*globalScale, 2*depthRatio*globalScale]} position={[-offset, -offset, offset]} onClick={HandleTimeSeries}>
-        <boxGeometry />
-        <meshBasicMaterial transparent opacity={0}/>
-    </mesh>
+    <group position={[-offset, -offset, -offset]}>
+      <UVCube scale={new THREE.Vector3(2*globalScale, 2*shapeRatio*globalScale, 2*depthRatio*globalScale)} />
+    </group>
   )
 }
 
@@ -277,7 +175,7 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       <mesh scale={[1,flipY ? -1:1, 1]} >
         <points geometry={geometry} material={shaderMaterial} frustumCulled={false}/>
       </mesh>
-      <MappingCube dimensions={{width,height,depth}} setters={{setPoints:setPointsObj, setStride, setDimWidth}}/>
+      <MappingCube/>
       </>
     );
   }

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -165,7 +165,7 @@ export const UVCube = ( {scale} : {scale?:THREE.Vector3} )=>{
     )
     const position = new THREE.Vector3(xPos, yPos * aspect, zPos * depth)
     return {geometry, position}
-  }, [xRange, yRange, zRange]);
+  }, [xRange, yRange, zRange, shape]);
 
   useEffect(() => {
     return () => {

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -61,7 +61,7 @@ const UpdateUVs = (
   }
 
 
-export const UVCube = ( )=>{
+export const UVCube = ( {scale} : {scale?:THREE.Vector3} )=>{
 
   const {setTimeSeries,setPlotDim,setDimCoords, updateTimeSeries, 
     updateDimCoords} = useGlobalStore(
@@ -174,7 +174,7 @@ export const UVCube = ( )=>{
   }, []);
 
   return (
-      <mesh geometry={geometry} position={position} scale={shape} onClick={(e) => {
+      <mesh geometry={geometry} position={position} scale={scale??shape} onClick={(e) => {
         e.stopPropagation();
         if (e.intersections.length > 0 && selectTS) {
           HandleTimeSeries(e.intersections[0]);

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -7,6 +7,60 @@ import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow';
 import { evaluate_cmap } from 'js-colormaps-es';
 
+function normalizeUV(uv:number, scale:number, pos:number){
+  return (uv*scale) + (pos-0.5*scale+0.5)
+}
+
+function updateFace(
+  startID:number, 
+  xData:{pos:number, scale:number},
+  yData:{pos:number, scale:number}, 
+  uvs:THREE.BufferAttribute | THREE.InterleavedBufferAttribute){
+  for (let i=startID; i < startID+4; i++){
+    const thisX = uvs.getX(i)
+    const thisY = uvs.getY(i)
+    const newX = normalizeUV(thisX, xData.scale, xData.pos)
+    const newY = normalizeUV(thisY, yData.scale, yData.pos)
+    uvs.setX(i,newX)
+    uvs.setY(i,newY)
+  }
+}
+
+
+const UpdateUVs = (
+  geometry: THREE.BoxGeometry, 
+  xData:{
+    xPos: number,
+    xScale: number
+  }, 
+  yData:{ 
+    yPos: number,
+    yScale: number
+  },
+  zData:{
+    zPos: number,
+    zScale: number
+  }) => {
+  const uvs = geometry.attributes.uv;
+  const {xPos, xScale} = xData;
+  const {yPos, yScale} = yData;
+  const {zPos, zScale} = zData;
+  //X+
+  updateFace(0, {pos:zPos, scale:zScale}, {pos:yPos, scale:yScale}, uvs)
+  //X-
+  updateFace(4, {pos:zPos, scale:zScale}, {pos:yPos, scale:yScale}, uvs)
+  //Y+
+  updateFace(8, {pos:xPos, scale:xScale}, {pos:zPos, scale:zScale}, uvs)
+  //Y-
+  updateFace(12, {pos:xPos, scale:xScale}, {pos:zPos, scale:zScale}, uvs)
+  //Z+
+  updateFace(16, {pos:xPos, scale:xScale}, {pos:yPos, scale:yScale}, uvs)
+  //Z-
+  updateFace(20, {pos:xPos, scale:xScale}, {pos:yPos, scale:yScale}, uvs)
+
+  }
+
+
 export const UVCube = ( )=>{
 
   const {setTimeSeries,setPlotDim,setDimCoords, updateTimeSeries, 
@@ -91,9 +145,9 @@ export const UVCube = ( )=>{
   }
 
   const {geometry, position} = useMemo(() => {
-    const xScale = xRange[1] - xRange[0]
-    const yScale = yRange[1] - yRange[0]
-    const zScale = zRange[1] - zRange[0]
+    const xScale = (xRange[1] - xRange[0])/2
+    const yScale = (yRange[1] - yRange[0])/2
+    const zScale = (zRange[1] - zRange[0])/2
 
     const aspect = shape.y/shape.x;
     const depth = shape.z/shape.x;
@@ -102,10 +156,15 @@ export const UVCube = ( )=>{
     const yPos = (yRange[1] + yRange[0]) / 2
     const zPos = (zRange[1] + zRange[0]) / 2
 
-    const geometry = new THREE.BoxGeometry(xScale/2, yScale/2, zScale/2)
+    const geometry = new THREE.BoxGeometry(xScale, yScale, zScale)
+    UpdateUVs(
+      geometry,
+      {xPos:xPos/2,xScale},
+      {yPos:yPos/2,yScale},
+      {zPos:-zPos/2, zScale}
+    )
     const position = new THREE.Vector3(xPos, yPos * aspect, zPos * depth)
     return {geometry, position}
-  
   }, [xRange, yRange, zRange]);
 
   useEffect(() => {
@@ -122,11 +181,11 @@ export const UVCube = ( )=>{
         }
       }}>
         <meshBasicMaterial 
-          // colorWrite={false}
-          // depthWrite={false}
+          colorWrite={false}
+          depthWrite={false}
           transparent 
-          opacity={1}
         />
       </mesh>
   )
 }
+

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -34,7 +34,8 @@ export const UVCube = ( )=>{
       dimUnits:state.dimUnits
     })))
   
-  const {selectTS, getColorIdx, incrementColorIdx} = usePlotStore(useShallow(state => ({
+  const {selectTS, xRange, yRange, zRange,getColorIdx, incrementColorIdx} = usePlotStore(useShallow(state => ({
+    xRange: state.xRange, yRange: state.yRange, zRange:state.zRange,
     selectTS: state.selectTS,
     getColorIdx: state.getColorIdx,
     incrementColorIdx: state.incrementColorIdx
@@ -43,7 +44,6 @@ export const UVCube = ( )=>{
   const lastNormal = useRef<number | null>( 0 )
 
   function HandleTimeSeries(event: THREE.Intersection){
-    const point = event.point;
     const uv = event.uv!;
     const normal = event.normal!;
     const dimAxis = getUnitAxis(normal);
@@ -90,7 +90,23 @@ export const UVCube = ( )=>{
     updateDimCoords({[tsID] : dimObj})
   }
 
-  const geometry = useMemo(() => new THREE.BoxGeometry(1, 1, 1), []);
+  const {geometry, position} = useMemo(() => {
+    const xScale = xRange[1] - xRange[0]
+    const yScale = yRange[1] - yRange[0]
+    const zScale = zRange[1] - zRange[0]
+
+    const aspect = shape.y/shape.x;
+    const depth = shape.z/shape.x;
+
+    const xPos = (xRange[1] + xRange[0]) / 2
+    const yPos = (yRange[1] + yRange[0]) / 2
+    const zPos = (zRange[1] + zRange[0]) / 2
+
+    const geometry = new THREE.BoxGeometry(xScale/2, yScale/2, zScale/2)
+    const position = new THREE.Vector3(xPos, yPos * aspect, zPos * depth)
+    return {geometry, position}
+  
+  }, [xRange, yRange, zRange]);
 
   useEffect(() => {
     return () => {
@@ -99,15 +115,18 @@ export const UVCube = ( )=>{
   }, []);
 
   return (
-    <>
-      <mesh geometry={geometry} scale={shape} onClick={(e) => {
+      <mesh geometry={geometry} position={position} scale={shape} onClick={(e) => {
         e.stopPropagation();
         if (e.intersections.length > 0 && selectTS) {
           HandleTimeSeries(e.intersections[0]);
         }
       }}>
-        <meshBasicMaterial transparent opacity={0} />
+        <meshBasicMaterial 
+          // colorWrite={false}
+          // depthWrite={false}
+          transparent 
+          opacity={1}
+        />
       </mesh>
-    </>
   )
 }


### PR DESCRIPTION
Although there is trimming of axis', this trimming was never applied to the invisible cube used for mouse events. So if you trimmed an axis and tried to click a point on the new surface, Unless you were looking perfectly straight on, the mouse event would miss or even hit a different face. 

This update scales the UV cube to match the trimming of the axis. It also normalizes the UV values to their original global space.

I also removed the UV Cube used in the Pointcloud component and replaced it with the one used for the volume cube. The only change needed was to added a scaling parameter so it can scale with the pointclouds. 