### PR TITLE
Changed globalstore to not be split

### DIFF
--- a/src/GlobalStates/GlobalStore.ts
+++ b/src/GlobalStates/GlobalStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, type StoreApi, type UseBoundStore } from 'zustand'
 import * as THREE from 'three';
 import { GetColorMapTexture } from "@/components/textures";
 
@@ -97,7 +97,7 @@ type StoreState = {
   setClampExtremes: (clampExtremes: boolean) => void;
 };
 
-export const useGlobalStore = create<StoreState>((set, get) => ({
+const createStore = () => create<StoreState>((set, get) => ({
   dataShape: [1, 1, 1],
   activeIndices: [],
   shape: new THREE.Vector3(2, 2, 2),
@@ -197,3 +197,12 @@ export const useGlobalStore = create<StoreState>((set, get) => ({
   setScalingFactor: (scalingFactor) => set({ scalingFactor }),
   setClampExtremes: (clampExtremes) => set({ clampExtremes }),
 }));
+
+declare global {
+  var __appStore: UseBoundStore<StoreApi<StoreState>> | undefined
+}
+
+
+// Supposedly this makes it a global that cannot be duplicated by Next into different code chunks
+export const useGlobalStore =
+  globalThis.__appStore ?? (globalThis.__appStore = createStore())

--- a/src/GlobalStates/GlobalStore.ts
+++ b/src/GlobalStates/GlobalStore.ts
@@ -1,3 +1,4 @@
+"use client";
 import { create, type StoreApi, type UseBoundStore } from 'zustand'
 import * as THREE from 'three';
 import { GetColorMapTexture } from "@/components/textures";


### PR DESCRIPTION
In #684 the `variable` state in `useGlobalStore` got duplicated during prod and was being passed as "Default" to the webGPU component.

This uses a method described here

https://www.prisma.io/docs/orm/more/troubleshooting/nextjs

Keeps `useGlobalStore` as a single global object. Analysis is working in prod. 

I'm new to globals. But this may be something we want to implement in all stores. Will need to read up on it.  