### PR TITLE
Jp/first workers

### DIFF
--- a/src/components/plots/AnalysisWG.tsx
+++ b/src/components/plots/AnalysisWG.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { ArrayMinMax, GetCurrentArray } from '@/utils/HelperFuncs';
+import { ArrayMinMax, GetCurrentArray, GetCurrentArrayWorkers } from '@/utils/HelperFuncs';
 import * as THREE from 'three';
 import React, { useEffect, useRef } from 'react';
 import { DataReduction, Convolve, Multivariate2D, Multivariate3D, CUMSUM3D, Convolve2D, CustomShader } from '../computation/webGPU';
@@ -98,7 +98,7 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
             }
 
             // --- 2. Dispatch GPU computation based on the operation ---
-            const inputArray = analysisMode ? analysisArray : await GetCurrentArray(analysisStore)
+            const inputArray = analysisMode ? analysisArray : await GetCurrentArrayWorkers(analysisStore)
             const shapeInfo = { shape: dataShape, strides};
             const kernelParams = { kernelDepth, kernelSize };
             // [1538316, 1481, 1]
@@ -204,7 +204,7 @@ const AnalysisWG = ({ setTexture, }: { setTexture: React.Dispatch<React.SetState
 
         const is2D = outputShape.length === 2
         async function Analyze(){
-            const dataArray = analysisMode ? analysisArray : GetCurrentArray(analysisStore)
+            const dataArray = analysisMode ? analysisArray : await GetCurrentArrayWorkers(analysisStore)
             const newArray = await CustomShader(dataArray, shapeInfo, kernelParams, axis, customShader?? "") as Float16Array
             const {minVal, maxVal} = valueScales
             const textureData = new Uint8Array(newArray.length)

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -9,7 +9,7 @@ import { useZarrStore } from '@/GlobalStates/ZarrStore';
 import { vertShader } from '@/components/computation/shaders'
 import { useShallow } from 'zustand/shallow'
 import { ThreeEvent } from '@react-three/fiber';
-import { coarsenFlatArray, GetCurrentArray, GetCurrentArrayWorkers, GetTimeSeries, parseUVCoords, deg2rad, TypedArray } from '@/utils/HelperFuncs';
+import { coarsenFlatArray, GetCurrentArray, GetCurrentArrayWorkers, GetTimeSeries, parseUVCoords, deg2rad } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { GetFrag } from '../textures';
@@ -133,44 +133,44 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture[] | THR
 
 
     // ----- TIMESERIES ----- //
-    function HandleTimeSeries(event: THREE.Intersection){
-            const uv = event.uv;
-            const normal = new THREE.Vector3(0,0,1)
-            if(uv){
-              const tsUV = flipY ? new THREE.Vector2(uv.x, 1-uv.y) : uv
-              const tempTS = GetTimeSeries({data:analysisMode ? analysisArray : GetCurrentArray(), shape:dataShape, stride:strides},{uv:tsUV,normal})
-              setPlotDim(0) //I think this 2 is only if there are 3-dims. Need to rework the logic
-                
-              const coordUV = parseUVCoords({normal:normal,uv:uv})
-              let dimCoords = coordUV.map((val,idx)=>val ? dimSlices[idx][Math.round(val*dimSlices[idx].length)] : null)
-              const thisDimNames = dimNames.filter((_,idx)=> dimCoords[idx] !== null)
-              const thisDimUnits = dimUnits.filter((_,idx)=> dimCoords[idx] !== null)
-              dimCoords = dimCoords.filter(val => val !== null)
-              const tsID = `${dimCoords[0]}_${dimCoords[1]}`
-              const tsObj = {
-                color:evaluate_cmap(getColorIdx()/10,"Paired"),
-                data:tempTS
-              }
-              incrementColorIdx();
-              updateTimeSeries({ [tsID] : tsObj})
-              const dimObj = {
-                first:{
-                  name:thisDimNames[0],
-                  loc:dimCoords[0] ?? 0,
-                  units:thisDimUnits[0]
-                },
-                second:{
-                  name:thisDimNames[1],
-                  loc:dimCoords[1] ?? 0,
-                  units:thisDimUnits[1]
-                },
-                plot:{
-                  units:dimUnits[0]
-                }
-              }
-              updateDimCoords({[tsID] : dimObj})
-            }
+    async function HandleTimeSeries(event: THREE.Intersection){
+      const uv = event.uv;
+      const normal = new THREE.Vector3(0,0,1)
+      if(uv){
+        const tsUV = flipY ? new THREE.Vector2(uv.x, 1-uv.y) : uv
+        const tempTS = GetTimeSeries({data:analysisMode ? analysisArray : await GetCurrentArrayWorkers(), shape:dataShape, stride:strides},{uv:tsUV,normal})
+        setPlotDim(0) //I think this 2 is only if there are 3-dims. Need to rework the logic
+          
+        const coordUV = parseUVCoords({normal:normal,uv:uv})
+        let dimCoords = coordUV.map((val,idx)=>val ? dimSlices[idx][Math.round(val*dimSlices[idx].length)] : null)
+        const thisDimNames = dimNames.filter((_,idx)=> dimCoords[idx] !== null)
+        const thisDimUnits = dimUnits.filter((_,idx)=> dimCoords[idx] !== null)
+        dimCoords = dimCoords.filter(val => val !== null)
+        const tsID = `${dimCoords[0]}_${dimCoords[1]}`
+        const tsObj = {
+          color:evaluate_cmap(getColorIdx()/10,"Paired"),
+          data:tempTS
+        }
+        incrementColorIdx();
+        updateTimeSeries({ [tsID] : tsObj})
+        const dimObj = {
+          first:{
+            name:thisDimNames[0],
+            loc:dimCoords[0] ?? 0,
+            units:thisDimUnits[0]
+          },
+          second:{
+            name:thisDimNames[1],
+            loc:dimCoords[1] ?? 0,
+            units:thisDimUnits[1]
+          },
+          plot:{
+            units:dimUnits[0]
           }
+        }
+        updateDimCoords({[tsID] : dimObj})
+      }
+    }
     // ----- SHADER MATERIAL ----- //
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -9,7 +9,7 @@ import { useZarrStore } from '@/GlobalStates/ZarrStore';
 import { vertShader } from '@/components/computation/shaders'
 import { useShallow } from 'zustand/shallow'
 import { ThreeEvent } from '@react-three/fiber';
-import { coarsenFlatArray, GetCurrentArray, GetTimeSeries, parseUVCoords, deg2rad } from '@/utils/HelperFuncs';
+import { coarsenFlatArray, GetCurrentArray, GetCurrentArrayWorkers, GetTimeSeries, parseUVCoords, deg2rad } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { GetFrag } from '../textures';
@@ -90,7 +90,16 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture[] | THR
     const infoRef = useRef<boolean>(false)
     const lastUV = useRef<THREE.Vector2>(new THREE.Vector2(0,0))
     const rotateMap = analysisMode && axis == 2;
-    const sampleArray = useMemo(()=> analysisMode ? analysisArray : GetCurrentArray(),[analysisMode, analysisArray, textures])
+    // const sampleArray = useMemo(()=> analysisMode ? analysisArray : GetCurrentArray(),[analysisMode, analysisArray, textures])
+    const sampleArray = useMemo(()=> {
+      if (analysisMode) return analysisArray 
+      else {
+        let output;
+        GetCurrentArrayWorkers().then(e=> output=e)
+        return output
+      }      
+    }
+    ,[analysisMode, analysisArray, textures])
     const analysisDims = useMemo(()=>dimArrays.length > 2 ? dimSlices.filter((_e,idx)=> idx != axis) : dimSlices,[dimSlices,axis])
 
     const {lonBounds, latBounds} = useCoordBounds()

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -9,7 +9,7 @@ import { useZarrStore } from '@/GlobalStates/ZarrStore';
 import { vertShader } from '@/components/computation/shaders'
 import { useShallow } from 'zustand/shallow'
 import { ThreeEvent } from '@react-three/fiber';
-import { coarsenFlatArray, GetCurrentArray, GetCurrentArrayWorkers, GetTimeSeries, parseUVCoords, deg2rad } from '@/utils/HelperFuncs';
+import { coarsenFlatArray, GetCurrentArray, GetCurrentArrayWorkers, GetTimeSeries, parseUVCoords, deg2rad, TypedArray } from '@/utils/HelperFuncs';
 import { evaluate_cmap } from 'js-colormaps-es';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { GetFrag } from '../textures';
@@ -91,16 +91,18 @@ const FlatMap = ({textures, infoSetters} : {textures : THREE.DataTexture[] | THR
     const lastUV = useRef<THREE.Vector2>(new THREE.Vector2(0,0))
     const rotateMap = analysisMode && axis == 2;
     // const sampleArray = useMemo(()=> analysisMode ? analysisArray : GetCurrentArray(),[analysisMode, analysisArray, textures])
-    const sampleArray = useMemo(()=> {
-      if (analysisMode) return analysisArray 
-      else {
-        let output;
-        GetCurrentArrayWorkers().then(e=> output=e)
-        return output
-      }      
-    }
-    ,[analysisMode, analysisArray, textures])
     const analysisDims = useMemo(()=>dimArrays.length > 2 ? dimSlices.filter((_e,idx)=> idx != axis) : dimSlices,[dimSlices,axis])
+    const [sampleArray, setSampleArray] = useState<any | undefined>(undefined) // Moved this to a state as async functions cannot be used in useMemo
+    useEffect(()=>{
+      if (analysisMode){
+        setSampleArray(analysisArray)
+        return
+      } 
+      else {
+        GetCurrentArrayWorkers().then(e=> setSampleArray(e))
+        return
+      }      
+    },[analysisMode, analysisArray, textures])
 
     const {lonBounds, latBounds} = useCoordBounds()
 

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -14,8 +14,9 @@ function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number})
     const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data )
     const textureData = new Uint8Array(data.length)
     const range = (maxVal - minVal)
+    const muiltiplier = 1/range
     for (let i = 0; i < data.length; i++){
-      const normed = (data[i] - minVal) / range;
+      const normed = (data[i] - minVal) * muiltiplier;
       if (isNaN(normed)){
         textureData[i] = 255;
       } else {

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -14,9 +14,9 @@ function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number})
     const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data )
     const textureData = new Uint8Array(data.length)
     const range = (maxVal - minVal)
-    const muiltiplier = 1/range
+    const multiplier = 1/range
     for (let i = 0; i < data.length; i++){
-      const normed = (data[i] - minVal) * muiltiplier;
+      const normed = (data[i] - minVal) * multiplier;
       if (isNaN(normed)){
         textureData[i] = 255;
       } else {

--- a/src/components/workers/chunkWorker.ts
+++ b/src/components/workers/chunkWorker.ts
@@ -1,6 +1,6 @@
 export default {}
 
-import { copyChunkToArray, DecompressArray } from "../zarr/utils";
+import { copyChunkToArray, copyChunkToArray2D, DecompressArray } from "../zarr/utils";
 
 //---- Worker ----//
 
@@ -15,21 +15,34 @@ self.onmessage = (e) => {
     strides,
     chunkCoord,
     startCoords,
+    hasZ
   } = e.data
 
   const typedArray = new Float16Array(sharedBuffer)
   const thisData = compressed ? DecompressArray(chunkData) : chunkData
-
-  copyChunkToArray(
-    thisData,
-    chunkShape,
-    chunkStride,
-    typedArray,
-    dataShape,
-    strides,
-    chunkCoord,
-    startCoords,
-  )
+  if (hasZ) {
+    copyChunkToArray(
+      thisData,
+      chunkShape,
+      chunkStride,
+      typedArray,
+      dataShape,
+      strides,
+      chunkCoord,
+      startCoords,
+    )
+  } else {
+  copyChunkToArray2D(
+      thisData,
+      chunkShape,
+      chunkStride,
+      typedArray,
+      dataShape,
+      strides,
+      chunkCoord,
+      startCoords,
+    )
+  }
 
   self.postMessage({ success: true })
 }

--- a/src/components/workers/chunkWorker.ts
+++ b/src/components/workers/chunkWorker.ts
@@ -20,29 +20,10 @@ self.onmessage = (e) => {
 
   const typedArray = new Float16Array(sharedBuffer)
   const thisData = compressed ? DecompressArray(chunkData) : chunkData
-  if (hasZ) {
-    copyChunkToArray(
-      thisData,
-      chunkShape,
-      chunkStride,
-      typedArray,
-      dataShape,
-      strides,
-      chunkCoord,
-      startCoords,
-    )
-  } else {
-  copyChunkToArray2D(
-      thisData,
-      chunkShape,
-      chunkStride,
-      typedArray,
-      dataShape,
-      strides,
-      chunkCoord,
-      startCoords,
-    )
-  }
+  const inputs = [thisData, chunkShape, chunkStride, typedArray, dataShape, strides, chunkCoord, startCoords] as const
+
+  if (hasZ) copyChunkToArray(...inputs)
+  else copyChunkToArray2D(...inputs)
 
   self.postMessage({ success: true })
 }

--- a/src/components/workers/chunkWorker.ts
+++ b/src/components/workers/chunkWorker.ts
@@ -1,0 +1,35 @@
+export default {}
+
+import { copyChunkToArray, DecompressArray } from "../zarr/utils";
+
+//---- Worker ----//
+
+self.onmessage = (e) => {
+  const {
+    sharedBuffer,
+    compressed,
+    chunkData,
+    chunkShape,
+    chunkStride,
+    dataShape,
+    strides,
+    chunkCoord,
+    startCoords,
+  } = e.data
+
+  const typedArray = new Float16Array(sharedBuffer)
+  const thisData = compressed ? DecompressArray(chunkData) : chunkData
+
+  copyChunkToArray(
+    thisData,
+    chunkShape,
+    chunkStride,
+    typedArray,
+    dataShape,
+    strides,
+    chunkCoord,
+    startCoords,
+  )
+
+  self.postMessage({ success: true })
+}

--- a/src/components/zarr/GetArray.ts
+++ b/src/components/zarr/GetArray.ts
@@ -12,7 +12,8 @@ export async function GetArray(varOveride?: string) {
     const { idx4D, initStore, variable, setProgress, setStrides, setStatus } = useGlobalStore.getState();
     const { compress, xSlice, ySlice, zSlice, coarsen, kernelSize, kernelDepth, fetchNC, setCurrentChunks, setArraySize } = useZarrStore.getState();
     const { cache } = useCacheStore.getState();
-    const fetcher = fetchNC ? NCFetcher() : zarrFetcher()
+    const useNC = initStore.startsWith("local") && fetchNC // In case a user has NetCDF switched but then goes to a remote
+    const fetcher = useNC ? NCFetcher() : zarrFetcher()
     const targetVariable = varOveride ?? variable;
     const meta = await fetcher.getMetadata(targetVariable);
     const { shape, chunkShape, fillValue, dtype } = meta;

--- a/src/components/zarr/utils.ts
+++ b/src/components/zarr/utils.ts
@@ -59,7 +59,9 @@ export function ToFloat16(array : Float32Array, scalingFactor: number | null) : 
 		initialScale
 	denominator = Math.pow(10,newScalingFactor);
 	multiplier = 1/denominator;
-	const newArray = new Float16Array(array.length)
+    // Need SharedArrayBuffer here or else chunks passed to workers will become detached on the main thread. 
+    const buffer = new SharedArrayBuffer(array.length * 2) // 2 for float16
+	const newArray = new Float16Array(buffer)
 	for (let i = 0; i < array.length; i++) {
 		newArray[i] = array[i] * multiplier;
 	}

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -385,7 +385,7 @@ export async function GetCurrentArrayWorkers(overrideStore?:string){
         compressed:task.compressed,
         chunkCoord: task.chunkCoord,
         startCoords: [zStartIdx, yStartIdx, xStartIdx],
-      },[task.chunkData.buffer])
+      })
     }
     workers.forEach(dispatch) // Distribute first tasks
   }).catch((e) => {

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -348,9 +348,9 @@ export async function GetCurrentArrayWorkers(overrideStore?:string){
       }
     }
   }
-  const POOL_COUNT = navigator.hardwareConcurrency;
+  const POOL_COUNT = navigator.hardwareConcurrency || 4;
   const workers = Array.from({length: Math.min(POOL_COUNT, tasks.length)}, () => 
-    new Worker(new URL('@/components/workers/chunkWorker.ts', import.meta.url), { type: 'module' })
+    new Worker(new URL('../components/workers/chunkWorker.ts', import.meta.url), { type: 'module' })
   )
 
   const terminateAll = () => workers.forEach(w => w.terminate())

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -317,7 +317,7 @@ export async function GetCurrentArrayWorkers(overrideStore?:string){
   }
   
   const sharedBuffer = new SharedArrayBuffer(arraySize * Float16Array.BYTES_PER_ELEMENT)
-
+  const hasZ = dataShape.length > 2;
   const [xStartIdx, xEndIdx] = currentChunks.x
   const [yStartIdx, yEndIdx] = currentChunks.y
   const [zStartIdx, zEndIdx] = currentChunks.z
@@ -343,7 +343,7 @@ export async function GetCurrentArrayWorkers(overrideStore?:string){
           chunkShape: chunk.shape,
           chunkStride: chunk.stride,
           chunkCoord: [z, y, x],
-          compressed
+          compressed,
         })
       }
     }
@@ -382,6 +382,7 @@ export async function GetCurrentArrayWorkers(overrideStore?:string){
         chunkStride: task.chunkStride,
         dataShape,
         strides,
+        hasZ,
         compressed:task.compressed,
         chunkCoord: task.chunkCoord,
         startCoords: [zStartIdx, yStartIdx, xStartIdx],

--- a/src/utils/HelperFuncs.ts
+++ b/src/utils/HelperFuncs.ts
@@ -301,6 +301,100 @@ export function GetCurrentArray(overrideStore?:string){
   }
 }
 
+export async function GetCurrentArrayWorkers(overrideStore?:string){
+  const { variable, is4D, idx4D, initStore, strides, dataShape, setStatus }= useGlobalStore.getState()
+  const { arraySize, currentChunks } = useZarrStore.getState()
+  const {cache} = useCacheStore.getState();
+  const store = overrideStore ? overrideStore : initStore
+  
+  if (cache.has(is4D ? `${store}_${idx4D}_${variable}` : `${store}_${variable}`)){ // Non-chunked data
+      const chunk = cache.get(is4D ? `${store}_${idx4D}_${variable}` : `${store}_${variable}`)
+      const compressed = chunk.compressed
+      setStatus(compressed ? "Decompressing data..." : null)
+      const thisData = compressed ? DecompressArray(chunk.data) : chunk.data
+      setStatus(null)
+			return thisData
+  }
+  
+  const sharedBuffer = new SharedArrayBuffer(arraySize * Float16Array.BYTES_PER_ELEMENT)
+
+  const [xStartIdx, xEndIdx] = currentChunks.x
+  const [yStartIdx, yEndIdx] = currentChunks.y
+  const [zStartIdx, zEndIdx] = currentChunks.z
+
+  type Task = {
+    chunkData: Float16Array | Uint8Array
+    chunkShape: number[]
+    chunkStride: number[]
+    chunkCoord: [number, number, number]
+    compressed: boolean
+  }
+  const tasks: Task[] = []
+
+  for (let z = zStartIdx; z < zEndIdx; z++) {
+    for (let y = yStartIdx; y < yEndIdx; y++) {
+      for (let x = xStartIdx; x < xEndIdx; x++) {
+        const chunkID = `z${z}_y${y}_x${x}`
+        const cacheName = is4D ? `${store}_${variable}_${idx4D}_chunk_${chunkID}` : `${store}_${variable}_chunk_${chunkID}`
+        const chunk = cache.get(cacheName);
+        const compressed = chunk.compressed;
+        tasks.push({
+          chunkData: chunk.data,
+          chunkShape: chunk.shape,
+          chunkStride: chunk.stride,
+          chunkCoord: [z, y, x],
+          compressed
+        })
+      }
+    }
+  }
+  const POOL_COUNT = navigator.hardwareConcurrency;
+  const workers = Array.from({length: Math.min(POOL_COUNT, tasks.length)}, () => 
+    new Worker(new URL('@/components/workers/chunkWorker.ts', import.meta.url), { type: 'module' })
+  )
+
+  const terminateAll = () => workers.forEach(w => w.terminate())
+
+  let taskIndex = 0
+  let completed = 0
+
+  await new Promise<void>((resolve, reject) => {
+    const dispatch = (worker: Worker) => {
+      if (taskIndex >= tasks.length) return  // this worker is done
+      const task = tasks[taskIndex++] // Next isntruction set
+      worker.onmessage = () => {
+        completed++
+        if (completed === tasks.length) {
+          terminateAll()
+          resolve()
+        } else { // More tasks left. Send worker new isntructions
+          dispatch(worker)  
+        }
+      }
+      worker.onerror = (e) => {
+        terminateAll()
+        reject(e)
+      }
+      worker.postMessage({
+        sharedBuffer,
+        chunkData: task.chunkData,
+        chunkShape: task.chunkShape,
+        chunkStride: task.chunkStride,
+        dataShape,
+        strides,
+        compressed:task.compressed,
+        chunkCoord: task.chunkCoord,
+        startCoords: [zStartIdx, yStartIdx, xStartIdx],
+      },[task.chunkData.buffer])
+    }
+    workers.forEach(dispatch) // Distribute first tasks
+  }).catch((e) => {
+    if (e.message === 'cancelled') return 
+    throw e
+  })
+  setStatus(null)
+  return new Float16Array(sharedBuffer)
+}
 
 export function TwoDecimals(val: number){
     return Math.round(val * 100)/100


### PR DESCRIPTION
This is the first batch of workers for array tasks as mentioned in #601. It just applies to `GetCurrentArray()` with its counterpart `GetCurrentArrayWorkers()`. For uncompressed data there isn't a very notable speed-up. Maybe on very large datasets. But for compressed data the speed-up is very noticeable. 

Trying to think of the most efficient application of workers to the data fetching itself. At the Moment may just create workers for data conversion as I haven't found a way to read netcdf data within the workers. Zarr can fetch in workers, but each worker must initialize the store every time which is inefficient. 

Also fixed a bug in the new `GetArray()` function which looks at fetchNC value. However, this can be true even wheil fetching zarr. So now it checks if fetchNC is true AND the initstore is Local. Then it's a NC for sure. 