### PR TITLE
adds icechunk catalog

### DIFF
--- a/src/components/ui/MainPanel/DataSetsModal.tsx
+++ b/src/components/ui/MainPanel/DataSetsModal.tsx
@@ -120,7 +120,6 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 activeOption={activeOption}
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedUrl}
-                onOpenDescription={() => {}}
               />
               <RemoteZarr
                 key={selectedUrl}
@@ -147,7 +146,6 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 activeOption={activeOption}
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedIcechunkUrl}
-                onOpenDescription={() => {}}
               />
               <RemoteIcechunk
                 key={selectedIcechunkUrl}

--- a/src/components/ui/MainPanel/DataSetsModal.tsx
+++ b/src/components/ui/MainPanel/DataSetsModal.tsx
@@ -15,6 +15,7 @@ import { ZARR_CATALOG, ICECHUNK_CATALOG } from "@/assets/index";
 import RemoteZarr from './RemoteZarr';
 import LocalContent from './LocalContent';
 import RemoteIcechunk from './RemoteIcechunk';
+import { Separator } from "@/components/ui/separator"
 
 type Tab = 'remote' | 'local' | 'icechunk';
 
@@ -103,8 +104,11 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 onOpenDescription={openDescription}
                 selectedUrl={selectedUrl}
               />
+              <Separator className="mb-2 mt-2"/>
               <StoreCatalog
                 catalog={ZARR_CATALOG}
+                placeholder="Search Zarr Stores..."
+                gradient="zarr"
                 activeOption={activeOption}
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedUrl}
@@ -127,8 +131,11 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 onOpenDescription={openDescription}
                 selectedUrl={selectedIcechunkUrl}
               />
+              <Separator className="mb-2 mt-2"/>
               <StoreCatalog
                 catalog={ICECHUNK_CATALOG}
+                placeholder="Search Icechunk Stores..."
+                gradient="icechunk"
                 activeOption={activeOption}
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedIcechunkUrl}

--- a/src/components/ui/MainPanel/DataSetsModal.tsx
+++ b/src/components/ui/MainPanel/DataSetsModal.tsx
@@ -10,7 +10,8 @@ import {
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Button } from "@/components/ui/button-enhanced";
 import { DescriptionContent } from './DescriptionContent';
-import CuratedDatasets from './CuratedDatasets';
+import StoreCatalog from './StoreCatalog';
+import { ZARR_CATALOG, ICECHUNK_CATALOG } from "@/assets/index";
 import RemoteZarr from './RemoteZarr';
 import LocalContent from './LocalContent';
 import RemoteIcechunk from './RemoteIcechunk';
@@ -32,6 +33,7 @@ type Props = {
 const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
   const [activeOption, setActiveOption] = useState<string>('');
   const [selectedUrl, setSelectedUrl] = useState<string>('');
+  const [selectedIcechunkUrl, setSelectedIcechunkUrl] = useState<string>('');
   const [hasFetched, setHasFetched] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>('remote');
 
@@ -51,12 +53,14 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
     setActiveTab(tab);
     setHasFetched(false);
     setSelectedUrl('');
+    setSelectedIcechunkUrl('');
     setActiveOption('');
   };
 
   const handleOpenChange = (v: boolean) => {
     if (!v) {
       setSelectedUrl('');
+      setSelectedIcechunkUrl('');
       setActiveOption('');
       setHasFetched(false);
     }
@@ -99,7 +103,8 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 onOpenDescription={openDescription}
                 selectedUrl={selectedUrl}
               />
-              <CuratedDatasets
+              <StoreCatalog
+                catalog={ZARR_CATALOG}
                 activeOption={activeOption}
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedUrl}
@@ -115,10 +120,21 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
             />
           )}
           {activeTab === 'icechunk' && (
-            <RemoteIcechunk
-              setInitStore={setInitStore}
-              onOpenDescription={openDescription}
-            />
+            <>
+              <RemoteIcechunk
+                key={selectedIcechunkUrl}
+                setInitStore={setInitStore}
+                onOpenDescription={openDescription}
+                selectedUrl={selectedIcechunkUrl}
+              />
+              <StoreCatalog
+                catalog={ICECHUNK_CATALOG}
+                activeOption={activeOption}
+                setActiveOption={setActiveOption}
+                setInitStore={setSelectedIcechunkUrl}
+                onOpenDescription={() => {}}
+              />
+            </>
           )}
           {showDescription && (
             <DescriptionContent

--- a/src/components/ui/MainPanel/DataSetsModal.tsx
+++ b/src/components/ui/MainPanel/DataSetsModal.tsx
@@ -7,9 +7,7 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  ButtonGroup,
-} from "@/components/ui/button-group";
+import { ButtonGroup } from "@/components/ui/button-group";
 import { Button } from "@/components/ui/button-enhanced";
 import { DescriptionContent } from './DescriptionContent';
 import CuratedDatasets from './CuratedDatasets';
@@ -17,13 +15,12 @@ import RemoteZarr from './RemoteZarr';
 import LocalContent from './LocalContent';
 import RemoteIcechunk from './RemoteIcechunk';
 
-type Tab = 'curated' | 'remote' | 'local' | 'icechunk';
+type Tab = 'remote' | 'local' | 'icechunk';
 
 const TABS: { value: Tab; label: string }[] = [
-  { value: 'curated', label: 'Curated' },
-  { value: 'remote',  label: 'Remote Zarr' },
-  { value: 'icechunk', label: 'Icechunk' },
-  { value: 'local',   label: 'Local' },
+  { value: 'remote',   label: 'Remote Zarr' },
+  { value: 'icechunk', label: 'Icechunk'    },
+  { value: 'local',    label: 'Local'       },
 ];
 
 type Props = {
@@ -34,8 +31,9 @@ type Props = {
 
 const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
   const [activeOption, setActiveOption] = useState<string>('');
+  const [selectedUrl, setSelectedUrl] = useState<string>('');
   const [hasFetched, setHasFetched] = useState(false);
-  const [activeTab, setActiveTab] = useState<Tab>('curated');
+  const [activeTab, setActiveTab] = useState<Tab>('remote');
 
   const { initStore, setInitStore, setOpenVariables, status } = useGlobalStore(
     useShallow(state => ({
@@ -47,16 +45,26 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
   );
 
   const showDescription = hasFetched && status === null;
-
   const openDescription = () => setHasFetched(true);
 
   const handleTabChange = (tab: Tab) => {
     setActiveTab(tab);
     setHasFetched(false);
+    setSelectedUrl('');
+    setActiveOption('');
+  };
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v) {
+      setSelectedUrl('');
+      setActiveOption('');
+      setHasFetched(false);
+    }
+    onOpenChange(v);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange }>
       <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0">
         <DialogTitle className="sr-only">Open Dataset</DialogTitle>
 
@@ -82,20 +90,22 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
         </div>
 
         <div className="p-4 flex flex-col gap-1 -mt-3">
-          {activeTab === 'curated' && (
-            <CuratedDatasets
-              activeOption={activeOption}
-              setActiveOption={setActiveOption}
-              setInitStore={setInitStore}
-              onOpenDescription={openDescription}
-            />
-          )}
           {activeTab === 'remote' && (
-            <RemoteZarr
-              initStore={initStore}
-              setInitStore={setInitStore}
-              onOpenDescription={openDescription}
-            />
+            <>
+              <RemoteZarr
+                key={selectedUrl}
+                initStore={initStore}
+                setInitStore={setInitStore}
+                onOpenDescription={openDescription}
+                selectedUrl={selectedUrl}
+              />
+              <CuratedDatasets
+                activeOption={activeOption}
+                setActiveOption={setActiveOption}
+                setInitStore={setSelectedUrl}
+                onOpenDescription={() => {}}
+              />
+            </>
           )}
           {activeTab === 'local' && (
             <LocalContent

--- a/src/components/ui/MainPanel/DataSetsModal.tsx
+++ b/src/components/ui/MainPanel/DataSetsModal.tsx
@@ -96,15 +96,7 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
 
         <div className="p-4 flex flex-col gap-1 -mt-3">
           {activeTab === 'remote' && (
-            <>
-              <RemoteZarr
-                key={selectedUrl}
-                initStore={initStore}
-                setInitStore={setInitStore}
-                onOpenDescription={openDescription}
-                selectedUrl={selectedUrl}
-              />
-              <Separator className="mb-2 mt-2"/>
+            <>             
               <StoreCatalog
                 catalog={ZARR_CATALOG}
                 placeholder="Search Zarr Stores..."
@@ -113,6 +105,13 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedUrl}
                 onOpenDescription={() => {}}
+              />
+               <RemoteZarr
+                key={selectedUrl}
+                initStore={initStore}
+                setInitStore={setInitStore}
+                onOpenDescription={openDescription}
+                selectedUrl={selectedUrl}
               />
             </>
           )}
@@ -125,13 +124,6 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
           )}
           {activeTab === 'icechunk' && (
             <>
-              <RemoteIcechunk
-                key={selectedIcechunkUrl}
-                setInitStore={setInitStore}
-                onOpenDescription={openDescription}
-                selectedUrl={selectedIcechunkUrl}
-              />
-              <Separator className="mb-2 mt-2"/>
               <StoreCatalog
                 catalog={ICECHUNK_CATALOG}
                 placeholder="Search Icechunk Stores..."
@@ -140,6 +132,12 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 setActiveOption={setActiveOption}
                 setInitStore={setSelectedIcechunkUrl}
                 onOpenDescription={() => {}}
+              />
+              <RemoteIcechunk
+                key={selectedIcechunkUrl}
+                setInitStore={setInitStore}
+                onOpenDescription={openDescription}
+                selectedUrl={selectedIcechunkUrl}
               />
             </>
           )}

--- a/src/components/ui/MainPanel/DataSetsModal.tsx
+++ b/src/components/ui/MainPanel/DataSetsModal.tsx
@@ -5,6 +5,8 @@ import { useShallow } from 'zustand/shallow';
 import {
   Dialog,
   DialogContent,
+  DialogHeader,
+  DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ButtonGroup } from "@/components/ui/button-group";
@@ -15,7 +17,6 @@ import { ZARR_CATALOG, ICECHUNK_CATALOG } from "@/assets/index";
 import RemoteZarr from './RemoteZarr';
 import LocalContent from './LocalContent';
 import RemoteIcechunk from './RemoteIcechunk';
-import { Separator } from "@/components/ui/separator"
 
 type Tab = 'remote' | 'local' | 'icechunk';
 
@@ -24,6 +25,12 @@ const TABS: { value: Tab; label: string }[] = [
   { value: 'icechunk', label: 'Icechunk'    },
   { value: 'local',    label: 'Local'       },
 ];
+
+const TAB_DESCRIPTIONS: Record<Tab, string> = {
+  remote: 'Browse and open remote Zarr stores via URL or from the catalog.',
+  icechunk: 'Connect to versioned Icechunk stores for transactional data access.',
+  local: 'Open a Zarr dataset stored on your local filesystem.',
+};
 
 type Props = {
   open: boolean;
@@ -69,16 +76,25 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange }>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0">
-        <DialogTitle className="sr-only">Open Dataset</DialogTitle>
+        <DialogHeader className="sr-only">
+          <DialogTitle>Open dataset</DialogTitle>
+          <DialogDescription>{TAB_DESCRIPTIONS[activeTab]}</DialogDescription>
+        </DialogHeader>
 
-        {/* Header */}
         <div className="px-4 pt-4 pb-3 border-b border-border">
-          <p className="text-xs font-medium mb-2 uppercase tracking-wide">
-            Open dataset
-          </p>
-          <ButtonGroup className="justify-between border-1 rounded-md">
+          {!showDescription && (
+            <>
+              <p className="text-xs font-medium mb-2 uppercase tracking-wide text-muted-foreground">
+                Open dataset
+              </p>
+              <p className="text-xs text-muted-foreground mb-2">
+                {TAB_DESCRIPTIONS[activeTab]}
+              </p>
+              </>
+          )}
+          <ButtonGroup className="justify-between border rounded-md">
             {TABS.map(({ value, label }) => (
               <Button
                 key={value}
@@ -94,9 +110,9 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
           </ButtonGroup>
         </div>
 
-        <div className="p-4 flex flex-col gap-1 -mt-3">
+        <div className="p-4 flex flex-col gap-1 -mt-4">
           {activeTab === 'remote' && (
-            <>             
+            <>
               <StoreCatalog
                 catalog={ZARR_CATALOG}
                 placeholder="Search Zarr Stores..."
@@ -106,7 +122,7 @@ const DatasetsModal = ({ open, onOpenChange, isSafari }: Props) => {
                 setInitStore={setSelectedUrl}
                 onOpenDescription={() => {}}
               />
-               <RemoteZarr
+              <RemoteZarr
                 key={selectedUrl}
                 initStore={initStore}
                 setInitStore={setInitStore}

--- a/src/components/ui/MainPanel/RemoteIcechunk.tsx
+++ b/src/components/ui/MainPanel/RemoteIcechunk.tsx
@@ -93,10 +93,11 @@ const HeaderRows = ({ rows, set }: HeaderRowsProps) => {
 type Props = {
   setInitStore: (v: string) => void;
   onOpenDescription: () => void;
+  selectedUrl?: string
 };
 
-const RemoteIcechunk = ({ setInitStore, onOpenDescription }: Props) => {
-  const [url, setUrl] = useState('');
+const RemoteIcechunk = ({ setInitStore, onOpenDescription, selectedUrl = '' }: Props) => {
+  const [url, setUrl] = useState(selectedUrl);
 
   const [showSettings, setShowSettings] = useState(false);
 

--- a/src/components/ui/MainPanel/RemoteIcechunk.tsx
+++ b/src/components/ui/MainPanel/RemoteIcechunk.tsx
@@ -156,7 +156,7 @@ const RemoteIcechunk = ({ setInitStore, onOpenDescription, selectedUrl = '' }: P
     <div className="flex flex-col gap-3">
 
       {/* URL + Fetch */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 mt-2">
         <Input
           className="w-full"
           placeholder="Store URL"

--- a/src/components/ui/MainPanel/RemoteZarr.tsx
+++ b/src/components/ui/MainPanel/RemoteZarr.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { Input } from '@/components/ui/';
 import { Button } from '@/components/ui/button-enhanced';

--- a/src/components/ui/MainPanel/RemoteZarr.tsx
+++ b/src/components/ui/MainPanel/RemoteZarr.tsx
@@ -98,7 +98,7 @@ const RemoteZarr = ({ initStore, setInitStore, onOpenDescription, selectedUrl = 
       }}
     >
       {/* URL + Fetch */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 mt-2">
         <Input
           className="w-full"
           placeholder="Store URL"

--- a/src/components/ui/MainPanel/RemoteZarr.tsx
+++ b/src/components/ui/MainPanel/RemoteZarr.tsx
@@ -1,9 +1,8 @@
 "use client";
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { Input } from '@/components/ui/';
 import { Button } from '@/components/ui/button-enhanced';
-
 import { ChevronDown, ChevronUp, Plus, Trash2 } from 'lucide-react';
 import { useZarrStore } from '@/GlobalStates/ZarrStore';
 
@@ -11,10 +10,10 @@ type HeaderRow  = { key: string; value: string };
 type AuthPreset = 'none' | 'bearer' | 'basic' | 'apikey';
 
 const PRESETS: { value: AuthPreset; label: string }[] = [
-  { value: 'none',   label: 'None'       },
-  { value: 'bearer', label: 'Bearer'     },
-  { value: 'basic',  label: 'Basic'      },
-  { value: 'apikey', label: 'API Key'    },
+  { value: 'none',   label: 'None'    },
+  { value: 'bearer', label: 'Bearer'  },
+  { value: 'basic',  label: 'Basic'   },
+  { value: 'apikey', label: 'API Key' },
 ];
 
 const PRESET_KEYS: Record<Exclude<AuthPreset, 'none'>, string> = {
@@ -33,14 +32,16 @@ type Props = {
   initStore: string;
   setInitStore: (v: string) => void;
   onOpenDescription: () => void;
+  selectedUrl?: string;
 };
 
-const RemoteZarr = ({ initStore, setInitStore, onOpenDescription }: Props) => {
+const RemoteZarr = ({ initStore, setInitStore, onOpenDescription, selectedUrl = '' }: Props) => {
   const [showFetchOptions, setShowFetchOptions] = useState(false);
   const [preset, setPreset] = useState<AuthPreset>('none');
   const [presetValue, setPresetValue] = useState('');
   const [headers, setHeaders] = useState<HeaderRow[]>([{ key: '', value: '' }]);
   const [showCustom, setShowCustom] = useState(false);
+  const [urlValue, setUrlValue] = useState(selectedUrl);
 
   const addHeaderRow = () => setHeaders(h => [...h, { key: '', value: '' }]);
   const removeHeaderRow = (i: number) => setHeaders(h => h.filter((_, idx) => idx !== i));
@@ -73,17 +74,16 @@ const RemoteZarr = ({ initStore, setInitStore, onOpenDescription }: Props) => {
       className="flex flex-col gap-3"
       onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        const input = e.currentTarget.elements[0] as HTMLInputElement;
-        const url = input.value;
-        if (!url) return;
+        if (!urlValue) return;
 
         const fetchHandler = buildFetchHandler();
-        if (fetchHandler && url.startsWith('http://')) {
+        if (fetchHandler && urlValue.startsWith('http://')) {
           useGlobalStore.getState().setStatus('Error: Cannot send auth headers over plain HTTP — use HTTPS.');
           return;
         }
+
         const fetchOptions = {
-          ...(fetchHandler && { fetch: fetchHandler}),
+          ...(fetchHandler && { fetch: fetchHandler }),
         };
 
         useZarrStore.getState().setIcechunkOptions(null);
@@ -93,19 +93,24 @@ const RemoteZarr = ({ initStore, setInitStore, onOpenDescription }: Props) => {
         useGlobalStore.getState().setStatus('Fetching...');
 
         useZarrStore.getState().bumpFetchKey();
-        setInitStore(url);
+        setInitStore(urlValue);
         onOpenDescription();
       }}
     >
       {/* URL + Fetch */}
       <div className="flex items-center gap-2">
-        <Input className="w-full" placeholder="Store URL" />
+        <Input
+          className="w-full"
+          placeholder="Store URL"
+          value={urlValue}
+          onChange={e => setUrlValue(e.target.value)}
+        />
         <Button type="submit" variant="outline" className="cursor-pointer">
           Fetch
         </Button>
       </div>
 
-      {/* FetchOptions */}
+      {/* fetchOptions toggle */}
       <div>
         <Button
           type="button"
@@ -127,7 +132,7 @@ const RemoteZarr = ({ initStore, setInitStore, onOpenDescription }: Props) => {
                   <Button
                     key={value}
                     variant={preset === value ? 'secondary' : 'ghost'}
-                    className='cursor-pointer'
+                    className="cursor-pointer"
                     size="sm"
                     onClick={() => { setPreset(value); setPresetValue(''); }}
                   >
@@ -154,7 +159,7 @@ const RemoteZarr = ({ initStore, setInitStore, onOpenDescription }: Props) => {
             <div>
               <Button
                 type="button"
-                variant={'ghost'}
+                variant="ghost"
                 className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
                 onClick={() => setShowCustom(v => !v)}
               >

--- a/src/components/ui/MainPanel/StoreCatalog.tsx
+++ b/src/components/ui/MainPanel/StoreCatalog.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { ChevronsDown } from 'lucide-react';
 import {
   Command,
   CommandEmpty,
@@ -8,7 +9,6 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { ChevronDown } from 'lucide-react';
 
 const PAGE_SIZE = 3;
 
@@ -33,7 +33,6 @@ const gradientTextStyle = (gradient: string): React.CSSProperties => ({
   backgroundClip: 'text',
 });
 
-/** Splits `text` into segments, marking which chars match `query`. */
 const getMatchSegments = (text: string, query: string) => {
   if (!query.trim()) return [{ text, match: false }];
 
@@ -56,11 +55,7 @@ const getMatchSegments = (text: string, query: string) => {
   return segments;
 };
 
-type HighlightedTextProps = {
-  text: string;
-  query: string;
-  gradient: string;
-};
+type HighlightedTextProps = { text: string; query: string; gradient: string };
 
 const HighlightedText = ({ text, query, gradient }: HighlightedTextProps) => {
   const segments = getMatchSegments(text, query);
@@ -94,82 +89,119 @@ const StoreCatalog = ({
   placeholder = 'Search datasets...',
   gradient,
 }: Props) => {
+  // Keep search, pagination, and scroll-hint in one place so they reset atomically.
   const [search, setSearch] = useState('');
-  const [showAll, setShowAll] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Resetting visibleCount and isScrolled here (in the event handler)
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setVisibleCount(PAGE_SIZE);
+    setIsScrolled(false);
+  };
 
   const filtered = catalog.filter(ds =>
     ds.label.toLowerCase().includes(search.toLowerCase()) ||
     ds.subtitle.toLowerCase().includes(search.toLowerCase())
   );
 
-  const visible = showAll ? filtered : filtered.slice(0, PAGE_SIZE);
-  const hiddenCount = filtered.length - PAGE_SIZE;
-  const hasMore = hiddenCount > 0;
-
+  const visible = filtered.slice(0, visibleCount);
+  const hasMore = visibleCount < filtered.length;
   const gradientValue = gradient ? GRADIENTS[gradient] : undefined;
+
+  // Track scroll position to fade out the hint once the user starts scrolling.
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const onScroll = () => setIsScrolled(el.scrollTop > 8);
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Load the next page when the sentinel scrolls into view.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount(c => Math.min(c + PAGE_SIZE, filtered.length));
+        }
+      },
+      { root: listRef.current, threshold: 0 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [filtered.length]);
 
   return (
     <Command shouldFilter={false} className="rounded-lg border">
       <CommandInput
         placeholder={placeholder}
         value={search}
-        onValueChange={(v) => {
-          setSearch(v);
-          setShowAll(false);
-        }}
+        onValueChange={handleSearchChange}
       />
-      <CommandList className='py-2'>
-        <CommandEmpty>No datasets found.</CommandEmpty>
-        <CommandGroup>
-          {visible.map(ds => (
-            <CommandItem
-              key={ds.key}
-              value={ds.key}
-              onSelect={() => {
-                setActiveOption(ds.key);
-                setInitStore(ds.store);
-                onOpenDescription();
-              }}
-              className={`flex flex-col items-start gap-0.5 mb-2 cursor-pointer ${
-                activeOption === ds.key ? 'bg-accent' : ''
-              }`}
-            >
-              <span className="font-medium text-sm">
-                {gradientValue && search
-                  ? <HighlightedText text={ds.label} query={search} gradient={gradientValue} />
-                  : ds.label
-                }
-              </span>
-              <span className="text-xs text-muted-foreground leading-snug">
-                {gradientValue && search
-                  ? <HighlightedText text={ds.subtitle} query={search} gradient={gradientValue} />
-                  : ds.subtitle
-                }
-              </span>
-            </CommandItem>
-          ))}
-          {!showAll && hasMore && (
-            <CommandItem
-              value="__show_more__"
-              onSelect={() => setShowAll(true)}
-              className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground cursor-pointer py-2 border-t border-dashed border-border mt-1 hover:text-foreground"
-            >
-              <ChevronDown className="size-3.5" />
-              {hiddenCount} more dataset{hiddenCount > 1 ? 's' : ''} available
-            </CommandItem>
-          )}
-          {showAll && hasMore && (
-            <CommandItem
-              value="__show_less__"
-              onSelect={() => setShowAll(false)}
-              className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground cursor-pointer py-2 border-t border-dashed border-border mt-1 hover:text-foreground"
-            >
-              <ChevronDown className="size-3.5 rotate-180" />
-              Show less
-            </CommandItem>
-          )}
-        </CommandGroup>
-      </CommandList>
+      <div className="relative">
+        <CommandList
+          ref={listRef}
+          className="py-2 overflow-y-auto"
+          style={{ maxHeight: '10rem' }}
+        >
+          <CommandEmpty>No datasets found.</CommandEmpty>
+          <CommandGroup>
+            {visible.map(ds => (
+              <CommandItem
+                key={ds.key}
+                value={ds.key}
+                onSelect={() => {
+                  setActiveOption(ds.key);
+                  setInitStore(ds.store);
+                  onOpenDescription();
+                }}
+                className={`flex flex-col items-start gap-0.5 mb-2 cursor-pointer ${
+                  activeOption === ds.key ? 'bg-accent' : ''
+                }`}
+              >
+                <span className="font-medium text-sm">
+                  {gradientValue && search
+                    ? <HighlightedText text={ds.label} query={search} gradient={gradientValue} />
+                    : ds.label}
+                </span>
+                <span className="text-xs text-muted-foreground leading-snug">
+                  {gradientValue && search
+                    ? <HighlightedText text={ds.subtitle} query={search} gradient={gradientValue} />
+                    : ds.subtitle}
+                </span>
+              </CommandItem>
+            ))}
+
+            {hasMore && <div ref={sentinelRef} className="h-px" aria-hidden />}
+          </CommandGroup>
+        </CommandList>
+
+        {hasMore && (
+          <div
+            className="pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center justify-end pb-1"
+            style={{
+              height: '3.5rem',
+              background: 'linear-gradient(to bottom, transparent, var(--popover, white) 80%)',
+              opacity: isScrolled ? 0 : 1,
+              transition: 'opacity 0.2s ease',
+            }}
+          >
+            <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+              <ChevronsDown className="size-3 animate-bounce" />
+              scroll for more
+            </span>
+          </div>
+        )}
+      </div>
     </Command>
   );
 };

--- a/src/components/ui/MainPanel/StoreCatalog.tsx
+++ b/src/components/ui/MainPanel/StoreCatalog.tsx
@@ -75,7 +75,7 @@ type Props = {
   activeOption: string;
   setActiveOption: (key: string) => void;
   setInitStore: (v: string) => void;
-  onOpenDescription: () => void;
+  onOpenDescription?: () => void;
   placeholder?: string;
   gradient?: GradientPreset;
 };
@@ -138,7 +138,7 @@ const StoreCatalog = ({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [filtered.length]);
+  }, [filtered.length, visibleCount]);
 
   return (
     <Command shouldFilter={false} className="rounded-lg border">
@@ -162,7 +162,7 @@ const StoreCatalog = ({
                 onSelect={() => {
                   setActiveOption(ds.key);
                   setInitStore(ds.store);
-                  onOpenDescription();
+                  onOpenDescription?.();
                 }}
                 className={`flex flex-col items-start gap-0.5 mb-2 cursor-pointer ${
                   activeOption === ds.key ? 'bg-accent' : ''
@@ -187,12 +187,9 @@ const StoreCatalog = ({
 
         {hasMore && (
           <div
-            className="pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center justify-end pb-1"
+            className="pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center justify-end pb-1 bg-gradient-to-t from-popover via-popover/80 to-transparent h-14 transition-opacity duration-200"
             style={{
-              height: '3.5rem',
-              background: 'linear-gradient(to bottom, transparent, var(--popover, white) 80%)',
               opacity: isScrolled ? 0 : 1,
-              transition: 'opacity 0.2s ease',
             }}
           >
             <span className="flex items-center gap-1 text-[11px] text-muted-foreground">

--- a/src/components/ui/MainPanel/StoreCatalog.tsx
+++ b/src/components/ui/MainPanel/StoreCatalog.tsx
@@ -12,11 +12,67 @@ import { ChevronDown } from 'lucide-react';
 
 const PAGE_SIZE = 3;
 
-type CatalogEntry = {
+export type CatalogEntry = {
   key: string;
   label: string;
   subtitle: string;
   store: string;
+};
+
+type GradientPreset = 'zarr' | 'icechunk';
+
+const GRADIENTS: Record<GradientPreset, string> = {
+  zarr:     'linear-gradient(90deg, #EC4899, #facc15)',
+  icechunk: 'linear-gradient(90deg, #3b82f6, #a5f3fc)',
+};
+
+const gradientTextStyle = (gradient: string): React.CSSProperties => ({
+  background: gradient,
+  WebkitBackgroundClip: 'text',
+  WebkitTextFillColor: 'transparent',
+  backgroundClip: 'text',
+});
+
+/** Splits `text` into segments, marking which chars match `query`. */
+const getMatchSegments = (text: string, query: string) => {
+  if (!query.trim()) return [{ text, match: false }];
+
+  const segments: { text: string; match: boolean }[] = [];
+  const lower = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const idx = lower.indexOf(lowerQuery, cursor);
+    if (idx === -1) {
+      segments.push({ text: text.slice(cursor), match: false });
+      break;
+    }
+    if (idx > cursor) segments.push({ text: text.slice(cursor, idx), match: false });
+    segments.push({ text: text.slice(idx, idx + query.length), match: true });
+    cursor = idx + query.length;
+  }
+
+  return segments;
+};
+
+type HighlightedTextProps = {
+  text: string;
+  query: string;
+  gradient: string;
+};
+
+const HighlightedText = ({ text, query, gradient }: HighlightedTextProps) => {
+  const segments = getMatchSegments(text, query);
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.match
+          ? <span key={i} style={gradientTextStyle(gradient)}>{seg.text}</span>
+          : <span key={i}>{seg.text}</span>
+      )}
+    </>
+  );
 };
 
 type Props = {
@@ -25,6 +81,8 @@ type Props = {
   setActiveOption: (key: string) => void;
   setInitStore: (v: string) => void;
   onOpenDescription: () => void;
+  placeholder?: string;
+  gradient?: GradientPreset;
 };
 
 const StoreCatalog = ({
@@ -33,6 +91,8 @@ const StoreCatalog = ({
   setActiveOption,
   setInitStore,
   onOpenDescription,
+  placeholder = 'Search datasets...',
+  gradient,
 }: Props) => {
   const [search, setSearch] = useState('');
   const [showAll, setShowAll] = useState(false);
@@ -46,10 +106,12 @@ const StoreCatalog = ({
   const hiddenCount = filtered.length - PAGE_SIZE;
   const hasMore = hiddenCount > 0;
 
+  const gradientValue = gradient ? GRADIENTS[gradient] : undefined;
+
   return (
     <Command shouldFilter={false} className="rounded-lg border">
       <CommandInput
-        placeholder="Search datasets..."
+        placeholder={placeholder}
         value={search}
         onValueChange={(v) => {
           setSearch(v);
@@ -72,9 +134,17 @@ const StoreCatalog = ({
                 activeOption === ds.key ? 'bg-accent' : ''
               }`}
             >
-              <span className="font-medium text-sm">{ds.label}</span>
+              <span className="font-medium text-sm">
+                {gradientValue && search
+                  ? <HighlightedText text={ds.label} query={search} gradient={gradientValue} />
+                  : ds.label
+                }
+              </span>
               <span className="text-xs text-muted-foreground leading-snug">
-                {ds.subtitle}
+                {gradientValue && search
+                  ? <HighlightedText text={ds.subtitle} query={search} gradient={gradientValue} />
+                  : ds.subtitle
+                }
               </span>
             </CommandItem>
           ))}

--- a/src/components/ui/MainPanel/StoreCatalog.tsx
+++ b/src/components/ui/MainPanel/StoreCatalog.tsx
@@ -89,15 +89,14 @@ const StoreCatalog = ({
   placeholder = 'Search datasets...',
   gradient,
 }: Props) => {
-  // Keep search, pagination, and scroll-hint in one place so they reset atomically.
   const [search, setSearch] = useState('');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [isScrolled, setIsScrolled] = useState(false);
 
   const sentinelRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
 
-  // Resetting visibleCount and isScrolled here (in the event handler)
   const handleSearchChange = (value: string) => {
     setSearch(value);
     setVisibleCount(PAGE_SIZE);
@@ -113,6 +112,28 @@ const StoreCatalog = ({
   const hasMore = visibleCount < filtered.length;
   const gradientValue = gradient ? GRADIENTS[gradient] : undefined;
 
+  // Intercept ArrowDown at the Command root. cmdk handles navigation itself
+  // and gives no callback when it reaches the last item — so we check whether
+  // the currently selected item is the last rendered one, and if there's more
+  // to load, we load it. cmdk will then naturally move focus to the new item
+  // on the next keydown.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'ArrowDown' || !hasMore) return;
+
+    const root = rootRef.current;
+    if (!root) return;
+
+    const items = Array.from(root.querySelectorAll('[cmdk-item]:not([aria-disabled="true"])'));
+    const selected = root.querySelector('[cmdk-item][aria-selected="true"]');
+
+    if (selected && items[items.length - 1] === selected) {
+      // We're on the last item — load the next page. This is still has issues but kinda works :/ 
+      // Don't preventDefault: let cmdk process the key after state updates
+      // so it can move selection to the newly rendered item.
+      setVisibleCount(c => Math.min(c + PAGE_SIZE, filtered.length));
+    }
+  };
+
   // Track scroll position to fade out the hint once the user starts scrolling.
   useEffect(() => {
     const el = listRef.current;
@@ -123,6 +144,7 @@ const StoreCatalog = ({
   }, []);
 
   // Load the next page when the sentinel scrolls into view.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: visibleCount controls sentinel mount/unmount; needed to re-bind observer after resets even when filtered.length is unchanged
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
@@ -141,7 +163,12 @@ const StoreCatalog = ({
   }, [filtered.length, visibleCount]);
 
   return (
-    <Command shouldFilter={false} className="rounded-lg border">
+    <Command
+      ref={rootRef}
+      shouldFilter={false}
+      className="rounded-lg border"
+      onKeyDown={handleKeyDown}
+    >
       <CommandInput
         placeholder={placeholder}
         value={search}
@@ -155,7 +182,7 @@ const StoreCatalog = ({
         >
           <CommandEmpty>No datasets found.</CommandEmpty>
           <CommandGroup>
-            {visible.map(ds => (
+            {visible.map((ds) => (
               <CommandItem
                 key={ds.key}
                 value={ds.key}
@@ -188,9 +215,7 @@ const StoreCatalog = ({
         {hasMore && (
           <div
             className="pointer-events-none absolute bottom-0 left-0 right-0 flex flex-col items-center justify-end pb-1 bg-gradient-to-t from-popover via-popover/80 to-transparent h-14 transition-opacity duration-200"
-            style={{
-              opacity: isScrolled ? 0 : 1,
-            }}
+            style={{ opacity: isScrolled ? 0 : 1 }}
           >
             <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
               <ChevronsDown className="size-3 animate-bounce" />

--- a/src/components/ui/MainPanel/StoreCatalog.tsx
+++ b/src/components/ui/MainPanel/StoreCatalog.tsx
@@ -1,8 +1,5 @@
 "use client";
-
 import React, { useState } from 'react';
-import { ZARR_CATALOG } from "@/assets/index";
-
 import {
   Command,
   CommandEmpty,
@@ -13,16 +10,25 @@ import {
 } from "@/components/ui/command";
 import { ChevronDown } from 'lucide-react';
 
-const PAGE_SIZE = 5;
+const PAGE_SIZE = 3;
+
+type CatalogEntry = {
+  key: string;
+  label: string;
+  subtitle: string;
+  store: string;
+};
 
 type Props = {
+  catalog: CatalogEntry[];
   activeOption: string;
   setActiveOption: (key: string) => void;
   setInitStore: (v: string) => void;
   onOpenDescription: () => void;
 };
 
-const CuratedDatasets = ({
+const StoreCatalog = ({
+  catalog,
   activeOption,
   setActiveOption,
   setInitStore,
@@ -31,7 +37,7 @@ const CuratedDatasets = ({
   const [search, setSearch] = useState('');
   const [showAll, setShowAll] = useState(false);
 
-  const filtered = ZARR_CATALOG.filter(ds =>
+  const filtered = catalog.filter(ds =>
     ds.label.toLowerCase().includes(search.toLowerCase()) ||
     ds.subtitle.toLowerCase().includes(search.toLowerCase())
   );
@@ -67,12 +73,11 @@ const CuratedDatasets = ({
               }`}
             >
               <span className="font-medium text-sm">{ds.label}</span>
-              <span className="text-xs text-muted-foreground leading-snug ">
+              <span className="text-xs text-muted-foreground leading-snug">
                 {ds.subtitle}
               </span>
             </CommandItem>
           ))}
-
           {!showAll && hasMore && (
             <CommandItem
               value="__show_more__"
@@ -83,7 +88,6 @@ const CuratedDatasets = ({
               {hiddenCount} more dataset{hiddenCount > 1 ? 's' : ''} available
             </CommandItem>
           )}
-
           {showAll && hasMore && (
             <CommandItem
               value="__show_less__"
@@ -100,4 +104,4 @@ const CuratedDatasets = ({
   );
 };
 
-export default CuratedDatasets;
+export default StoreCatalog;


### PR DESCRIPTION
Several improvements to the datasets modal. Also, the icechunk catalog is now available. More options for testing. 

<img width="507" height="458" alt="Screenshot 2026-06-21 at 17 30 44" src="https://github.com/user-attachments/assets/22e8f9ba-53fc-4fd9-a09a-7bb94b143990" />
<img width="510" height="457" alt="Screenshot 2026-06-21 at 17 30 36" src="https://github.com/user-attachments/assets/e975ca27-2908-429d-b316-a6a237792b5c" />
<img width="512" height="455" alt="Screenshot 2026-06-21 at 17 30 25" src="https://github.com/user-attachments/assets/d4ffa763-f6e3-422f-a3b6-798f2698f300" />
<img width="505" height="450" alt="Screenshot 2026-06-21 at 17 29 59" src="https://github.com/user-attachments/assets/0b5fa54e-183e-47fe-a47a-60381d22ac11" />
