### PR TITLE
icechunk 0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "embla-carousel-react": "^8.6.0",
     "fflate": "^0.8.2",
     "gsap": "^3.13.0",
-    "icechunk-js": "^0.3.1",
+    "icechunk-js": "^0.4.0",
     "input-otp": "^1.4.2",
     "js-colormaps-es": "^0.0.5",
     "lucide-react": "^0.562.0",

--- a/src/components/zarr/icechunk-store.ts
+++ b/src/components/zarr/icechunk-store.ts
@@ -44,7 +44,7 @@ export async function getIcechunkStore(
 		try {
 			const icechunkStore = await IcechunkStore.open(storePath, {
 				branch: options?.branch ?? "main",
-				formatVersion: "v1",
+				// formatVersion: "v1",
 				...(options?.tag && { tag: options.tag }),
 				...(options?.snapshot && { snapshot: options.snapshot }),
 				...(fetchClient && { fetchClient }),


### PR DESCRIPTION
bumping version, and now letting it effectively find the correct v1/v2 icechunk version of the store.