### PR TITLE
serve browzarr

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -1,30 +1,44 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
-import { extname, resolve } from "node:path";
+import { extname, isAbsolute, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const OUT_DIR = resolve(__dirname, "out");
 const portFlag = process.argv.indexOf("--port");
-const preferredPort = portFlag !== -1
+const rawPort = portFlag !== -1 && portFlag + 1 < process.argv.length
   ? Number(process.argv[portFlag + 1])
   : process.env.PORT
     ? Number(process.env.PORT)
     : 3000;
+const preferredPort = Number.isInteger(rawPort) && rawPort >= 0 && rawPort <= 65535 ? rawPort : 3000;
 
-function findAvailablePort(startPort) {
-  return new Promise((resolve) => {
+function findAvailablePort(startPort, maxRetries = 100) {
+  return new Promise((resolve, reject) => {
+    if (maxRetries <= 0) {
+      reject(new Error("Could not find an available port after 100 attempts."));
+      return;
+    }
     const server = createServer();
     server.listen(startPort, () => {
       const { port } = server.address();
       server.close(() => resolve(port));
     });
-    server.on("error", () => resolve(findAvailablePort(startPort + 1)));
+    server.on("error", () => {
+      const nextPort = startPort >= 65535 ? 1024 : startPort + 1;
+      findAvailablePort(nextPort, maxRetries - 1).then(resolve, reject);
+    });
   });
 }
 
-const PORT = await findAvailablePort(preferredPort);
+let PORT;
+try {
+  PORT = await findAvailablePort(preferredPort);
+} catch (err) {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+}
 
 const MIME = {
   ".html": "text/html",
@@ -47,7 +61,8 @@ createServer((req, res) => {
   const filePath = resolve(OUT_DIR, url.replace(/^\//, ""));
 
   // path traversal guard
-  if (!filePath.startsWith(OUT_DIR)) {
+  const rel = relative(OUT_DIR, filePath);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
     res.writeHead(403); res.end(); return;
   }
 
@@ -71,5 +86,5 @@ createServer((req, res) => {
   // open browser without any dependency
   const { platform } = process;
   const cmd = platform === "win32" ? "start" : platform === "darwin" ? "open" : "xdg-open";
-  import("node:child_process").then(({ exec }) => exec(`${cmd} ${url}`));
+  import("node:child_process").then(({ exec }) => exec(`${cmd} ${url}`, () => {}));
 });

--- a/cli.mjs
+++ b/cli.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const OUT_DIR = resolve(__dirname, "out");
+const portFlag = process.argv.indexOf("--port");
+const preferredPort = portFlag !== -1
+  ? Number(process.argv[portFlag + 1])
+  : process.env.PORT
+    ? Number(process.env.PORT)
+    : 3000;
+
+function findAvailablePort(startPort) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.listen(startPort, () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+    server.on("error", () => resolve(findAvailablePort(startPort + 1)));
+  });
+}
+
+const PORT = await findAvailablePort(preferredPort);
+
+const MIME = {
+  ".html": "text/html",
+  ".js":   "application/javascript",
+  ".css":  "text/css",
+  ".png":  "image/png",
+  ".svg":  "image/svg+xml",
+  ".json": "application/json",
+  ".woff2": "font/woff2",
+  ".glsl": "text/plain",
+};
+
+createServer((req, res) => {
+  let url = req.url ?? "/";
+  // strip query strings
+  url = url.split("?")[0];
+  // Next.js static export uses trailing slashes → serve index.html
+  if (url.endsWith("/")) url += "index.html";
+
+  const filePath = resolve(OUT_DIR, url.replace(/^\//, ""));
+
+  // path traversal guard
+  if (!filePath.startsWith(OUT_DIR)) {
+    res.writeHead(403); res.end(); return;
+  }
+
+  try {
+    const data = readFileSync(filePath);
+    res.writeHead(200, { "Content-Type": MIME[extname(filePath)] ?? "application/octet-stream" });
+    res.end(data);
+  } catch {
+    // fallback to index.html for SPA-style routing
+    try {
+      const data = readFileSync(resolve(OUT_DIR, "index.html"));
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(data);
+    } catch {
+      res.writeHead(404); res.end("Not found");
+    }
+  }
+}).listen(PORT, () => {
+  const url = `http://localhost:${PORT}`;
+  console.log(`Serving on ${url}`);
+  // open browser without any dependency
+  const { platform } = process;
+  const cmd = platform === "win32" ? "start" : platform === "darwin" ? "open" : "xdg-open";
+  import("node:child_process").then(({ exec }) => exec(`${cmd} ${url}`));
+});

--- a/package.json
+++ b/package.json
@@ -38,9 +38,13 @@
   "packageManager": "pnpm@10.11.1",
   "files": [
     "out/",
+    "cli.mjs",
     "README.md",
     "LICENSE"
   ],
+  "bin": {
+    "browzarr": "./cli.mjs"
+  },
   "scripts": {
     "postinstall": "node src/hooks/copy-wasm.mjs",
     "prBuild": "pnpm buildRepo",


### PR DESCRIPTION
with this PR, after publishing to `npm`, users will be able to do

## Usage

### Quick start with `npx` (no installation required)

Run Browzarr directly without installing anything:

```bash
npx browzarr
```

On a custom port:

```bash
npx browzarr --port 8080
```

> **Note:** Requires an internet connection to download the package. The app itself runs fully locally in your browser.

---

### After global installation (offline-friendly)

Install once, run anytime — no internet required after install:

```bash
npm install -g browzarr
```

Then launch:

```bash
browzarr
```

On a custom port:

```bash
browzarr --port 8080
# or via environment variable (macOS/Linux)
PORT=8080 browzarr
# Windows PowerShell
$env:PORT=8080; browzarr
# Windows CMD
set PORT=8080 && browzarr
```

By default, Browzarr starts on port `3000`. If that port is already in use, it will automatically try the next available one.