### PR TITLE
Parameters

### DIFF
--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -1,6 +1,5 @@
 import { create } from "zustand";
 import * as THREE from "three";
-import { cameraPosition } from "three/src/nodes/TSL.js";
 
 type PlotState ={
   plotType: string;

--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import * as THREE from "three";
+import { cameraPosition } from "three/src/nodes/TSL.js";
 
 type PlotState ={
   plotType: string;
@@ -64,6 +65,7 @@ type PlotState ={
   maskValue: number;
   cameraPosition: THREE.Vector3;
   disablePointScale: boolean;
+  camera: THREE.Camera | undefined;
 
   setQuality: (quality: number) => void;
   setTimeScale: (timeScale : number) =>void;
@@ -119,7 +121,9 @@ type PlotState ={
   setUseOrtho: (useOrtho: boolean) => void;
   setFillValue: (fillValue: number | undefined) => void;
   setCameraPosition: (cameraPosition: THREE.Vector3) => void;
+  
 }
+
 
 export const usePlotStore = create<PlotState>((set, get) => ({
   plotType: "volume", 
@@ -185,6 +189,7 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   borderWidth: 0.05,
   cameraPosition: new THREE.Vector3(0, 0, 5),
   disablePointScale: false,
+  camera: undefined,
 
   setVTransferRange: (vTransferRange) => set({ vTransferRange }),
   setVTransferScale: (vTransferScale) => set({ vTransferScale }),
@@ -242,4 +247,5 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   setUseOrtho: (useOrtho) => set({ useOrtho }),
   setFillValue: (fillValue) => set({ fillValue }),
   setCameraPosition: (cameraPosition) => set({ cameraPosition }),
+
 }))

--- a/src/GlobalStates/ZarrStore.ts
+++ b/src/GlobalStates/ZarrStore.ts
@@ -23,6 +23,7 @@ type ZarrState = {
   fetchOptions: FetchStoreOptions | null;
   abortController: AbortController | null;
   fetchKey: number;
+  ncBlobKey: string | undefined; // The key for the stored File blob for a local NC
   
   setZSlice: (zSlice: [number , number | null]) => void;
   setYSlice: (ySlice: [number , number | null]) => void;
@@ -63,6 +64,7 @@ export const useZarrStore = create<ZarrState>((set, get) => ({
   fetchOptions: null,
   abortController: null,
   fetchKey: 0,
+  ncBlobKey: undefined,
 
   setZSlice: (zSlice) => set({ zSlice }),
   setYSlice: (ySlice) => set({ ySlice }),

--- a/src/GlobalStates/ZarrStore.ts
+++ b/src/GlobalStates/ZarrStore.ts
@@ -23,7 +23,7 @@ type ZarrState = {
   fetchOptions: FetchStoreOptions | null;
   abortController: AbortController | null;
   fetchKey: number;
-  ncBlobKey: string | undefined; // The key for the stored File blob for a local NC
+  blobKey: string | undefined; // The key for the stored File blob for a local NC
   
   setZSlice: (zSlice: [number , number | null]) => void;
   setYSlice: (ySlice: [number , number | null]) => void;
@@ -64,7 +64,7 @@ export const useZarrStore = create<ZarrState>((set, get) => ({
   fetchOptions: null,
   abortController: null,
   fetchKey: 0,
-  ncBlobKey: undefined,
+  blobKey: undefined,
 
   setZSlice: (zSlice) => set({ zSlice }),
   setYSlice: (ySlice) => set({ ySlice }),

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -23,27 +23,31 @@ function StoreInitializerInner() {
     const store = searchParams.get("store");
     let data = searchParams.get("data")
     if (data){
-		const fullObj = JSON.parse(data);
-		if (fullObj.zarrState.blobKey){ // If NC local must load file beforehand
-			const blobKey = fullObj.zarrState.blobKey
-			const isNC = fullObj.zarrState.useNC
-			loadFile(blobKey).then(cache =>{
-				if (!isNC){
-					LoadLocalZarr(cache?.blob as File[])
-				} else {
-					//@ts-ignore cache is what we want
-					const file = cache.blob as File
-					loadNetCDF(file, file.name).then(() => {
-						useZarrStore.setState(fullObj.zarrState);
-						useGlobalStore.setState(fullObj.globalState);
-						usePlotStore.setState(fullObj.plotState);
-					})
-				}
-			})
-		} else {
-			useZarrStore.setState(fullObj.zarrState)
-			useGlobalStore.setState(fullObj.globalState)
-			usePlotStore.setState(fullObj.plotState)
+		try{
+			const fullObj = JSON.parse(data);
+			if (fullObj.zarrState.blobKey){ // If NC local must load file beforehand
+				const blobKey = fullObj.zarrState.blobKey
+				const isNC = fullObj.zarrState.useNC
+				loadFile(blobKey).then(cache =>{
+					if (!isNC){
+						LoadLocalZarr(cache?.blob as File[])
+					} else {
+						//@ts-ignore cache is what we want
+						const file = cache.blob as File
+						loadNetCDF(file, file.name).then(() => {
+							useZarrStore.setState(fullObj.zarrState);
+							useGlobalStore.setState(fullObj.globalState);
+							usePlotStore.setState(fullObj.plotState);
+						})
+					}
+				})
+			} else {
+				useZarrStore.setState(fullObj.zarrState)
+				useGlobalStore.setState(fullObj.globalState)
+				usePlotStore.setState(fullObj.plotState)
+			}
+		} catch {
+			console.error('Something Failed :/')
 		}
     }
     if (!store) {

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -8,6 +8,7 @@ import { useShallow } from 'zustand/shallow';
 import { isRemoteStore } from '@/utils/isRemoteStore';
 import { loadNetCDF } from "@/utils/loadNetCDF";
 import { loadFile } from "@/utils/IndexDB";
+import { LoadLocalZarr } from "./ui/MainPanel/LocalZarr";
 
 function StoreInitializerInner() {
   const searchParams = useSearchParams();
@@ -22,23 +23,28 @@ function StoreInitializerInner() {
     const store = searchParams.get("store");
     let data = searchParams.get("data")
     if (data){
-      const fullObj = JSON.parse(data);
-      if (fullObj.zarrState.useNC){ // If NC must load file beforehand
-		const blobKey = fullObj.zarrState.blobKey
-        loadFile(blobKey).then(cache =>{
-			//@ts-ignore cache is what we want
-			const file = cache.blob as File
-			loadNetCDF(file, file.name).then(() => {
-				useZarrStore.setState(fullObj.zarrState);
-				useGlobalStore.setState(fullObj.globalState);
-				usePlotStore.setState(fullObj.plotState);
+		const fullObj = JSON.parse(data);
+		if (fullObj.zarrState.blobKey){ // If NC local must load file beforehand
+			const blobKey = fullObj.zarrState.blobKey
+			const isNC = fullObj.zarrState.useNC
+			loadFile(blobKey).then(cache =>{
+				if (!isNC){
+					LoadLocalZarr(cache?.blob as File[])
+				} else {
+					//@ts-ignore cache is what we want
+					const file = cache.blob as File
+					loadNetCDF(file, file.name).then(() => {
+						useZarrStore.setState(fullObj.zarrState);
+						useGlobalStore.setState(fullObj.globalState);
+						usePlotStore.setState(fullObj.plotState);
+					})
+				}
 			})
-	  })
-      } else {
-		useZarrStore.setState(fullObj.zarrState)
-		useGlobalStore.setState(fullObj.globalState)
-		usePlotStore.setState(fullObj.plotState)
-	  }
+		} else {
+			useZarrStore.setState(fullObj.zarrState)
+			useGlobalStore.setState(fullObj.globalState)
+			usePlotStore.setState(fullObj.plotState)
+		}
     }
     if (!store) {
       setStoreFromURL(false);

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -7,17 +7,7 @@ import { usePlotStore } from "@/GlobalStates/PlotStore";
 import { useShallow } from 'zustand/shallow';
 import { isRemoteStore } from '@/utils/isRemoteStore';
 import { loadNetCDF } from "@/utils/loadNetCDF";
-import { openDB } from "./ui/MainPanel/LocalNetCDF";
-
-async function LoadNCBlob(blobKey:string){
-	const db = await openDB();
-	return new Promise((res, rej) => {
-    const tx = db.transaction('blobs', 'readonly');
-    const req = tx.objectStore('blobs').get(blobKey);
-    req.onsuccess = () => res(req.result ?? null);
-    req.onerror = () => rej(req.error);
-  });
-}
+import { loadFile } from "@/utils/IndexDB";
 
 function StoreInitializerInner() {
   const searchParams = useSearchParams();
@@ -33,12 +23,11 @@ function StoreInitializerInner() {
     let data = searchParams.get("data")
     if (data){
       const fullObj = JSON.parse(data);
-      console.log(fullObj.zarrState)
-      if (fullObj.zarrState.useNC){
-		const blobKey = fullObj.zarrState.ncBlobKey
-        LoadNCBlob(blobKey).then(cache =>{
+      if (fullObj.zarrState.useNC){ // If NC must load file beforehand
+		const blobKey = fullObj.zarrState.blobKey
+        loadFile(blobKey).then(cache =>{
 			//@ts-ignore cache is what we want
-			const file = cache.file
+			const file = cache.blob as File
 			loadNetCDF(file, file.name).then(() => {
 				useZarrStore.setState(fullObj.zarrState);
 				useGlobalStore.setState(fullObj.globalState);

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -3,8 +3,21 @@ import { useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useGlobalStore } from "@/GlobalStates/GlobalStore";
 import { useZarrStore } from '@/GlobalStates/ZarrStore';
+import { usePlotStore } from "@/GlobalStates/PlotStore";
 import { useShallow } from 'zustand/shallow';
 import { isRemoteStore } from '@/utils/isRemoteStore';
+import { loadNetCDF } from "@/utils/loadNetCDF";
+import { openDB } from "./ui/MainPanel/LocalNetCDF";
+
+async function LoadNCBlob(blobKey:string){
+	const db = await openDB();
+	return new Promise((res, rej) => {
+    const tx = db.transaction('blobs', 'readonly');
+    const req = tx.objectStore('blobs').get(blobKey);
+    req.onsuccess = () => res(req.result ?? null);
+    req.onerror = () => rej(req.error);
+  });
+}
 
 function StoreInitializerInner() {
   const searchParams = useSearchParams();
@@ -17,11 +30,32 @@ function StoreInitializerInner() {
 
   useEffect(() => {
     const store = searchParams.get("store");
+    let data = searchParams.get("data")
+    if (data){
+      const fullObj = JSON.parse(data);
+      console.log(fullObj.zarrState)
+      if (fullObj.zarrState.useNC){
+		const blobKey = fullObj.zarrState.ncBlobKey
+        LoadNCBlob(blobKey).then(cache =>{
+			//@ts-ignore cache is what we want
+			const file = cache.file
+			loadNetCDF(file, file.name).then(() => {
+				useZarrStore.setState(fullObj.zarrState);
+				useGlobalStore.setState(fullObj.globalState);
+				usePlotStore.setState(fullObj.plotState);
+			})
+	  })
+      } else {
+		useZarrStore.setState(fullObj.zarrState)
+		useGlobalStore.setState(fullObj.globalState)
+		usePlotStore.setState(fullObj.plotState)
+	  }
+    }
     if (!store) {
       setStoreFromURL(false);
       return;
     }
-
+    
     const isNC = searchParams.get("format") === "nc";
     setUseNC(isNC);
     setFetchNC(isNC);

--- a/src/components/plots/AxisLines.tsx
+++ b/src/components/plots/AxisLines.tsx
@@ -114,9 +114,9 @@ const CubeAxis = ({flipX, flipY, flipDown}: {flipX: boolean, flipY: boolean, fli
   const zDimScale = zResolution/(zResolution-1)
   const zValDelta = 1/(zResolution-1)
 
-  const xTitleOffset = useMemo(() => (dimNames[shapeLength - 1].length * AXIS_CONSTANTS.TITLE_FONT_SIZE_FACTOR / 2 + 0.1) * globalScale, [dimNames, globalScale]);
-  const yTitleOffset = useMemo(() => (dimNames[shapeLength - 2].length * AXIS_CONSTANTS.TITLE_FONT_SIZE_FACTOR / 2 + 0.1) * globalScale, [dimNames, globalScale]);
-  const zTitleOffset = useMemo(() => (dimNames[shapeLength - 3].length * AXIS_CONSTANTS.TITLE_FONT_SIZE_FACTOR / 2 + 0.1) * globalScale, [dimNames, globalScale]);
+  const xTitleOffset = useMemo(() => (dimNames[shapeLength - 1]?.length * AXIS_CONSTANTS.TITLE_FONT_SIZE_FACTOR / 2 + 0.1) * globalScale, [dimNames, globalScale]);
+  const yTitleOffset = useMemo(() => (dimNames[shapeLength - 2]?.length * AXIS_CONSTANTS.TITLE_FONT_SIZE_FACTOR / 2 + 0.1) * globalScale, [dimNames, globalScale]);
+  const zTitleOffset = useMemo(() => (dimNames[shapeLength - 3]?.length * AXIS_CONSTANTS.TITLE_FONT_SIZE_FACTOR / 2 + 0.1) * globalScale, [dimNames, globalScale]);
   
   return (
     <group visible={plotType != 'sphere' && plotType != 'flat' && !hideAxis}>

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -142,6 +142,9 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
   // ---- Camera Ref for state saves ---- //
   useEffect(()=>{
     usePlotStore.setState({camera})
+    return () => {
+      usePlotStore.setState({camera: undefined})
+    }
   },[camera])
 
   return (

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -39,6 +39,7 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
   const hasMounted = useRef(false);
   const cameraRef = useRef<THREE.Camera | null>(null)
   const {set, camera, size} = useThree()
+
   // Reset Camera Position and Target
   useEffect(()=>{
     if (!hasMounted.current) {
@@ -81,6 +82,7 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
     }
   },[resetCamera, isFlat])
 
+  // ---- Switch from Perspective to Orthographic ---- //
   useEffect(()=>{
     if (hasMounted.current){
       let newCamera;
@@ -117,6 +119,7 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
   }
   },[useOrtho])
 
+  // ---- Move camera to position ---- //
   useEffect(()=>{
     const cam = cameraRef.current
     const controls = orbitRef.current
@@ -135,6 +138,11 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
       invalidate()
     }
   },[cameraPosition])
+
+  // ---- Camera Ref for state saves ---- //
+  useEffect(()=>{
+    usePlotStore.setState({camera})
+  },[camera])
 
   return (
     <OrbitControls 

--- a/src/components/ui/MainPanel/LocalContent.tsx
+++ b/src/components/ui/MainPanel/LocalContent.tsx
@@ -40,7 +40,6 @@ const LocalContent = ({
         <LocalZarr
           setShowLocal={setShowLocal ?? (() => {})}
           setOpenVariables={onOpenDescription}
-          setInitStore={setInitStore}
         />
       )}
     </div>

--- a/src/components/ui/MainPanel/LocalNetCDF.tsx
+++ b/src/components/ui/MainPanel/LocalNetCDF.tsx
@@ -3,7 +3,7 @@ import React, {ChangeEvent, useState} from 'react'
 import { Input } from '../input'
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { loadNetCDF, NETCDF_EXT_REGEX } from '@/utils/loadNetCDF';
-
+import { saveFile } from '@/utils/IndexDB';
 import {
   Alert,
   AlertDescription,
@@ -18,15 +18,6 @@ interface LocalNCType {
 
 const DB_NAME = 'browzarr-files';
 const STORE = 'blobs';
-
-export function openDB(): Promise<IDBDatabase> { // This will store File Blobs on disk for re-opening NetCDFs from searchParams.  
-  return new Promise((res, rej) => {
-    const req = indexedDB.open(DB_NAME, 1);
-    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
-    req.onsuccess = () => res(req.result);
-    req.onerror = () => rej(req.error);
-  });
-}
 
 const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
     const {setStatus } = useGlobalStore.getState()
@@ -44,17 +35,10 @@ const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
 		}
 		try {
 			await loadNetCDF(file, file.name);
-			const db = await openDB();
-			const key = `local_${file.name}`
-			new Promise((res, rej) => {
-				const tx = db.transaction(STORE, 'readwrite');
-				tx.objectStore(STORE).put({ file, key }, key);
-				tx.oncomplete = () => {
-					res(key);
-					useZarrStore.setState({ncBlobKey:key})
-				};
-				tx.onerror = () => rej(tx.error);
-			});
+			const blobKey = `local_${file.name}`
+			await saveFile(file, file.name)
+			useZarrStore.setState({blobKey})
+			console.log('Set Key?')
 			setOpenVariables(true)
 		} catch (e) {
 			setError(`Failed to load file: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/components/ui/MainPanel/LocalNetCDF.tsx
+++ b/src/components/ui/MainPanel/LocalNetCDF.tsx
@@ -16,9 +16,6 @@ interface LocalNCType {
   setOpenVariables: (open: boolean) => void;
 }
 
-const DB_NAME = 'browzarr-files';
-const STORE = 'blobs';
-
 const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
     const {setStatus } = useGlobalStore.getState()
     // const {ncModule} = useZarrStore.getState()
@@ -36,7 +33,7 @@ const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
 		try {
 			await loadNetCDF(file, file.name);
 			const blobKey = `local_${file.name}`
-			await saveFile(file, file.name)
+			await saveFile(file, blobKey)
 			useZarrStore.setState({blobKey})
 			console.log('Set Key?')
 			setOpenVariables(true)

--- a/src/components/ui/MainPanel/LocalNetCDF.tsx
+++ b/src/components/ui/MainPanel/LocalNetCDF.tsx
@@ -10,9 +10,22 @@ import {
   AlertTitle,
 } from '@/components/ui/alert';
 import { isMobile } from '../MobileUIHider';
+import { useZarrStore } from '@/GlobalStates/ZarrStore';
 
 interface LocalNCType {
   setOpenVariables: (open: boolean) => void;
+}
+
+const DB_NAME = 'browzarr-files';
+const STORE = 'blobs';
+
+export function openDB(): Promise<IDBDatabase> { // This will store File Blobs on disk for re-opening NetCDFs from searchParams.  
+  return new Promise((res, rej) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
 }
 
 const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
@@ -20,23 +33,33 @@ const LocalNetCDF = ({ setOpenVariables}:LocalNCType) => {
     // const {ncModule} = useZarrStore.getState()
     const [ncError, setError] = useState<string | null>(null);
 
-    const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
-    setError(null);
-    const files = event.target.files;
-    if (!files || files.length === 0) { setStatus(null); return; }
-    const file = files[0];
-    if (!NETCDF_EXT_REGEX.test(file.name)) {
-      setError('Please select a valid NetCDF (.nc, .netcdf, .nc3, .nc4) file.');
-      return;
-    }
-    try {
-      await loadNetCDF(file, file.name);
-      setOpenVariables(true)
-
-    } catch (e) {
-      setError(`Failed to load file: ${e instanceof Error ? e.message : String(e)}`);
-    }
-  };
+	const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+		setError(null);
+		const files = event.target.files;
+		if (!files || files.length === 0) { setStatus(null); return; }
+		const file = files[0];
+		if (!NETCDF_EXT_REGEX.test(file.name)) {
+			setError('Please select a valid NetCDF (.nc, .netcdf, .nc3, .nc4) file.');
+			return;
+		}
+		try {
+			await loadNetCDF(file, file.name);
+			const db = await openDB();
+			const key = `local_${file.name}`
+			new Promise((res, rej) => {
+				const tx = db.transaction(STORE, 'readwrite');
+				tx.objectStore(STORE).put({ file, key }, key);
+				tx.oncomplete = () => {
+					res(key);
+					useZarrStore.setState({ncBlobKey:key})
+				};
+				tx.onerror = () => rej(tx.error);
+			});
+			setOpenVariables(true)
+		} catch (e) {
+			setError(`Failed to load file: ${e instanceof Error ? e.message : String(e)}`);
+		}
+  	};
 
   return (
     <div className="w-full">

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -13,18 +13,9 @@ interface LocalZarrType {
   setInitStore: (store: string) => void;
 }
 
-const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
-  const setCurrentStore = useZarrStore(state => state.setCurrentStore)
-  const {setStatus} = useGlobalStore.getState()
-  const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files;
-    if (!files || files.length === 0) {
-      setStatus(null)
-      return;
-    }
-    // Create a Map to hold the Zarr store data
+export async function LoadLocalZarr(files:File[]){
+  // Create a Map to hold the Zarr store data
     const fileMap = new Map<string, File>();
-
     // The base directory name will be the first part of the relative path
     const baseDir = files[0].webkitRelativePath.split('/')[0];
 
@@ -36,7 +27,6 @@ const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType)
         fileMap.set('/' + relativePath, file); // Zarrita looks for a leading slash before variables. Need to add it back
       }
     }
-
     // Create a custom zarrita store from the Map
     const customStore: zarr.AsyncReadable = {
       async get(key: string): Promise<Uint8Array | undefined> {
@@ -49,39 +39,53 @@ const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType)
       // Open the Zarr store using the custom store
       let store = await zarr.withMaybeConsolidatedMetadata(customStore);
       if (!('contents' in store)){
+        console.log("Trying to parse?")
         // Metadata is missing. We will need to parse variables here. 
         store = await ZarrParser(files, customStore)
       }
+      console.log("Here?")
       const gs = await zarr.open(store, {kind: 'group'});
       const blobKey = `local_${baseDir}`
-      //saveFile(gs, blobKey)
-      setCurrentStore(gs);
-      setShowLocal(false);
-      setOpenVariables(true);
-      setInitStore(blobKey)
-      setStatus(null)
-      useZarrStore.setState({ useNC: false})
+      useGlobalStore.setState({initStore:blobKey})
+      useZarrStore.setState({ useNC: false, blobKey, currentStore:gs})
     } catch (error) {
-      setStatus(null)
+      
       if (error instanceof Error) {
         console.log(`Error opening Zarr store: ${error.message}`);
       } else {
         console.log('An unknown error occurred when opening the Zarr store.');
       }
     }
-  };
-  return (
-    <div>
-        <Input type="file" id="filepicker"
-          className='hover:drop-shadow-md hover:scale-[110%]'
-          style={{width:'200px', cursor:'pointer'}}
-          // @ts-expect-error `webkitdirectory` is non-standard attribute. TS doesn't know about it. It's used for cross-browser compatibility.
-          directory=''
-          webkitdirectory='true'
-          onChange={handleFileSelect}
-        />
-    </div>
-  )
+}
+
+const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
+	const {setStatus} = useGlobalStore.getState()
+	const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+		const files = event.target.files;
+		if (!files || files.length === 0) {
+			setStatus(null)
+			return;
+		}
+		const baseDir = files[0].webkitRelativePath.split('/')[0];
+		LoadLocalZarr(Array.from(files)).then(()=>{
+		saveFile(Array.from(files), `local_${baseDir}`)
+		setShowLocal(false);
+		setOpenVariables(true);
+		setStatus(null)
+		})
+	};
+	return (
+		<div>
+			<Input type="file" id="filepicker"
+			className='hover:drop-shadow-md hover:scale-[110%]'
+			style={{width:'200px', cursor:'pointer'}}
+			// @ts-expect-error `webkitdirectory` is non-standard attribute. TS doesn't know about it. It's used for cross-browser compatibility.
+			directory=''
+			webkitdirectory='true'
+			onChange={handleFileSelect}
+			/>
+		</div>
+	)
 }
 
 export default LocalZarr

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -5,6 +5,7 @@ import { useZarrStore } from '@/GlobalStates/ZarrStore';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { Input } from '../input';
 import ZarrParser from '@/components/zarr/ZarrParser';
+import { saveFile } from '@/utils/IndexDB';
 
 interface LocalZarrType {
   setShowLocal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -52,10 +53,12 @@ const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType)
         store = await ZarrParser(files, customStore)
       }
       const gs = await zarr.open(store, {kind: 'group'});
+      const blobKey = `local_${baseDir}`
+      //saveFile(gs, blobKey)
       setCurrentStore(gs);
       setShowLocal(false);
       setOpenVariables(true);
-      setInitStore(`local_${baseDir}`)
+      setInitStore(blobKey)
       setStatus(null)
       useZarrStore.setState({ useNC: false})
     } catch (error) {

--- a/src/components/ui/MainPanel/LocalZarr.tsx
+++ b/src/components/ui/MainPanel/LocalZarr.tsx
@@ -10,7 +10,6 @@ import { saveFile } from '@/utils/IndexDB';
 interface LocalZarrType {
   setShowLocal: React.Dispatch<React.SetStateAction<boolean>>;
   setOpenVariables: (open: boolean) => void;
-  setInitStore: (store: string) => void;
 }
 
 export async function LoadLocalZarr(files:File[]){
@@ -43,7 +42,6 @@ export async function LoadLocalZarr(files:File[]){
         // Metadata is missing. We will need to parse variables here. 
         store = await ZarrParser(files, customStore)
       }
-      console.log("Here?")
       const gs = await zarr.open(store, {kind: 'group'});
       const blobKey = `local_${baseDir}`
       useGlobalStore.setState({initStore:blobKey})
@@ -58,7 +56,7 @@ export async function LoadLocalZarr(files:File[]){
     }
 }
 
-const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType) => {
+const LocalZarr = ({setShowLocal, setOpenVariables}:LocalZarrType) => {
 	const {setStatus} = useGlobalStore.getState()
 	const handleFileSelect = async (event: ChangeEvent<HTMLInputElement>) => {
 		const files = event.target.files;
@@ -68,21 +66,21 @@ const LocalZarr = ({setShowLocal, setOpenVariables, setInitStore}:LocalZarrType)
 		}
 		const baseDir = files[0].webkitRelativePath.split('/')[0];
 		LoadLocalZarr(Array.from(files)).then(()=>{
-		saveFile(Array.from(files), `local_${baseDir}`)
-		setShowLocal(false);
-		setOpenVariables(true);
-		setStatus(null)
+      saveFile(Array.from(files), `local_${baseDir}`)
+      setShowLocal(false);
+      setOpenVariables(true);
+      setStatus(null)
 		})
 	};
 	return (
 		<div>
 			<Input type="file" id="filepicker"
-			className='hover:drop-shadow-md hover:scale-[110%]'
-			style={{width:'200px', cursor:'pointer'}}
-			// @ts-expect-error `webkitdirectory` is non-standard attribute. TS doesn't know about it. It's used for cross-browser compatibility.
-			directory=''
-			webkitdirectory='true'
-			onChange={handleFileSelect}
+        className='hover:drop-shadow-md hover:scale-[110%]'
+        style={{width:'200px', cursor:'pointer'}}
+        // @ts-expect-error `webkitdirectory` is non-standard attribute. TS doesn't know about it. It's used for cross-browser compatibility.
+        directory=''
+        webkitdirectory='true'
+        onChange={handleFileSelect}
 			/>
 		</div>
 	)

--- a/src/components/ui/NavBar/Navbar.tsx
+++ b/src/components/ui/NavBar/Navbar.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
+import { ParameterExport } from "./ParameterExport";
 import { Orthographic, Perspective } from "../Elements/Icons";
 import PerformanceMode from "./PerformanceMode";
 
@@ -108,6 +109,7 @@ const Navbar = React.memo(function Navbar() {
 					</Button>
 					<PlotLineButton />
 					<ExportImageSettings />
+					<ParameterExport />
 					<PerformanceMode />
 				</div>
 			</div>

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react'
+import { useGlobalStore } from '@/GlobalStates/GlobalStore'
+import { usePlotStore } from '@/GlobalStates/PlotStore'
+import { useZarrStore } from '@/GlobalStates/ZarrStore'
+import { BiExport } from "react-icons/bi";
+import { FiCopy } from "react-icons/fi";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
+import { Button } from '../button';
+
+function pick(obj: Record<string, any>, keys: string[]) {
+    return Object.fromEntries(
+        keys.map((k) => [k, obj[k]])
+    )
+}
+const globalValues = [
+    'initStore',
+    'storeFromURL',
+    'variable',
+]
+
+const plotValues = [
+    'PlotType',
+    'pointSize',
+    'scalePoints',
+    'scaleIntensity',
+    'timeScale',
+    'valueRange',
+    'xRange',
+    'yRange',
+    'zRange',
+    'showPoints',
+    'linePointSize',
+    'lineWidth',
+    'lineColor',
+    'pointColor',
+    'useLineColor',
+    'lineResolution',
+    'cOffset',
+    'cScale',
+    'useFragOpt',
+    'useCustomColor',
+    'useCustomPointColor',
+    'transparency',
+    'nanTransparency',
+    'nanColor',
+    'showBorders',
+    'borderColor',
+    'lonExtent',
+    'latExtent',
+    'originalExtent',
+    'lonResolution',
+    'latResolution',
+    'colorIdx',
+    'vTransferRange',
+    'vTransferScale',
+    'sphereResolution',
+    'displacement',
+    'displaceSurface',
+    'offsetNegatives',
+    'zSlice',
+    'ySlice',
+    'xSlice',
+    'interpPixels',
+    'useOrtho',
+    'rotateFlat',
+    'fillValue',
+    'coarsen',
+    'kernel',
+    'useBorderTexture',
+    'maskValue',
+    'borderWidth',
+    'cameraPosition',
+    'disablePointScale',
+
+]
+
+const zarrValues = [
+    'zSlice',
+    'ySlice',
+    'xSlice',
+    'compress',
+    'useNC', // This one is more static and so toggling switch doesn't break all other logic
+    'fetchNC',
+    'coarsen',
+    'kernelSize',
+    'kernelDepth',
+    'icechunkOptions',
+    'fetchOptions',
+    'fetchKey',
+    'ncBlobKey'
+]
+
+
+export const ParameterExport = () => {
+    const [copied, setCopied] = useState(false);
+
+    function generateURL(){
+        const fullObj = {
+            globalState: pick(useGlobalStore.getState(), globalValues),
+            plotState: pick(usePlotStore.getState(), plotValues),
+            zarrState: pick(useZarrStore.getState(), zarrValues),
+        }
+        const jString = JSON.stringify(fullObj, (_, v) => typeof v === 'bigint' ? v.toString() : v)
+        const params = `https://browzarr.io/latest/?data=${encodeURIComponent(jString)}`
+        return params
+    }
+
+    const copyToClipboard = async () => {
+        const url = generateURL()
+        await navigator.clipboard.writeText(url);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    };
+    
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button 
+                    variant="ghost"
+                    size="icon"
+                    className="cursor-pointer" 
+                    onClick={copyToClipboard}
+                >
+                    <BiExport className='size-8'/>
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent>
+                <div
+                    
+                >
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="cursor-pointer" 
+                    >
+                        <FiCopy className='size-5'/>
+                    </Button>
+                        
+                    
+                </div> 
+            </PopoverContent>
+        </Popover>
+    )
+}
+
+

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -71,7 +71,6 @@ const plotValues = [
     'borderWidth',
     'cameraPosition',
     'disablePointScale',
-
 ]
 
 const zarrValues = [
@@ -95,6 +94,8 @@ export const ParameterExport = () => {
     const [copied, setCopied] = useState(false);
 
     function generateURL(){
+        const {camera} = usePlotStore.getState()
+        usePlotStore.setState({cameraPosition:camera?.position})
         const fullObj = {
             globalState: pick(useGlobalStore.getState(), globalValues),
             plotState: pick(usePlotStore.getState(), plotValues),
@@ -109,7 +110,7 @@ export const ParameterExport = () => {
         const url = generateURL()
         await navigator.clipboard.writeText(url);
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        setTimeout(() => setCopied(false), 1500); //Use for a pop-up that fades away
     };
     
     return (
@@ -119,24 +120,33 @@ export const ParameterExport = () => {
                     variant="ghost"
                     size="icon"
                     className="cursor-pointer" 
-                    onClick={copyToClipboard}
                 >
                     <BiExport className='size-8'/>
                 </Button>
             </PopoverTrigger>
-            <PopoverContent>
+            <PopoverContent
+                side="right"
+                className='w-[200px]'
+            >
                 <div
-                    
+                    className='flex items-center'
                 >
                     <Button
                         variant="ghost"
                         size="icon"
                         className="cursor-pointer" 
+                        onClick={copyToClipboard}
                     >
                         <FiCopy className='size-5'/>
                     </Button>
-                        
-                    
+                        <div
+                            style={{
+                                opacity:copied ? 1 : 0,
+                                transition:'0.75s'
+                            }}
+                        >
+                            Copied!
+                        </div>
                 </div> 
             </PopoverContent>
         </Popover>

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -19,7 +19,7 @@ const globalValues = [
 ]
 
 const plotValues = [
-    'PlotType',
+    'plotType',
     'pointSize',
     'scalePoints',
     'scaleIntensity',

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -95,7 +95,7 @@ export const ParameterExport = () => {
 
     function generateURL(){
         const {camera} = usePlotStore.getState()
-        usePlotStore.setState({cameraPosition:camera?.position})
+        usePlotStore.setState({cameraPosition:camera?.position}) // Set Camera position first to copy visual state
         const fullObj = {
             globalState: pick(useGlobalStore.getState(), globalValues),
             plotState: pick(usePlotStore.getState(), plotValues),

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -102,7 +102,7 @@ export const ParameterExport = () => {
             zarrState: pick(useZarrStore.getState(), zarrValues),
         }
         const jString = JSON.stringify(fullObj, (_, v) => typeof v === 'bigint' ? v.toString() : v)
-        const params = `http://localhost:3000/?data=${encodeURIComponent(jString)}` //`https://browzarr.io/latest/?data=${encodeURIComponent(jString)}` 
+        const params = `https://browzarr.io/latest/?data=${encodeURIComponent(jString)}` 
         return params
     }
 

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -87,7 +87,7 @@ const zarrValues = [
     'icechunkOptions',
     'fetchOptions',
     'fetchKey',
-    'ncBlobKey'
+    'blobKey'
 ]
 
 
@@ -101,7 +101,7 @@ export const ParameterExport = () => {
             zarrState: pick(useZarrStore.getState(), zarrValues),
         }
         const jString = JSON.stringify(fullObj, (_, v) => typeof v === 'bigint' ? v.toString() : v)
-        const params = `https://browzarr.io/latest/?data=${encodeURIComponent(jString)}`
+        const params = `http://localhost:3000/?data=${encodeURIComponent(jString)}` //`https://browzarr.io/latest/?data=${encodeURIComponent(jString)}` 
         return params
     }
 

--- a/src/components/zarr/ZarrParser.ts
+++ b/src/components/zarr/ZarrParser.ts
@@ -11,6 +11,7 @@ function is_v3(meta: any) {
     return "zarr_format" in meta && meta.zarr_format === 3;
 }
 async function ZarrParser(files: any, store: any){
+    console.log(store)
     const fileCount = files.length;
     const vars = []
     const metadata: { [key: string]: any } = {}
@@ -26,6 +27,7 @@ async function ZarrParser(files: any, store: any){
     }
     for (const variable of vars){
         const decoded = await store.get(variable)
+        console.log(decoded)
         metadata[variable.slice(1)] = jsonDecodeObject(decoded)
     }
     const v2_meta = {metadata, zarr_consolidated_format: 1}

--- a/src/utils/IndexDB.ts
+++ b/src/utils/IndexDB.ts
@@ -11,7 +11,7 @@ export function openDB(): Promise<IDBDatabase> {
   });
 }
 
-export async function saveFile(blob: Blob, key: string): Promise<string> {
+export async function saveFile(blob: any, key: string): Promise<string> {
   const db = await openDB();
   return new Promise((res, rej) => {
     const tx = db.transaction(STORE, 'readwrite');
@@ -21,7 +21,7 @@ export async function saveFile(blob: Blob, key: string): Promise<string> {
   });
 }
 
-export async function loadFile(key: string): Promise<{ blob: Blob; name: string } | null> {
+export async function loadFile(key: string): Promise<{ blob: any; name: string } | null> {
   const db = await openDB();
   console.log(key)
   return new Promise((res, rej) => {

--- a/src/utils/IndexDB.ts
+++ b/src/utils/IndexDB.ts
@@ -1,0 +1,33 @@
+const DB_NAME = 'browzarr-files';
+const STORE = 'blobs';
+
+
+export function openDB(): Promise<IDBDatabase> { 
+  return new Promise((res, rej) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE);
+    req.onsuccess = () => res(req.result);
+    req.onerror = () => rej(req.error);
+  });
+}
+
+export async function saveFile(blob: Blob, key: string): Promise<string> {
+  const db = await openDB();
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put({ blob, key }, key);
+    tx.oncomplete = () => res(key);
+    tx.onerror = () => rej(tx.error);
+  });
+}
+
+export async function loadFile(key: string): Promise<{ blob: Blob; name: string } | null> {
+  const db = await openDB();
+  console.log(key)
+  return new Promise((res, rej) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get(key);
+    req.onsuccess = () => res(req.result ?? null);
+    req.onerror = () => rej(req.error);
+  });
+}

--- a/src/utils/IndexDB.ts
+++ b/src/utils/IndexDB.ts
@@ -23,7 +23,6 @@ export async function saveFile(blob: any, key: string): Promise<string> {
 
 export async function loadFile(key: string): Promise<{ blob: any; name: string } | null> {
   const db = await openDB();
-  console.log(key)
   return new Promise((res, rej) => {
     const tx = db.transaction(STORE, 'readonly');
     const req = tx.objectStore(STORE).get(key);


### PR DESCRIPTION
This update adds a button and back-end for saving and restoring plots based on states.

<img width="265" height="214" alt="copied" src="https://github.com/user-attachments/assets/0c3dc1a3-72a8-41b5-ac0a-c1bec9f3a7a7" />

Clicking this button copies all of the current settings to URL. This also opens things up to being more easily compatible with a coding library eventually. 

At the moment it is crazy long. Will update it later to only save the states that are changed from default values. 
At the moment it _doesnt_ work with local zarr files through the Browser. Or local NetCDF from Julia. Julia will be fairly easily fixable. Local Zarr through browser may not be easily doable. 

### Future: Will add more information in the menu informign what's going on. As well as downloading a file `json/yaml` to upload instead of having to store the url somewhere. 

example:

https://browzarr.io/latest/?data=%7B%22globalState%22%3A%7B%22initStore%22%3A%22https%3A%2F%2Fs3.bgc-jena.mpg.de%3A9000%2Fesdl-esdc-v3.0.2%2Fesdc-16d-2.5deg-46x72x1440-3.0.2.zarr%22%2C%22storeFromURL%22%3Afalse%2C%22variable%22%3A%22air_temperature_2m%22%7D%2C%22plotState%22%3A%7B%22pointSize%22%3A5%2C%22scalePoints%22%3Afalse%2C%22scaleIntensity%22%3A1%2C%22timeScale%22%3A1%2C%22valueRange%22%3A%5B0%2C1%5D%2C%22xRange%22%3A%5B-1%2C1%5D%2C%22yRange%22%3A%5B-1%2C1%5D%2C%22zRange%22%3A%5B-1%2C1%5D%2C%22showPoints%22%3Atrue%2C%22linePointSize%22%3A2%2C%22lineWidth%22%3A1.25%2C%22lineColor%22%3A%22%23111111%22%2C%22pointColor%22%3A%22%23EA8686%22%2C%22useLineColor%22%3Afalse%2C%22lineResolution%22%3A3%2C%22cOffset%22%3A0%2C%22cScale%22%3A1%2C%22useFragOpt%22%3Afalse%2C%22useCustomColor%22%3Afalse%2C%22useCustomPointColor%22%3Afalse%2C%22transparency%22%3A0%2C%22nanTransparency%22%3A1%2C%22nanColor%22%3A%22%23000000%22%2C%22showBorders%22%3Afalse%2C%22borderColor%22%3A%22%23000000%22%2C%22lonExtent%22%3A%5B-180%2C180%5D%2C%22latExtent%22%3A%5B-90%2C90%5D%2C%22originalExtent%22%3A%7B%22x%22%3A-180%2C%22y%22%3A180%2C%22z%22%3A-90%2C%22w%22%3A90%7D%2C%22lonResolution%22%3A1%2C%22latResolution%22%3A1%2C%22colorIdx%22%3A0%2C%22vTransferRange%22%3Afalse%2C%22vTransferScale%22%3A1%2C%22sphereResolution%22%3A10%2C%22displacement%22%3A0%2C%22displaceSurface%22%3Atrue%2C%22offsetNegatives%22%3Atrue%2C%22zSlice%22%3A%5B0%2Cnull%5D%2C%22ySlice%22%3A%5B0%2Cnull%5D%2C%22xSlice%22%3A%5B0%2Cnull%5D%2C%22interpPixels%22%3Afalse%2C%22useOrtho%22%3Afalse%2C%22rotateFlat%22%3Afalse%2C%22coarsen%22%3Afalse%2C%22kernel%22%3A%7B%22kernelDepth%22%3A1%2C%22kernelSize%22%3A1%7D%2C%22useBorderTexture%22%3Afalse%2C%22maskValue%22%3A0%2C%22borderWidth%22%3A0.05%2C%22cameraPosition%22%3A%7B%22x%22%3A-3.780967105888259%2C%22y%22%3A-1.5251678420343258%2C%22z%22%3A-2.8945035494563265%7D%2C%22disablePointScale%22%3Afalse%7D%2C%22zarrState%22%3A%7B%22zSlice%22%3A%5B0%2C322%5D%2C%22ySlice%22%3A%5B0%2Cnull%5D%2C%22xSlice%22%3A%5B0%2Cnull%5D%2C%22compress%22%3Afalse%2C%22useNC%22%3Afalse%2C%22fetchNC%22%3Afalse%2C%22coarsen%22%3Afalse%2C%22kernelSize%22%3A2%2C%22kernelDepth%22%3A2%2C%22icechunkOptions%22%3Anull%2C%22fetchOptions%22%3Anull%2C%22fetchKey%22%3A0%7D%7D

