### PR TITLE
added gribberish codec support

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  serverExternalPackages: ['@mattnucc/gribberish'],
   // Turbopack config for dev mode
   turbopack: {
     rules: {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "@hookform/resolvers": "^5.2.2",
+    "@mattnucc/gribberish": "^1.5.0",
     "@monaco-editor/react": "^4.7.0",
     "@react-spring/three": "^10.0.0",
     "@react-three/drei": "^10.7.7",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+  - '.'
+
+supportedArchitectures:
+  cpu:
+    - current
+    - wasm32

--- a/src/assets/catalogs/IcechunkCatalog.ts
+++ b/src/assets/catalogs/IcechunkCatalog.ts
@@ -1,5 +1,11 @@
 export const ICECHUNK_CATALOG = [
-    {
+  {
+    key: 'noaa-hrrr-forecast-48-hour-virtual',
+    label: 'NOAA HRRR (High-Resolution Rapid Refresh)',
+    subtitle: '3 km resolution, Continental US, hourly steps out to 48 hours',
+    store: 'https://dynamical-noaa-hrrr.s3.us-west-2.amazonaws.com/noaa-hrrr-forecast-48-hour-virtual/v0.5.0.icechunk/',
+  },
+  {
     key: 'chirps-daily',
     label: 'CHIRPS Daily Precipitation',
     subtitle: '',

--- a/src/codecs/gribberish.ts
+++ b/src/codecs/gribberish.ts
@@ -1,7 +1,9 @@
 import { registry } from "zarrita";
 
-// Minimal dtype -> TypedArray constructor map. GRIB decodes to float; dynamical
-// stores use float64/float32 (the coordinate helper path may hit either).
+/**
+ * Minimal dtype to TypedArray constructor map.
+ * GRIB decodes to float; dynamical stores use float64/float32 (the coordinate helper path may hit either).
+ */
 const CTORS: Record<string, new (length: number) => any> = {
   float64: Float64Array,
   float32: Float32Array,
@@ -15,7 +17,9 @@ const CTORS: Record<string, new (length: number) => any> = {
   uint8: Uint8Array,
 };
 
-// C-order (row-major) strides for a chunk shape.
+/**
+ * Calculates C-order (row-major) strides for a chunk shape.
+ */
 function cStrides(shape: readonly number[]): number[] {
   const stride = new Array<number>(shape.length);
   let acc = 1;
@@ -34,6 +38,18 @@ type GribberishConfig = {
 
 type ChunkMeta = { dataType: string; shape: number[] };
 
+/**
+ * A Zarrita `array_to_bytes` codec that decodes GRIB2 message bytes into a
+ * typed array, backed by the `@mattnucc/gribberish` bindings (native in Node,
+ * WASM in the browser).
+ *
+ * This mirrors gribberish's own Python numcodecs `GribberishCodec`
+ * (python/gribberish/zarr/codec.py): each stored chunk is one GRIB2 message;
+ * data variables decode via `dataAdjusted(adjust_longitude_range, north_up)`,
+ * and the synthetic `latitude`/`longitude` variables come from `latlngAdjusted`.
+ *
+ * @see {@link https://github.com/mpiannucci/gribberish/blob/main/python/gribberish/zarr/codec.py | Reference Python Implementation}
+ */
 export class GribberishCodec {
   kind = "array_to_bytes" as const;
 
@@ -57,14 +73,23 @@ export class GribberishCodec {
     this.#stride = cStrides(meta.shape);
   }
 
+  /**
+   * Instantiates the codec from config and metadata.
+   */
   static fromConfig(config: GribberishConfig, meta: ChunkMeta): GribberishCodec {
     return new GribberishCodec(config, meta);
   }
 
+  /**
+   * Read-only codec, encoding is not supported.
+   */
   encode(): never {
     throw new Error("gribberish codec is read-only (decode only)");
   }
 
+  /**
+   * Decodes GRIB2 binary bytes into the target layout array.
+   */
   async decode(bytes: Uint8Array): Promise<{
     data: ArrayBufferView;
     shape: number[];

--- a/src/codecs/gribberish.ts
+++ b/src/codecs/gribberish.ts
@@ -87,6 +87,20 @@ export class GribberishCodec {
     throw new Error("gribberish codec is read-only (decode only)");
   }
 
+  #copyToTypedArray(values: ArrayLike<number>): ArrayBufferView {
+    const out = new this.#ctor(values.length);
+    const isBig = out instanceof BigInt64Array || out instanceof BigUint64Array;
+    if (isBig) {
+      for (let i = 0; i < values.length; i++) {
+        const val = values[i]!;
+        out[i] = Number.isFinite(val) ? BigInt(Math.trunc(val)) : BigInt(0);
+      }
+    } else {
+      out.set(values);
+    }
+    return out;
+  }
+
   /**
    * Decodes GRIB2 binary bytes into the target layout array.
    */
@@ -96,30 +110,31 @@ export class GribberishCodec {
     stride: number[];
   }> {
     const { GribMessage } = await import("@mattnucc/gribberish");
-    let values: ArrayLike<number>;
+    let out: ArrayBufferView;
     
     const isLatitude = this.#var === "latitude" || this.#var === "lat";
     const isLongitude = this.#var === "longitude" || this.#var === "lon";
 
-    if (isLatitude || isLongitude) {
-      const msg = GribMessage.parseFromBuffer(bytes, 0);
-      const latlng = msg.latlngAdjusted(this.#adjustLon, this.#northUp);
-      values = isLatitude ? latlng.latitude : latlng.longitude;
-    } else {
-      const msg = GribMessage.parseFromBuffer(bytes, 0);
-      values = msg.dataAdjusted(this.#adjustLon, this.#northUp);
-    }
-
-    // Copy into the array's native dtype. gribberish returns JS numbers, so
-    // integer dtypes go through the BigInt/Number constructors as needed.
-    const out = new this.#ctor(values.length);
-    const isBig = out instanceof BigInt64Array || out instanceof BigUint64Array;
-    if (isBig) {
-      for (let i = 0; i < values.length; i++) {
-        out[i] = BigInt(Math.trunc(values[i]!));
+    const msg = GribMessage.parseFromBuffer(bytes, 0);
+    try {
+      if (isLatitude || isLongitude) {
+        const latlng = msg.latlngAdjusted(this.#adjustLon, this.#northUp);
+        try {
+          const values = isLatitude ? latlng.latitude : latlng.longitude;
+          out = this.#copyToTypedArray(values);
+        } finally {
+          if (latlng && typeof (latlng as any).free === "function") {
+            (latlng as any).free();
+          }
+        }
+      } else {
+        const values = msg.dataAdjusted(this.#adjustLon, this.#northUp);
+        out = this.#copyToTypedArray(values);
       }
-    } else {
-      out.set(values);
+    } finally {
+      if (msg && typeof (msg as any).free === "function") {
+        (msg as any).free();
+      }
     }
 
     return { data: out, shape: this.#shape, stride: this.#stride };

--- a/src/codecs/gribberish.ts
+++ b/src/codecs/gribberish.ts
@@ -1,0 +1,106 @@
+import { registry } from "zarrita";
+
+// Minimal dtype -> TypedArray constructor map. GRIB decodes to float; dynamical
+// stores use float64/float32 (the coordinate helper path may hit either).
+const CTORS: Record<string, new (length: number) => any> = {
+  float64: Float64Array,
+  float32: Float32Array,
+  int64: BigInt64Array,
+  int32: Int32Array,
+  int16: Int16Array,
+  int8: Int8Array,
+  uint64: BigUint64Array,
+  uint32: Uint32Array,
+  uint16: Uint16Array,
+  uint8: Uint8Array,
+};
+
+// C-order (row-major) strides for a chunk shape.
+function cStrides(shape: readonly number[]): number[] {
+  const stride = new Array<number>(shape.length);
+  let acc = 1;
+  for (let i = shape.length - 1; i >= 0; i--) {
+    stride[i] = acc;
+    acc *= shape[i]!;
+  }
+  return stride;
+}
+
+type GribberishConfig = {
+  var?: string | null;
+  adjust_longitude_range?: boolean;
+  north_up?: boolean;
+};
+
+type ChunkMeta = { dataType: string; shape: number[] };
+
+export class GribberishCodec {
+  kind = "array_to_bytes" as const;
+
+  #var: string | null;
+  #adjustLon: boolean;
+  #northUp: boolean;
+  #ctor: new (length: number) => any;
+  #shape: number[];
+  #stride: number[];
+
+  constructor(config: GribberishConfig, meta: ChunkMeta) {
+    this.#var = config?.var ?? null;
+    this.#adjustLon = Boolean(config?.adjust_longitude_range);
+    this.#northUp = Boolean(config?.north_up);
+    const ctor = CTORS[meta.dataType];
+    if (!ctor) {
+      throw new Error(`gribberish codec: unsupported data type ${meta.dataType}`);
+    }
+    this.#ctor = ctor;
+    this.#shape = meta.shape;
+    this.#stride = cStrides(meta.shape);
+  }
+
+  static fromConfig(config: GribberishConfig, meta: ChunkMeta): GribberishCodec {
+    return new GribberishCodec(config, meta);
+  }
+
+  encode(): never {
+    throw new Error("gribberish codec is read-only (decode only)");
+  }
+
+  async decode(bytes: Uint8Array): Promise<{
+    data: ArrayBufferView;
+    shape: number[];
+    stride: number[];
+  }> {
+    const { GribMessage } = await import("@mattnucc/gribberish");
+    let values: ArrayLike<number>;
+    
+    const isLatitude = this.#var === "latitude" || this.#var === "lat";
+    const isLongitude = this.#var === "longitude" || this.#var === "lon";
+
+    if (isLatitude || isLongitude) {
+      const msg = GribMessage.parseFromBuffer(bytes, 0);
+      const latlng = msg.latlngAdjusted(this.#adjustLon, this.#northUp);
+      values = isLatitude ? latlng.latitude : latlng.longitude;
+    } else {
+      const msg = GribMessage.parseFromBuffer(bytes, 0);
+      values = msg.dataAdjusted(this.#adjustLon, this.#northUp);
+    }
+
+    // Copy into the array's native dtype. gribberish returns JS numbers, so
+    // integer dtypes go through the BigInt/Number constructors as needed.
+    const out = new this.#ctor(values.length);
+    const isBig = out instanceof BigInt64Array || out instanceof BigUint64Array;
+    if (isBig) {
+      for (let i = 0; i < values.length; i++) {
+        out[i] = BigInt(Math.trunc(values[i]!));
+      }
+    } else {
+      out.set(values);
+    }
+
+    return { data: out, shape: this.#shape, stride: this.#stride };
+  }
+}
+
+// Register the codec globally in Zarrita
+registry.set("gribberish", async () => GribberishCodec as any);
+registry.set("numcodecs.gribberish", async () => GribberishCodec as any);

--- a/src/components/zarr/icechunk-store.ts
+++ b/src/components/zarr/icechunk-store.ts
@@ -3,6 +3,7 @@
 import type { NodeSnapshot } from "icechunk-js";
 import { IcechunkStore } from "icechunk-js";
 import * as zarr from "zarrita";
+import "@/codecs/gribberish";
 import { useCacheStore } from "@/GlobalStates/CacheStore";
 import { useErrorStore, ZarrError } from "@/GlobalStates/ErrorStore";
 import { useGlobalStore } from "@/GlobalStates/GlobalStore";

--- a/src/hooks/copy-wasm.mjs
+++ b/src/hooks/copy-wasm.mjs
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { createRequire } from 'module';
 
 const src = 'node_modules/@earthyscience/netcdf4-wasm/dist';
 const dest = 'public/';
@@ -12,3 +13,22 @@ fs.readdirSync(src)
     fs.copyFileSync(path.join(src, f), path.join(dest, f));
     console.log(`✓ ${f}`);
   });
+
+// Patch the invalid syntax in the gribberish WASM loader if it is installed
+try {
+  const require = createRequire(import.meta.url);
+  const loaderPath = require.resolve('@mattnucc/gribberish-wasm32-wasi/gribberish-js.wasm32-wasi.wasm_.loader.mjs');
+  if (fs.existsSync(loaderPath)) {
+    let content = fs.readFileSync(loaderPath, 'utf8');
+    if (content.includes('import { thread-spawn } from "wasi";')) {
+      content = content.replace(
+        'import { thread-spawn } from "wasi";',
+        '/* import { thread-spawn } from "wasi"; */'
+      );
+      fs.writeFileSync(loaderPath, content, 'utf8');
+      console.log('✓ patched @mattnucc/gribberish-wasm32-wasi loader syntax error');
+    }
+  }
+} catch (e) {
+  console.log('⚠ skipped gribberish WASM loader patching (package not installed or already patched)');
+}

--- a/src/hooks/useDataFetcher.tsx
+++ b/src/hooks/useDataFetcher.tsx
@@ -129,7 +129,9 @@ export const useDataFetcher = () => {
                 setDimUnits(dimUnits);
                 useGlobalStore.setState({axisDimArrays: dimArrays, axisDimNames: dimNames, axisDimUnits: dimUnits});
 
-                const targetDim = dimArrays.length > 2 ? dimArrays[1] : dimArrays[0];
+                const { axisMapping } = useZarrStore.getState();
+                const yIdx = (axisMapping.y >= 0 && axisMapping.y < dimArrays.length) ? axisMapping.y : Math.max(0, dimArrays.length - 2);
+                const targetDim = dimArrays[yIdx] || dimArrays[0];
                 const shouldFlip = targetDim[1] < targetDim[0];
                 setFlipY(shouldFlip);
 

--- a/src/hooks/useDataFetcher.tsx
+++ b/src/hooks/useDataFetcher.tsx
@@ -132,7 +132,7 @@ export const useDataFetcher = () => {
                 const { axisMapping } = useZarrStore.getState();
                 const yIdx = (axisMapping.y >= 0 && axisMapping.y < dimArrays.length) ? axisMapping.y : Math.max(0, dimArrays.length - 2);
                 const targetDim = dimArrays[yIdx] || dimArrays[0];
-                const shouldFlip = targetDim[1] < targetDim[0];
+                const shouldFlip = (targetDim && targetDim.length >= 2) ? targetDim[1] < targetDim[0] : false;
                 setFlipY(shouldFlip);
 
                 ParseExtent(dimUnits, dimArrays);


### PR DESCRIPTION
This PR adds support to Read GRIB files via icechunk by using the `@mattnucc/gribberish` package and registering a new code for zarrita.js. Codec conventions were translated from https://github.com/mpiannucci/gribberish/blob/main/python/gribberish/zarr/codec.py

This will allow users to get access to:

- Docs: https://dynamical.org/catalog/noaa-hrrr-forecast-48-hour-virtual/
- Data: https://dynamical-noaa-hrrr.s3.us-west-2.amazonaws.com/noaa-hrrr-forecast-48-hour-virtual/v0.5.0.icechunk/

Further reading:
- https://www.earthmover.io/blog/virtual-grib-nbm/
- According to [this](https://www.linkedin.com/posts/tom-nicholas_dynamicalorg-activity-7483931052067971072-ykIA?utm_source=share&utm_medium=member_desktop&rcm=ACoAAAw4UzoBWD3fffrQEs3UXY9k1LuehpOWopg) we will be looking at `> 14 PB` and 1 billion GRIB messages [as one virtual Icechunk store]

<img width="814" height="508" alt="Screenshot 2026-07-18 at 21 09 14" src="https://github.com/user-attachments/assets/c9e1817a-e6bb-4405-9c99-aecfebcd9f45" />


> [!CAUTION]
> For local dev is not enough to simple do `npm install` because the codec comes as a `wasm` asset.
> Note that in production we are using `pnpm` as the package manager. The new `wasm` asset gets resolved with the `pnpm-workspace.yaml` file. So, before you do `npm run dev`, is necessary to do 
>
> ```sh
>pnpm install
>```
> and that's it. Now you have the needed `wasm`  in `node_modules`. Now do
>
>```
>npm run dev
>```
> as usual. These instructions should go into a new file, `CONTRIBUTING.md`. Will do in another PR.