### PR TITLE
Points now only sample and are simplified

### DIFF
--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -136,7 +136,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       },
       defines: {
         GLOBAL_SCALE: globalscale*2,
-        ASPECT_RATIO: Math.abs(shape.x/shape.y), // It gets cast as INT without the math.abs for some reason
         ...(remapTexture ? { REPROJECT: true } : {}),
         ...(disablePointScale ? { NO_SCALE: true } : {})
       },
@@ -172,7 +171,7 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       );
       uniforms.fillValue.value = fillValue?? NaN
       uniforms.maskValue.value = maskValue
-      uniforms.aspect.value = shape.x/shape.x;
+      uniforms.aspect.value = shape.x/shape.y;
     }
   }, [volTexture, depthRatio, depth, height, shape, width, pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, animProg, xRange, yRange, fillValue, zRange, maskValue]);
   

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -43,10 +43,9 @@ const MappingCube = () =>{
 export const PointCloud = ({textures} : {textures:PCProps} )=>{
     const { colormap } = textures;
     const volTexture = usePaddedTextures(textures.texture);
-    const { flipY, dataShape, textureData, remapTexture, textureArrayDepths, shape } = useGlobalStore(useShallow(state=>({
+    const { flipY, dataShape, remapTexture, textureArrayDepths, shape } = useGlobalStore(useShallow(state=>({
       flipY: state.flipY,
       dataShape: state.dataShape,
-      textureData: state.textureData,
       remapTexture: state.remapTexture,
       textureArrayDepths: state.textureArrayDepths,
       shape: state.shape
@@ -72,56 +71,44 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
     })))
 
     //Extract data and shape from Data3DTexture
-    const { data, width, height, depth } = useMemo(() => {
+    const { width, height, depth } = useMemo(() => {
         const [depth, height, width] = dataShape
         return {
-          data: textureData,
           width: width,
           height: height,
           depth: depth,
         };
-    }, [textureData, dataShape]);
-
-    const targetWidth = (remapTexture && remapTexture.image) ? remapTexture.image.width : width;
-    const targetHeight = (remapTexture && remapTexture.image) ? remapTexture.image.height : height;
-    const is2D = dataShape.length === 2;
+    }, [dataShape]);
+    const globalscale = dataShape[2]/500
     const depthRatio = useMemo(()=> (shape && shape.x > 0 ? (shape.z / shape.x) * timeScale : 1),[shape, timeScale]);
 
-    // Create buffer geometries (divided into chunks of max 25M vertices to fit WebGL draw limit)
     const geometries = useMemo(() => {
-      const numPoints = depth * targetHeight * targetWidth;
-      const maxPoints = 100000000;
+      const numPoints = depth * height * width;
+      const maxPoints = 1e8;
       const stride = numPoints > maxPoints ? Math.ceil(numPoints / maxPoints) : 1;
       
       const subNumPoints = Math.floor(numPoints / stride);
-      const attrData = new Uint8Array(subNumPoints);
-      const indexData = new Float32Array(subNumPoints);
-      const originalData = data as Uint8Array;
+      const indexData = new Int32Array(subNumPoints);
       
       let writePtr = 0;
       for (let i = 0; i < numPoints; i += stride) {
         if (writePtr < subNumPoints) {
-          attrData[writePtr] = originalData[i] ?? 0;
-          indexData[writePtr] = i;
-          writePtr++;
+          indexData[writePtr++] = i;
         }
       }
-      
-      const valueAttr = new THREE.Uint8BufferAttribute(attrData, 1);
-      const indexAttr = new THREE.Float32BufferAttribute(indexData, 1);
-      
-      const maxPointsPerDraw = 25000000;
+      const indexAttr = new THREE.Int32BufferAttribute(indexData, 1);
+      const maxPointsPerDraw = 2e31 - 1; // 32bit limit
       const list = [];
       for (let offset = 0; offset < subNumPoints; offset += maxPointsPerDraw) {
         const count = Math.min(maxPointsPerDraw, subNumPoints - offset);
         const geom = new THREE.BufferGeometry();
-        geom.setAttribute('value', valueAttr);
         geom.setAttribute('vertexIdx', indexAttr);
         geom.setDrawRange(offset, count);
         list.push(geom);
       }
       return list;
-    }, [data, depth, targetWidth, targetHeight]);
+    }, [depth, width, height]);
+
     const {lonBounds, latBounds} = useCoordBounds() 
 
     const shaderMaterial = useMemo(()=> (new THREE.ShaderMaterial({
@@ -132,8 +119,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
         textureDepths: { value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0]) },
         maskTexture: {value: maskTexture},
         maskValue: {value: maskValue},
-        latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
-        lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
         pointSize: {value: pointSize},
         cmap: {value: colormap},
         cOffset: {value: cOffset},
@@ -143,16 +128,16 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
         scaleIntensity: {value: scaleIntensity},
         timeScale: {value: depthRatio},
         animateProg: {value: animProg},
-        shape: {value: new THREE.Vector3(depth, targetHeight, targetWidth)},
-        nativeShape: {value: new THREE.Vector3(dataShape[0], dataShape[1], dataShape[2])},
+        aspect: {value: shape.x/shape.y},
+        shape: {value: new THREE.Vector3(depth, height, width)},
         flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0], zRange[1])},
         vertBounds:{value: new THREE.Vector2(yRange[0], yRange[1])},
         fillValue: {value: fillValue?? NaN}
       },
       defines: {
+        GLOBAL_SCALE: globalscale*2,
+        ASPECT_RATIO: Math.abs(shape.x/shape.y), // It gets cast as INT without the math.abs for some reason
         ...(remapTexture ? { REPROJECT: true } : {}),
-        ...(flipY ? { FLIP_Y: true } : {}),
-        ...(is2D ? { IS_2D: true } : {}),
         ...(disablePointScale ? { NO_SCALE: true } : {})
       },
       vertexShader: pointVert,
@@ -161,31 +146,14 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       depthTest: true,
       blending:THREE.NoBlending,
     })
-    ),[disablePointScale, is2D, remapTexture, flipY]);
+    ),[disablePointScale, remapTexture]);
   
    useEffect(() => {
     if (shaderMaterial) {
       const uniforms = shaderMaterial.uniforms;
       uniforms.map.value = volTexture;
-      uniforms.remapTexture.value = remapTexture;
-      if (remapTexture) {
-        shaderMaterial.defines.REPROJECT = true;
-      } else {
-        delete shaderMaterial.defines.REPROJECT;
-      }
-      if (flipY) {
-        shaderMaterial.defines.FLIP_Y = true;
-      } else {
-        delete shaderMaterial.defines.FLIP_Y;
-      }
-      if (is2D) {
-        shaderMaterial.defines.IS_2D = true;
-      } else {
-        delete shaderMaterial.defines.IS_2D;
-      }
       shaderMaterial.needsUpdate = true;
-      uniforms.shape.value.set(depth, targetHeight, targetWidth);
-      uniforms.nativeShape.value.set(dataShape[0], dataShape[1], dataShape[2]);
+      uniforms.shape.value.set(depth, height, width);
       uniforms.pointSize.value = pointSize;
       uniforms.cmap.value = colormap;
       uniforms.cOffset.value = cOffset;
@@ -193,8 +161,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       uniforms.valueRange.value.set(valueRange[0], valueRange[1]);
       uniforms.scalePoints.value = scalePoints;
       uniforms.scaleIntensity.value = scaleIntensity;
-      uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
-      uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
       uniforms.timeScale.value = depthRatio;
       uniforms.animateProg.value = animProg;
       uniforms.flatBounds.value.set(
@@ -206,17 +172,20 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       );
       uniforms.fillValue.value = fillValue?? NaN
       uniforms.maskValue.value = maskValue
+      uniforms.aspect.value = shape.x/shape.x;
     }
-  }, [volTexture, remapTexture, flipY, is2D, depthRatio, depth, targetHeight, targetWidth, pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, animProg, xRange, yRange, fillValue, zRange, maskValue, lonBounds, latBounds]);
-  const tsScale = dataShape[2]/500
+  }, [volTexture, depthRatio, depth, height, shape, width, pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, animProg, xRange, yRange, fillValue, zRange, maskValue]);
+  
   return (
-    <group scale={[1, 1, 1]}>
-      <group scale={[tsScale,tsScale,tsScale]}>
+    <group>
+      <group scale={[globalscale,globalscale,globalscale]}>
         <ColumnMeshes />
       </group>
-      {geometries.map((geom, idx) => (
-        <points key={idx} geometry={geom} material={shaderMaterial} frustumCulled={false}/>
-      ))}
+      <group scale={[1, (flipY && !remapTexture) ? -1 : 1, 1]}>
+        {geometries.map((geom, idx) => (
+          <points key={idx} geometry={geom} material={shaderMaterial} frustumCulled={false}/>
+        ))}
+      </group>
       <MappingCube/>
     </group>
 

--- a/src/components/textures/ProjectionTexture.ts
+++ b/src/components/textures/ProjectionTexture.ts
@@ -198,7 +198,7 @@ export function reproject(resolution: number = 256){
         targetWidth = width;
         targetHeight = height;
         xTicks = linspace(minX, maxX, targetWidth);
-        yTicks = flipY ? linspace(maxY, minY, targetHeight) : linspace(minY, maxY, targetHeight);
+        yTicks = linspace(minY, maxY, targetHeight);
         data = new Uint16Array(targetWidth * targetHeight * 4);
 
         const xDiff = Math.abs(maxX - minX);
@@ -211,8 +211,8 @@ export function reproject(resolution: number = 256){
                 const [px, py] = proj.forward([lon, lat]);
                 const valid = (isFinite(px) && isFinite(py)) ? 1 : 0;
 
-                const u = xDiff > 0 ? (px - minX) / xDiff : 0;
-                const v = yDiff > 0 ? (py - minY) / yDiff : 0;
+                const u = (px - minX) / xDiff;
+                const v = (py - minY) / yDiff;
 
                 const idx = (j * targetWidth + i) * 4;
                 data[idx]     = THREE.DataUtils.toHalfFloat(u);  

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -1,9 +1,11 @@
 attribute float value;
-in float vertexIdx;
+in int vertexIdx;
 
 out float vValue;
 
 uniform sampler2D maskTexture;
+uniform sampler3D map[12];
+uniform vec3 textureDepths;
 
 uniform float pointSize;
 uniform bool scalePoints;
@@ -14,10 +16,7 @@ uniform float animateProg;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
 uniform vec3 shape;
-uniform vec3 nativeShape;
 uniform float fillValue;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
 uniform int maskValue;
 
 #define PI 3.1415925
@@ -26,7 +25,7 @@ uniform int maskValue;
     uniform sampler2D remapTexture;
 #endif
 
-vec3 computePosition(int vertexID) {
+vec3 computeTexCoord(int vertexID) {
     int depth = int(shape.x);
     int height = int(shape.y);
     int width = int(shape.z);
@@ -37,105 +36,75 @@ vec3 computePosition(int vertexID) {
     int y = (vertexID % sliceSize) / width;
     int x = vertexID % width;
 
-    #ifdef REPROJECT
-        // Get the reprojected normalized coordinates (u, v) from remapTexture
-        vec2 uv = vec2((float(x) + 0.5) / float(width), (float(y) + 0.5) / float(height));
-        vec3 remap = texture(remapTexture, uv).rgb;
-        
-        float nativeWidth = nativeShape.z;
-        float px = (remap.r - 0.5) * (nativeWidth / 500.0);
-        
-        float lonRange = abs(lonBounds.y - lonBounds.x);
-        float latRange = abs(latBounds.y - latBounds.x);
-        float aspectRatio = (latRange > 0.0 && lonRange > 0.0) ? (lonRange / latRange) : 1.0;
-        
-        float py = (remap.g - 0.5) * (nativeWidth / 500.0) / aspectRatio;
-    #else
-        float px = (float(x) - (float(width)/2.)) / 500.;
-        float py = (float(y) - (float(height)/2.)) / 500.;
-    #endif
-    #ifndef REPROJECT
-        #ifdef FLIP_Y
-            py = -py;
-        #endif
-    #endif
-    float pz = (float(depth) > 1.0) ? (float(z) / (float(depth) - 1.0) - 0.5) * (nativeShape.z / 500.0) : 0.0;
+    float px = (float(x) + 0.5) / float(width);
+    float py = (float(y) + 0.5) / float(height);
+    float pz = (float(z) + 0.5) / float(depth);
 
-    return vec3(px * 2.0, py * 2.0, pz * 2.0);
+    return vec3(px, py, pz);
 }
 
-vec2 giveUV(int vertexID){
+vec3 givePosition(vec3 texCoord) {
+    int depth = int(shape.x);
     int height = int(shape.y);
     int width = int(shape.z);
 
-    int sliceSize = width * height;
-    int y = (vertexID % sliceSize) / width;
-    int x = vertexID % width;
-    float u = float(x)/float(width);
-    float v = float(y)/float(height);
+    float px = (texCoord.x - 0.5);
+    float py =  (texCoord.y - 0.5) / ASPECT_RATIO;
+    float pz = (texCoord.z - 0.5) * timeScale;
 
-    return vec2(u, v);
+    return vec3(px, py, pz) * GLOBAL_SCALE;
 }
 
-vec2 realCoords(vec2 uv){
-    vec2 normalizedLon = lonBounds/2./PI+0.5;
-    vec2 normalizedLat = latBounds/PI+0.5;
-    float lonScale = normalizedLon.y-normalizedLon.x;
-    float latScale = normalizedLat.y-normalizedLat.x;
-    
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
-
-    return vec2(u, v);
+float sample1(vec3 p, int index) { // Shader doesn't support dynamic indexing so we gotta use switching
+    if (index == 0) return texture(map[0], p).r;
+    else if (index == 1) return texture(map[1], p).r;
+    else if (index == 2) return texture(map[2], p).r;
+    else if (index == 3) return texture(map[3], p).r;
+    else if (index == 4) return texture(map[4], p).r;
+    else if (index == 5) return texture(map[5], p).r;
+    else if (index == 6) return texture(map[6], p).r;
+    else if (index == 7) return texture(map[7], p).r;
+    else if (index == 8) return texture(map[8], p).r;
+    else if (index == 9) return texture(map[9], p).r;
+    else if (index == 10) return texture(map[10], p).r;
+    else if (index == 11) return texture(map[11], p).r;
+    else return 0.0;
 }
 
 void main() {
-    int originalID = int(vertexIdx);
-
+    vec3 texCoord = computeTexCoord(vertexIdx);
     if (maskValue != 0 ){ // If using a mask, quick check if vertex is masked out before doing additional rendering
-        vec2 newV = realCoords(giveUV(originalID));
-        float mask = texture(maskTexture, newV).r;
+        float mask = texture(maskTexture, texCoord.xy).r;
         bool cond = maskValue == 1 ? mask< 0.5 : mask>=0.5;
         if (cond){ // Masked out. Move off screen
             gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
             return;
         }
     }
+    int zStepSize = int(textureDepths.y) * int(textureDepths.x); 
+    int yStepSize = int(textureDepths.x); 
 
-    // Set the point value directly from attribute (no 3D texture sampling needed!)
-    vValue = float(value)/255.;
+    ivec3 idx = clamp(ivec3(texCoord * textureDepths), ivec3(0), ivec3(textureDepths) - 1); // Ivec3 is like running a "floor" operation on all three at once. The clamp is because the very last idx is OOR
+    int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;
+    vec3 localCoord = texCoord * textureDepths; // Scale up
+
+    localCoord = fract(localCoord);
+    vValue = sample1(localCoord, textureIdx);
 
     #ifdef REPROJECT
-        // For reprojected points, we must check if they are in the valid projection area.
-        int height = int(shape.y);
-        int width = int(shape.z);
-        int sliceSize = width * height;
-        int y = (originalID % sliceSize) / width;
-        int x = originalID % width;
-        
-        vec2 uv = vec2((float(x) + 0.5) / float(width), (float(y) + 0.5) / float(height));
-        vec3 remap = texture(remapTexture, uv).rgb;
-        if (remap.b < 0.5) {
-            gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-            return;
-        }
+        vec2 remap = texture(remapTexture, texCoord.xy).rg;
+        vec3 position = givePosition(vec3(remap, texCoord.z));
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    #else
+        vec3 position = givePosition(texCoord);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
     #endif
-
-    vec3 scaledPos = computePosition(originalID);
-    float depthSize = (float(shape.x) > 1.0) ? (nativeShape.z / 500.0) : 0.001;
-
-    scaledPos.z += depthSize;
-    scaledPos.z = mod(scaledPos.z + animateProg*depthSize*2., depthSize*2.);
-    scaledPos.z -= depthSize;
-
-    scaledPos.z *= timeScale;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(scaledPos, 1.0);
 
     #ifndef NO_SCALE
         float pointScale = pointSize/gl_Position.w;
         pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
         
-        if (value == 255. || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scaled
+        if (vValue == 1. || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scaled
             gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
         }
         gl_PointSize =  pointScale;
@@ -145,31 +114,18 @@ void main() {
     if (vValue < valueRange.x || vValue > valueRange.y){ //Hide points that are outside of value range
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     }
-    
-    #ifdef REPROJECT
-        float nativeWidth = nativeShape.z;
-        float lonRange = abs(lonBounds.y - lonBounds.x);
-        float latRange = abs(latBounds.y - latBounds.x);
-        float aspectRatio = (latRange > 0.0 && lonRange > 0.0) ? (lonRange / latRange) : 1.0;
 
-        float scaleX = nativeWidth / 500.0;
-        float scaleY = (nativeWidth / 500.0) / aspectRatio;
-    #else
-        float scaleX = float(shape.z) / 500.0; //width scaling
-        float scaleY = float(shape.y) / 500.0; //height scaling
-    #endif
-    float scaleZ = (float(shape.x) > 1.0) ? (nativeShape.z / 500.0) : 0.001; //depth scaling
+    vec2 scaledXBounds = vec2(flatBounds.x, flatBounds.y) / 2. + 0.5; // Scale from [-1, 1] to [0, 1] to match texCoords
+    vec2 scaledZBounds = vec2(flatBounds.z, flatBounds.w) / 2. + 0.5;
+    vec2 scaledYBounds = vec2(vertBounds.x, vertBounds.y) / 2. + 0.5;
     
-    vec2 scaledXBounds = vec2(flatBounds.x, flatBounds.y) * scaleX;
-    vec2 scaledZBounds = vec2(flatBounds.z, flatBounds.w) * scaleZ * timeScale;
-    vec2 scaledYBounds = vec2(vertBounds.x, vertBounds.y) * scaleY;
-    
-    bool xCheck = scaledPos.x < scaledXBounds.x || scaledPos.x > scaledXBounds.y;
-    bool zCheck = scaledPos.z < scaledZBounds.x || scaledPos.z > scaledZBounds.y;
-    bool yCheck = scaledPos.y < scaledYBounds.x || scaledPos.y > scaledYBounds.y;
+    bool xCheck = texCoord.x < scaledXBounds.x || texCoord.x > scaledXBounds.y;
+    bool zCheck = texCoord.z < scaledZBounds.x || texCoord.z > scaledZBounds.y;
+    bool yCheck = texCoord.y < scaledYBounds.x || texCoord.y > scaledYBounds.y;
     bool fillCheck = abs(vValue - fillValue) < 0.005;
 
     if (xCheck || zCheck || yCheck || fillCheck){ //Hide points that are clipped
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     }
+
 }

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -18,6 +18,7 @@ uniform vec2 vertBounds;
 uniform vec3 shape;
 uniform float fillValue;
 uniform int maskValue;
+uniform float aspect;
 
 #define PI 3.1415925
 
@@ -49,7 +50,7 @@ vec3 givePosition(vec3 texCoord) {
     int width = int(shape.z);
 
     float px = (texCoord.x - 0.5);
-    float py =  (texCoord.y - 0.5) / ASPECT_RATIO;
+    float py =  (texCoord.y - 0.5) / aspect;
     float pz = (texCoord.z - 0.5) * timeScale;
 
     return vec3(px, py, pz) * GLOBAL_SCALE;


### PR DESCRIPTION
This reworks the points to just sample the textures and not require the extra `textureData` stored in the global store. That hasn't been removed yet as it is tied to the texture creation and I will do that in a new PR.

## Changes

- vertexIdx: float --> Int floats cant capture large ints
- Calculate texCoord implicitly from vertexIdx for sampling
- Calculate position implicitly from texCoord using GLOBAL_SCALE definition
- Moved the flipping of values for reprojection to the plot level
- Pass just the aspect ratio as a uniform to handle the change in aspect ratio with new CRS

| WG84 | Mollweide |
| -- | --|
| <img width="1536" height="1284" alt="browzarr-plot (6)" src="https://github.com/user-attachments/assets/b74c974f-43f4-4096-862a-3da05b3c4183" /> | <img width="1536" height="1284" alt="browzarr-plot (5)" src="https://github.com/user-attachments/assets/a8df0240-e639-4aa2-9766-320fdb4dccf2" /> |

