### PR TITLE
Updated GetCurrentArray to use chunkstrides

### DIFF
--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -69,14 +69,12 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
         xSlice: state.xSlice
     })));
     const isMounted = useRef(false)
-
     useEffect(() => {
         if (!plotOn){
             return
         }
-        const dataArray = GetCurrentArray(analysisStore);
         // Guard clauses: exit if not triggered, no operation is selected, or data is invalid.
-        if (!operation || dataArray.length <= 1) {
+        if (!operation) {
             return;
         }
         const executeAnalysis = async () => {
@@ -100,7 +98,7 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
             }
 
             // --- 2. Dispatch GPU computation based on the operation ---
-            const inputArray = analysisMode ? analysisArray : dataArray;
+            const inputArray = GetCurrentArray(analysisStore)
             const shapeInfo = { shape: dataShape, strides};
             const kernelParams = { kernelDepth, kernelSize };
             // [1538316, 1481, 1]

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -275,8 +275,7 @@ export function GetCurrentArray(overrideStore?:string){
     const [xStartIdx, xEndIdx] = currentChunks.x
     const [yStartIdx, yEndIdx] = currentChunks.y
     const [zStartIdx, zEndIdx] = currentChunks.z
-    let chunkShape;
-    let chunkStride;
+
     for (let z = zStartIdx; z < zEndIdx; z++) {
       for (let y = yStartIdx; y < yEndIdx; y++) {
         for (let x = xStartIdx; x < xEndIdx; x++) {
@@ -285,14 +284,10 @@ export function GetCurrentArray(overrideStore?:string){
           const chunk = cache.get(cacheName)
           const compressed = chunk.compressed
           const thisData = compressed ? DecompressArray(chunk.data) : chunk.data
-          if (!chunkShape) {
-            chunkShape = chunk.shape
-            chunkStride = chunk.stride
-          }
           copyChunkToArray(
             thisData,
-            chunkShape,
-            chunkStride,
+            chunk.shape,
+            chunk.stride,
             typedArray,
             dataShape,
             strides as [number, number, number], 


### PR DESCRIPTION
`GetCurrentArray()` was using a global stride value but the `copychunk2array()` function wants individual chunkstrides. This was the cause for when analyzing certain datasets would produce completely wrong values on the edges. 