### PR TITLE
optional remote store

### DIFF
--- a/src/app/ClientRoot.tsx
+++ b/src/app/ClientRoot.tsx
@@ -8,6 +8,7 @@ import HomeButton from "@/components/ui/Elements/HomeButton";
 import MobileUIHider from "@/components/ui/MobileUIHider";
 import ThemeSwitch from "@/components/ui/Elements/ThemeSwitch";
 import { BrowZarrPopover } from "./BrowZarrPopover";
+import { StoreInitializer } from "@/components/StoreInitializer";
 
 export default function ClientRoot({
 	children,
@@ -21,6 +22,7 @@ export default function ClientRoot({
 			defaultTheme="system"
 			disableTransitionOnChange
 		>
+			<StoreInitializer />
 			<MobileUIHider />
 			{/* left menu */}
 			<div className="fixed top-2 left-2 z-50 flex items-center gap-2">

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { useGlobalStore } from "@/GlobalStates/GlobalStore";
+import { useZarrStore } from '@/GlobalStates/ZarrStore';
+import { useShallow } from 'zustand/shallow';
+import { isRemoteStore } from '@/utils/isRemoteStore';
+
+function StoreInitializerInner() {
+  const searchParams = useSearchParams();
+  const setInitStore = useGlobalStore(s => s.setInitStore);
+  const { setUseNC, setFetchNC } = useZarrStore(useShallow(s => ({
+    setUseNC: s.setUseNC,
+    setFetchNC: s.setFetchNC,
+  })));
+
+  useEffect(() => {
+    const store = searchParams.get("store");
+    if (!store) return;
+
+    const isNC = searchParams.get("format") === "nc";
+    setUseNC(isNC);
+    setFetchNC(isNC);
+    setInitStore(isRemoteStore(store) ? store : `local:${store}`);
+  }, []);
+
+  return null;
+}
+
+export function StoreInitializer() {
+  return (
+    <Suspense fallback={null}>
+      <StoreInitializerInner />
+    </Suspense>
+  );
+}

--- a/src/utils/isRemoteStore.ts
+++ b/src/utils/isRemoteStore.ts
@@ -1,0 +1,5 @@
+export const REMOTE_PROTOCOLS = ['http://', 'https://', 's3://', 'gs://', 'ftp://']
+
+export function isRemoteStore(path: string): boolean {
+  return REMOTE_PROTOCOLS.some(p => path.toLowerCase().startsWith(p));
+}


### PR DESCRIPTION
this should allows us to do things like

```
https://browzarr.io/latest/?store=...
```

so that it can be launched with a custom store urls.

local files are trickier, I still haven't found the right approach for them. Consider the `isNC` logic just placeholders for now.