### PR TITLE
fix local zarr

### DIFF
--- a/src/components/LandingHome.tsx
+++ b/src/components/LandingHome.tsx
@@ -92,7 +92,7 @@ export function LandingHome() {
 
   useEffect(() => {
     const { initStore } = useGlobalStore.getState();
-    if (initStore.startsWith('local')) return;
+    if (initStore.startsWith('local:')) return;
 
     let isMounted = true;
     const activeStore = currentStore;


### PR DESCRIPTION
while adding functionality for local servers I had a name clash (added a bug) `local:` vs `local`, where `local` is a global state use when uploading local netCDF or Zarr stores. For now this fixes the issue of opening in those cases. We should have more descriptive names in the future. 