### PR TITLE
remove shader bounds

### DIFF
--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -42,12 +42,11 @@ export const DataCube = ({ volTexture }: DataCubeProps ) => {
     const aspectRatio = shape.y/shape.x
     const timeRatio = shape.z/shape.x;
     const {lonBounds, latBounds} = useCoordBounds()
-    
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
       glslVersion: THREE.GLSL3,
       uniforms: {
           modelViewMatrixInverse: { value: new THREE.Matrix4() }, // Used for Orthographic RayMarcher
-          map: { value: volTexture },
+          map: { value: Array.from({ length: 14 }, (_, idx) => volTexture?.[idx])},
           maskTexture: { value: maskTexture },
           maskValue: {value: maskValue },
           textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},

--- a/src/components/plots/FlatBlocks.tsx
+++ b/src/components/plots/FlatBlocks.tsx
@@ -99,9 +99,9 @@ const FlatBlocks = ({textures} : {textures: THREE.Data3DTexture[] | THREE.DataTe
             },
             vertexShader: GetVert("flatBlocksVert", isFlat),
             fragmentShader: sphereBlocksFrag,
-            blending: THREE.NormalBlending,
-            side:THREE.DoubleSide,
+            blending: THREE.NoBlending,
             depthWrite:true,
+            depthTest:true,
         })
         return shader
     },[width, height, isFlat])

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -22,7 +22,7 @@ interface InfoSettersProps{
   coords: React.RefObject<number[]>;
 }
 
-const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE.Data3DTexture[], infoSetters : InfoSettersProps}) => {
+const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture[] | THREE.Data3DTexture[], infoSetters : InfoSettersProps}) => {
     const {setLoc, setShowInfo, val, coords} = infoSetters;
     const {flipY, colormap, valueScales, dimArrays, dimNames, dimUnits, 
       isFlat, dataShape, textureArrayDepths, strides,
@@ -168,7 +168,7 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
             uniforms:{
               cScale: {value: cScale},
               cOffset: {value: cOffset},
-              map : {value: textures},
+              map : {value: Array.from({ length: 14 }, (_, idx) => textures?.[idx])},
               maskTexture: {value: maskTexture},
               maskValue: {value: maskValue},
               latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
@@ -180,8 +180,7 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
               nanAlpha: {value: 1 - nanTransparency},
             },
             vertexShader: vertShader,
-            // fragmentShader: GetFrag("flatFrag", isFlat),
-            fragmentShader: flatFrag,
+            fragmentShader: GetFrag("flatFrag", isFlat),
             side: THREE.DoubleSide,
         }),[isFlat, textures])
     
@@ -189,7 +188,6 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
       if(shaderMaterial){
         const uniforms = shaderMaterial.uniforms
         uniforms.cOffset.value = cOffset;
-        uniforms.map.value = textures;
         uniforms.cmap. value = colormap;
         uniforms.animateProg.value =animProg;
         uniforms.nanColor.value = new THREE.Color(nanColor);
@@ -199,7 +197,7 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
         uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
         uniforms.maskValue.value = maskValue
       }
-    },[cScale, cOffset, textures, colormap, animProg, nanColor, nanTransparency, latBounds, lonBounds, maskValue])
+    },[cScale, cOffset, colormap, animProg, nanColor, nanTransparency, latBounds, lonBounds, maskValue])
 
   return (
     <>

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -13,6 +13,7 @@ import { coarsenFlatArray, GetCurrentArray, GetTimeSeries, parseUVCoords, deg2ra
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { GetFrag } from '../textures';
+import flatFrag from '../textures/shaders/flatFrag.glsl'
 
 interface InfoSettersProps{
   setLoc: React.Dispatch<React.SetStateAction<number[]>>;
@@ -21,22 +22,17 @@ interface InfoSettersProps{
   coords: React.RefObject<number[]>;
 }
 
-function Rescale(value: number, scales: {minVal: number, maxVal: number}){
-  const range = scales.maxVal-scales.minVal
-  return value * range + scales.minVal
-}
-
 const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE.Data3DTexture[], infoSetters : InfoSettersProps}) => {
     const {setLoc, setShowInfo, val, coords} = infoSetters;
     const {flipY, colormap, valueScales, dimArrays, dimNames, dimUnits, 
-      isFlat, dataShape, textureArrayDepths, strides, timeSeries,
+      isFlat, dataShape, textureArrayDepths, strides,
       setPlotDim,updateDimCoords, updateTimeSeries} = useGlobalStore(useShallow(state => ({
       flipY: state.flipY, colormap: state.colormap, 
       valueScales: state.valueScales, dimArrays: state.dimArrays,
       dimNames:state.dimNames, dimUnits: state.dimUnits,
       isFlat: state.isFlat, dataShape: state.dataShape,
       textureArrayDepths: state.textureArrayDepths,
-      strides: state.strides, timeSeries: state.timeSeries,
+      strides: state.strides, 
       setPlotDim:state.setPlotDim, 
       updateDimCoords:state.updateDimCoords,
       updateTimeSeries: state.updateTimeSeries
@@ -128,33 +124,6 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
 
 
     // ----- TIMESERIES ----- //
-    const [boundsObj, setBoundsObj] = useState<Record<string, THREE.Vector4>>({})
-    const [bounds, setBounds] = useState<THREE.Vector4[]>(new Array(10).fill(new THREE.Vector4(-1 , -1, -1, -1)))
-    const [height, width] = [dataShape[dataShape.length-2], dataShape[dataShape.length-1]]
-
-    useEffect(()=>{ //This goes through the list of highlighted squares and removes those that aren't included in the timeseries object.
-          let boundIDs = Object.keys(boundsObj)
-          const tsIDs = Object.keys(timeSeries)
-          boundIDs = boundIDs.filter((val) => tsIDs.includes(val))
-          const pointValues = boundIDs.map(id => boundsObj[id]);
-          const paddedArray = [
-            ...pointValues,
-            ...Array(Math.max(0, 10 - pointValues.length)).fill(new THREE.Vector4(-1 , -1, -1, -1))
-          ];
-          setBounds(paddedArray)
-        },[boundsObj, timeSeries])
-
-    function addBounds(uv : THREE.Vector2, tsID: string){ //This adds the bounds in UV space of a selected square on the sphere. 
-          const widthID = Math.floor(uv.x*(width))+.5;
-          const heightID = Math.ceil(uv.y*height)-.5 ;
-          const delX = 1/width;
-          const delY = 1/height;
-          const xBounds = [widthID/width-delX/2,widthID/width+delX/2]
-          const yBounds = [heightID/height-delY/2,heightID/height+delY/2]
-          const bounds = new THREE.Vector4(...xBounds, ...yBounds)
-          const newBoundObj = {[tsID] : bounds}
-          setBoundsObj(prev=>{ return {...newBoundObj, ...prev}})
-        }
     function HandleTimeSeries(event: THREE.Intersection){
             const uv = event.uv;
             const normal = new THREE.Vector3(0,0,1)
@@ -191,7 +160,6 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
                 }
               }
               updateDimCoords({[tsID] : dimObj})
-              addBounds(uv, tsID);
             }
           }
     // ----- SHADER MATERIAL ----- //
@@ -200,8 +168,6 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
             uniforms:{
               cScale: {value: cScale},
               cOffset: {value: cOffset},
-              selectTS: {value: selectTS},
-              selectBounds: {value: bounds},
               map : {value: textures},
               maskTexture: {value: maskTexture},
               maskValue: {value: maskValue},
@@ -214,7 +180,8 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
               nanAlpha: {value: 1 - nanTransparency},
             },
             vertexShader: vertShader,
-            fragmentShader: GetFrag("flatFrag", isFlat),
+            // fragmentShader: GetFrag("flatFrag", isFlat),
+            fragmentShader: flatFrag,
             side: THREE.DoubleSide,
         }),[isFlat, textures])
     
@@ -230,11 +197,9 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture | THREE
         uniforms.cScale.value = cScale;
         uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
         uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
-        uniforms.selectBounds.value = bounds;
-        uniforms.selectTS.value = selectTS;
         uniforms.maskValue.value = maskValue
       }
-    },[cScale, cOffset, textures, colormap, animProg, nanColor, nanTransparency, bounds, selectTS, latBounds, lonBounds, maskValue])
+    },[cScale, cOffset, textures, colormap, animProg, nanColor, nanTransparency, latBounds, lonBounds, maskValue])
 
   return (
     <>

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -13,7 +13,6 @@ import { coarsenFlatArray, GetCurrentArray, GetTimeSeries, parseUVCoords, deg2ra
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { GetFrag } from '../textures';
-import flatFrag from '../textures/shaders/flatFrag.glsl'
 
 interface InfoSettersProps{
   setLoc: React.Dispatch<React.SetStateAction<number[]>>;

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -244,7 +244,7 @@ const Plot = () => {
         }
         <Orbiter isFlat={plotType == "flat"} />
         {plotType == "flat" && show && <>
-          {displaceSurface && <FlatMap textures={textures as THREE.DataTexture | THREE.Data3DTexture[]} infoSetters={infoSetters} /> }
+          {displaceSurface && <FlatMap textures={textures as THREE.DataTexture[] | THREE.Data3DTexture[]} infoSetters={infoSetters} /> }
           {!displaceSurface && <FlatBlocks textures={textures} />}
         </>
         }

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -1,12 +1,10 @@
 import * as THREE from 'three'
-import { useEffect, useMemo, useState, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import { pointFrag, pointVert } from '@/components/textures/shaders'
-import { useAnalysisStore } from '@/GlobalStates/AnalysisStore';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow';
-import { parseUVCoords, getUnitAxis, GetTimeSeries, GetCurrentArray, deg2rad } from '@/utils/HelperFuncs';
-import { evaluate_cmap } from 'js-colormaps-es';
+import { deg2rad } from '@/utils/HelperFuncs';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { UVCube } from './UVCube';
 
@@ -40,14 +38,13 @@ const MappingCube = () =>{
 
 export const PointCloud = ({textures} : {textures:PCProps} )=>{
     const { colormap } = textures;
-    const {timeSeries, flipY, dataShape, textureData} = useGlobalStore(useShallow(state=>({
-      timeSeries: state.timeSeries,
+    const { flipY, dataShape, textureData} = useGlobalStore(useShallow(state=>({
       flipY: state.flipY,
       dataShape: state.dataShape,
       textureData: state.textureData
     })))
     const {scalePoints, scaleIntensity, pointSize, cScale, cOffset, valueRange, animProg, 
-      selectTS, timeScale, xRange, yRange, zRange, fillValue,
+      timeScale, xRange, yRange, zRange, fillValue,
       maskTexture, maskValue } = usePlotStore(useShallow(state => ({
       scalePoints: state.scalePoints,
       scaleIntensity: state.scaleIntensity,
@@ -56,7 +53,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       cOffset:state.cOffset,
       valueRange: state.valueRange,
       animProg: state.animProg,
-      selectTS: state.selectTS,
       timeScale: state.timeScale,
       xRange: state.xRange,
       yRange: state.yRange,
@@ -65,24 +61,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       maskTexture: state.maskTexture,
       maskValue: state.maskValue,
     })))
-    
-    const [pointsObj, setPointsObj] = useState<Record<string, number>>({})
-    const [pointIDs, setPointIDs] = useState<number[]>(new Array(10).fill(-1))
-    const [stride, setStride] = useState<number>(1)
-    const [dimWidth, setDimWidth] = useState<number>(0);
-
-    useEffect(()=>{ //This goes through the list of highlighted columns and removes those that aren't included in the timeseries object.
-      let pointIDs = Object.keys(pointsObj)
-      const tsIDs = Object.keys(timeSeries)
-      pointIDs = pointIDs.filter((val) => tsIDs.includes(val))
-      const pointValues = pointIDs.map(id => pointsObj[id]);
-      const paddedArray = [
-        ...pointValues,
-        ...Array(Math.max(0, 10 - pointValues.length)).fill(-1)
-      ];
-      setPointIDs(paddedArray)
-
-    },[timeSeries, pointsObj])
 
     //Extract data and shape from Data3DTexture
     const { data, width, height, depth } = useMemo(() => {
@@ -94,7 +72,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
           depth: depth,
         };
     }, [textureData, dataShape]);
-
     // Create buffer geometry
     const geometry = useMemo(() => {
       const geom = new THREE.BufferGeometry();
@@ -119,10 +96,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
         valueRange: {value: new THREE.Vector2(valueRange[0], valueRange[1])},
         scalePoints:{value: scalePoints},
         scaleIntensity: {value: scaleIntensity},
-        startIDs: {value : pointIDs},
-        stride: {value : stride},
-        showTransect: { value: selectTS},
-        dimWidth: {value: dimWidth},
         timeScale: {value: timeScale},
         animateProg: {value: animProg},
         shape: {value: new THREE.Vector3(depth, height, width)},
@@ -134,12 +107,11 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       fragmentShader:pointFrag,
       depthWrite: true,
       depthTest: true,
-      transparent: false,
-      blending:THREE.NormalBlending,
-      side:THREE.DoubleSide,
+      depthFunc:THREE.LessEqualDepth,
+      blending:THREE.NoBlending,
     })
     ),[]);
-
+  
    useEffect(() => {
     if (shaderMaterial) {
       const uniforms = shaderMaterial.uniforms;
@@ -150,12 +122,8 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       uniforms.valueRange.value.set(valueRange[0], valueRange[1]);
       uniforms.scalePoints.value = scalePoints;
       uniforms.scaleIntensity.value = scaleIntensity;
-      uniforms.startIDs.value = pointIDs;
-      uniforms.stride.value = stride;
       uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
       uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
-      uniforms.showTransect.value = selectTS;
-      uniforms.dimWidth.value = dimWidth;
       uniforms.timeScale.value = timeScale;
       uniforms.animateProg.value = animProg;
       uniforms.flatBounds.value.set(
@@ -168,8 +136,7 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       uniforms.fillValue.value = fillValue?? NaN
       uniforms.maskValue.value = maskValue
     }
-  }, [pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, pointIDs, stride, selectTS, animProg, timeScale, xRange, yRange, fillValue, zRange, maskValue, lonBounds, latBounds]);
-
+  }, [pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, animProg, timeScale, xRange, yRange, fillValue, zRange, maskValue, lonBounds, latBounds]);
     return (
       <>
       <mesh scale={[1,flipY ? -1:1, 1]} >

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -107,7 +107,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       fragmentShader:pointFrag,
       depthWrite: true,
       depthTest: true,
-      depthFunc:THREE.LessEqualDepth,
       blending:THREE.NoBlending,
     })
     ),[]);

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -8,6 +8,7 @@ import { parseUVCoords, GetTimeSeries, GetCurrentArray, deg2rad } from '@/utils/
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds'
 import { GetFrag, GetVert } from '../textures';
+import sphereFrag from '../textures/shaders/sphereFrag.glsl'
 
 function XYZtoUV(xyz : THREE.Vector3, width: number, height : number){
     const lon = Math.atan2(xyz.z,xyz.x)
@@ -39,14 +40,13 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
       analysisArray: state.analysisArray
     })))
     const {colormap, isFlat, dimArrays, dimNames, dimUnits, valueScales, 
-          timeSeries, dataShape, strides, flipY, textureArrayDepths} = useGlobalStore(useShallow(state=>({
+          dataShape, strides, flipY, textureArrayDepths} = useGlobalStore(useShallow(state=>({
         colormap: state.colormap,
         isFlat: state.isFlat,  
         dimArrays:state.dimArrays,
         dimNames:state.dimNames,
         dimUnits:state.dimUnits,
         valueScales: state.valueScales,
-        timeSeries: state.timeSeries,
         dataShape: state.dataShape,
         strides: state.strides,
         flipY: state.flipY,
@@ -78,35 +78,8 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
       dimArrays[1].slice(ySlice[0], ySlice[1] ? ySlice[1] : undefined),
       dimArrays.length > 2 ? dimArrays[2].slice(xSlice[0], xSlice[1] ? xSlice[1] : undefined) : [],
     ]
-    const [boundsObj, setBoundsObj] = useState<Record<string, THREE.Vector4>>({})
-    const [bounds, setBounds] = useState<THREE.Vector4[]>(new Array(10).fill(new THREE.Vector4(-1 , -1, -1, -1)))
-    const [height, width] = useMemo(()=>isFlat ? dataShape : [dataShape[1], dataShape[2]], [dataShape])
-    useEffect(()=>{ //This goes through the list of highlighted squares and removes those that aren't included in the timeseries object.
-      let boundIDs = Object.keys(boundsObj)
-      const tsIDs = Object.keys(timeSeries)
-      boundIDs = boundIDs.filter((val) => tsIDs.includes(val))
-      const pointValues = boundIDs.map(id => boundsObj[id]);
-      const paddedArray = [
-        ...pointValues,
-        ...Array(Math.max(0, 10 - pointValues.length)).fill(new THREE.Vector4(-1 , -1, -1, -1))
-      ];
-      setBounds(paddedArray)
-    },[boundsObj, timeSeries])
-
-    function addBounds(uv : THREE.Vector2, tsID: string){ //This adds the bounds in UV space of a selected square on the sphere. 
-      const widthID = Math.floor(uv.x*(width))+.5;
-      const heightID = Math.ceil(uv.y*height)-.5 ;
-      const delX = 1/width;
-      const delY = 1/height;
-      const xBounds = [widthID/width-delX/2,widthID/width+delX/2]
-      const yBounds = [heightID/height-delY/2,heightID/height+delY/2]
-      const bounds = new THREE.Vector4(...xBounds, ...yBounds)
-      const newBoundObj = {[tsID] : bounds}
-      setBoundsObj(prev=>{ return {...newBoundObj, ...prev}})
-    }
 
     const {lonBounds, latBounds} = useCoordBounds()
-
 
     const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, sphereResolution), [sphereResolution]);
     const shaderMaterial = useMemo(()=>{
@@ -117,8 +90,6 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
                 maskTexture: { value: maskTexture},
                 maskValue: { value: maskValue },
                 textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
-                selectTS: {value: selectTS},
-                selectBounds: {value: bounds},
                 cmap:{value: colormap},
                 cOffset:{value: cOffset},
                 cScale: {value: cScale},
@@ -150,8 +121,6 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
     const updateMaterial = (material: THREE.ShaderMaterial) =>{
       const uniforms = material.uniforms;
       uniforms.map.value =  textures 
-      uniforms.selectTS.value =  selectTS
-      uniforms.selectBounds.value =  bounds
       uniforms.cmap.value =  colormap
       uniforms.maskValue.value = maskValue
       uniforms.cOffset.value =  cOffset
@@ -173,7 +142,7 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
       if (backMaterial){
         updateMaterial(backMaterial)
       }
-    },[textures, animProg, colormap, cOffset, cScale, animate, bounds, selectTS, lonBounds, latBounds, nanColor, nanTransparency, sphereDisplacement, fillValue, maskValue, valueScales])
+    },[textures, animProg, colormap, cOffset, cScale, animate, selectTS, lonBounds, latBounds, nanColor, nanTransparency, sphereDisplacement, fillValue, maskValue, valueScales])
     
     
     function HandleTimeSeries(event: THREE.Intersection){
@@ -214,7 +183,6 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
           }
         }
         updateDimCoords({[tsID] : dimObj})
-        addBounds(uv, tsID);
       }
 
   return (

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -8,18 +8,6 @@ import { parseUVCoords, GetTimeSeries, GetCurrentArray, deg2rad } from '@/utils/
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds'
 import { GetFrag, GetVert } from '../textures';
-import sphereFrag from '../textures/shaders/sphereFrag.glsl'
-
-function XYZtoUV(xyz : THREE.Vector3, width: number, height : number){
-    const lon = Math.atan2(xyz.z,xyz.x)
-    const lat = Math.asin(xyz.y);
-    let u = (lon + Math.PI) / (2 * Math.PI);
-    u = 1 - u;
-    let v = (lat + Math.PI / 2) / Math.PI;
-    u = Math.round(u*width-.5)/width
-    v = Math.round(v*height-.5)/height
-    return new THREE.Vector2(u,v)
-}
 
 function XYZtoRemap(xyz : THREE.Vector3, latBounds: number[], lonBounds : number[]){
     const lon = Math.atan2(xyz.z,xyz.x)

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -74,7 +74,7 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
         const shader = new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms: {
-                map: { value: textures },
+                map: { value: Array.from({ length: 14 }, (_, idx) => textures?.[idx]) },
                 maskTexture: { value: maskTexture},
                 maskValue: { value: maskValue },
                 textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
@@ -108,7 +108,6 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
 
     const updateMaterial = (material: THREE.ShaderMaterial) =>{
       const uniforms = material.uniforms;
-      uniforms.map.value =  textures 
       uniforms.cmap.value =  colormap
       uniforms.maskValue.value = maskValue
       uniforms.cOffset.value =  cOffset
@@ -130,7 +129,7 @@ export const Sphere = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Dat
       if (backMaterial){
         updateMaterial(backMaterial)
       }
-    },[textures, animProg, colormap, cOffset, cScale, animate, selectTS, lonBounds, latBounds, nanColor, nanTransparency, sphereDisplacement, fillValue, maskValue, valueScales])
+    },[animProg, colormap, cOffset, cScale, animate, lonBounds, latBounds, nanColor, nanTransparency, sphereDisplacement, fillValue, maskValue, valueScales])
     
     
     function HandleTimeSeries(event: THREE.Intersection){

--- a/src/components/plots/SphereBlocks.tsx
+++ b/src/components/plots/SphereBlocks.tsx
@@ -96,9 +96,9 @@ const SphereBlocks = ({textures} : {textures: THREE.Data3DTexture[] | THREE.Data
             },
             vertexShader: GetVert("sphereBlocksVert", isFlat),
             fragmentShader: sphereBlocksFrag,
-            blending: THREE.NormalBlending,
-            side:THREE.DoubleSide,
+            blending:THREE.NoBlending,
             depthWrite:true,
+            depthTest:true,
         })
         return shader
     },[count, isFlat])

--- a/src/components/textures/shaders/flatFrag.glsl
+++ b/src/components/textures/shaders/flatFrag.glsl
@@ -9,7 +9,7 @@ uniform sampler2D maskTexture;
 uniform sampler2D cmap;
 uniform vec3 textureDepths;
 
-uniform bool selectTS;
+
 uniform float cOffset;
 uniform float cScale;
 uniform float animateProg;
@@ -17,7 +17,6 @@ uniform float nanAlpha;
 uniform vec3 nanColor;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
-uniform vec4[10] selectBounds; 
 uniform int maskValue;
 
 varying vec2 vUv;
@@ -62,20 +61,6 @@ float sample1(
     else return 0.0;
 }
 
-bool isValid(vec2 sampleCoord){
-    for (int i = 0; i < 10; i++){
-        vec4 thisBound = selectBounds[i];
-        if (thisBound.x == -1.){
-            return false;
-        }
-        bool cond = (sampleCoord.x < thisBound.r || sampleCoord.x > thisBound.g || sampleCoord.y < thisBound.b ||  sampleCoord.y > thisBound.a);
-        if (!cond){
-            return true;
-        }
-    }
-    return false;
-}
-
 void main() {
     if (maskValue != 0){
         vec2 maskUV = realCoords(vUv);
@@ -110,8 +95,4 @@ void main() {
     float sampLoc = isNaN ? strength: (strength)*cScale;
     sampLoc = isNaN ? strength : min(sampLoc+cOffset,0.995);
     Color = isNaN ? vec4(nanColor, nanAlpha) : vec4(texture2D(cmap, vec2(sampLoc, 0.5)).rgb, 1.);
-    if (selectTS){
-        bool cond = isValid(vUv);
-        Color.rgb *= cond ? 1. : 0.65;
-    }
 }

--- a/src/components/textures/shaders/pointFrag.glsl
+++ b/src/components/textures/shaders/pointFrag.glsl
@@ -1,24 +1,15 @@
 out vec4 Color;
 
 in float vValue;
-flat in int highlight;
-
 
 uniform sampler2D cmap;
 uniform float cScale;
 uniform float cOffset;
-uniform bool showTransect;
 
 void main() {
     float sampLoc = vValue == 1. ? vValue : (vValue - 0.5)*cScale + 0.5;
     sampLoc = vValue == 1. ? vValue : min(sampLoc+cOffset,0.99);
     vec4 color = texture(cmap, vec2(sampLoc, 0.5));
     color.a = 1.;
-    Color = color;
-    if (showTransect){
-        Color = highlight == 1 ? color : color * vec4(vec3(0.4),1.);
-    }
-    else{
-        Color = color;
-    }
+    Color = color;    
 }

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -2,17 +2,12 @@ attribute float value;
 
 out float vValue;
 
-flat out int highlight;
 uniform sampler2D maskTexture;
 
 uniform float pointSize;
 uniform bool scalePoints;
 uniform float scaleIntensity;
 uniform vec2 valueRange;
-uniform int[10] startIDs;
-uniform int stride;
-uniform int dimWidth;
-uniform bool showTransect;
 uniform float timeScale;
 uniform float animateProg;
 uniform vec4 flatBounds;
@@ -25,21 +20,6 @@ uniform int maskValue;
 
 #define PI 3.1415925
 
-bool isValidPoint(){
-    for (int i = 0; i < 10; i++){
-        if (startIDs[i] == -1){
-            return false;
-        }
-        int rePos = gl_VertexID - startIDs[i];
-        bool isValid = rePos % stride == 0;
-        bool secondary = gl_VertexID < (startIDs[i] + dimWidth*stride) && gl_VertexID > startIDs[i];
-        isValid = isValid && secondary;
-        if (isValid){
-            return true;
-        }
-    }
-    return false;
-}
 vec3 computePosition(int vertexID) {
     int depth = int(shape.x);
     int height = int(shape.y);
@@ -106,9 +86,6 @@ void main() {
 
     float pointScale = pointSize/gl_Position.w;
     pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
-
-    bool isValid = isValidPoint();
-    highlight = isValid ? 1 : 0;
     
     if (value == 255. || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scalled
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
@@ -135,11 +112,7 @@ void main() {
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     }
     
-    if (showTransect){
-        gl_PointSize = isValid ? pointScale*5. : pointScale;
-    }
-    else{
-        gl_PointSize =  pointScale;
-    }
+    gl_PointSize =  pointScale;
+    
 
 }

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -16,8 +16,6 @@ uniform vec3 textureDepths;
 uniform float cOffset;
 uniform float cScale;
 uniform float animateProg;
-uniform vec4[10] selectBounds; 
-uniform bool selectTS;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
 uniform vec3 nanColor;
@@ -48,21 +46,6 @@ vec2 giveMaskUV(vec3 position){
     float u = longitude + 0.5;
     float v = latitude + 0.5;
     return vec2(u, v);
-}
-
-
-bool isValid(vec2 sampleCoord){
-    for (int i = 0; i < 10; i++){
-        vec4 thisBound = selectBounds[i];
-        if (thisBound.x == -1.){
-            return false;
-        }
-        bool cond = (sampleCoord.x < thisBound.r || sampleCoord.x > thisBound.g || sampleCoord.y < thisBound.b ||  sampleCoord.y > thisBound.a);
-        if (!cond){
-            return true;
-        }
-    }
-    return false;
 }
 
 float sample1( 
@@ -123,12 +106,6 @@ void main(){
         if (!isNaN){
             color.a = 1.;
         }
-        #ifndef IS_FLAT
-            if (selectTS){
-                bool cond = isValid(sampleCoord);
-                color.rgb *= cond ? 1. : 0.65;
-            }
-        #endif
         if (maskValue != 0){
             vec2 maskUV = giveMaskUV(aPosition);
             float mask = texture(maskTexture, maskUV).r;


### PR DESCRIPTION
This is the first step for #592 by removing all of the bound logic from components and shaders.

Additionally, I was using `DoubleSide` render for the instances and points-clouds for some reason. So I removed that back to default (Frontside) and that gave a very notable performance improvement to the instanced plots. Points are still not ideal.
I also added NoBlending to instanced materials in case that helps with performance and added depth testing as I now understand better whats happening and that helps performance.

Lastly, I solved #609 by ensuring that the texture array fed into the shaders is always an array of length 14 and that seems to have handled the issue with changing array sizes
