### PR TITLE
remove textureData

### DIFF
--- a/src/GlobalStates/GlobalStore.ts
+++ b/src/GlobalStates/GlobalStore.ts
@@ -53,7 +53,6 @@ type StoreState = {
   idx4D: number | null;
   titleDescription: { title: string | null; description: string | null };
   textureArrayDepths: number[];
-  textureData: Uint8Array;
   clampExtremes: boolean;
   
   // setters
@@ -92,7 +91,6 @@ type StoreState = {
   setIdx4D: (idx4D: number | null) => void;
   setTitleDescription: (titleDescription: { title: string | null; description: string | null }) => void;
   setTextureArrayDepths: (textureArrayResolution: number[] ) => void;
-  setTextureData: (textureData: Uint8Array ) => void;
   setDPR: (DPR: number) => void;
   setScalingFactor: (scalingFactor: number | null) => void;
   setClampExtremes: (clampExtremes: boolean) => void;
@@ -133,7 +131,6 @@ const createStore = () => create<StoreState>((set, get) => ({
   idx4D: null,
   titleDescription: { title: null, description: null },
   textureArrayDepths: [1,1,1], 
-  textureData: new Uint8Array(1),
   DPR: 1,
   scalingFactor: null,
   clampExtremes: false,
@@ -193,7 +190,6 @@ const createStore = () => create<StoreState>((set, get) => ({
   setIdx4D: (idx4D) => set({ idx4D }),
   setTitleDescription: (titleDescription) => set({ titleDescription }),
   setTextureArrayDepths: (textureArrayDepths) => set({ textureArrayDepths }),
-  setTextureData: (textureData) => set({ textureData }),
   setDPR: (DPR) => set({ DPR }),
   setScalingFactor: (scalingFactor) => set({ scalingFactor }),
   setClampExtremes: (clampExtremes) => set({ clampExtremes }),

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -96,7 +96,7 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
           indexData[writePtr++] = i;
         }
       }
-      const indexAttr = new THREE.Uint32BufferAttribute(indexData, 1);
+      const indexAttr = new THREE.Int32BufferAttribute(indexData, 1);
       const maxPointsPerDraw = 25e6;
       const list = [];
       for (let offset = 0; offset < subNumPoints; offset += maxPointsPerDraw) {

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -96,8 +96,8 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
           indexData[writePtr++] = i;
         }
       }
-      const indexAttr = new THREE.Int32BufferAttribute(indexData, 1);
-      const maxPointsPerDraw = 2**31 - 1; // 32bit limit
+      const indexAttr = new THREE.Uint32BufferAttribute(indexData, 1);
+      const maxPointsPerDraw = 25e6;
       const list = [];
       for (let offset = 0; offset < subNumPoints; offset += maxPointsPerDraw) {
         const count = Math.min(maxPointsPerDraw, subNumPoints - offset);

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -4,8 +4,6 @@ import { pointFrag, pointVert } from '@/components/textures/shaders'
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow';
-import { deg2rad } from '@/utils/HelperFuncs';
-import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { UVCube } from './UVCube';
 import { ColumnMeshes } from './TransectMeshes';
 
@@ -108,8 +106,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       }
       return list;
     }, [depth, width, height]);
-
-    const {lonBounds, latBounds} = useCoordBounds() 
 
     const shaderMaterial = useMemo(()=> (new THREE.ShaderMaterial({
       glslVersion: THREE.GLSL3,

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -97,7 +97,7 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
         }
       }
       const indexAttr = new THREE.Int32BufferAttribute(indexData, 1);
-      const maxPointsPerDraw = 2e31 - 1; // 32bit limit
+      const maxPointsPerDraw = 2**31 - 1; // 32bit limit
       const list = [];
       for (let offset = 0; offset < subNumPoints; offset += maxPointsPerDraw) {
         const count = Math.min(maxPointsPerDraw, subNumPoints - offset);

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -8,10 +8,9 @@ interface Array {
     shape: number[];
 }
 
-function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number}): {minVal: number, maxVal: number}{
-    const { setTextureData} = useGlobalStore.getState()
+function createData(array: Array, valueScales?: {maxVal: number, minVal: number}): {textureData: Uint8Array, scales:{minVal: number, maxVal: number}}{
     const data = array.data;
-    const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data )
+    const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data)
     const textureData = new Uint8Array(data.length)
     const range = (maxVal - minVal)
     for (let i = 0; i < data.length; i++){
@@ -22,13 +21,12 @@ function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number})
         textureData[i] = normed * 254;
       }
     };
-    setTextureData(textureData)
-    return {minVal, maxVal}
+    return {textureData, scales:{minVal, maxVal}}
 }
 
 export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTexture[] | THREE.Data3DTexture[] | undefined {
   const {textureArrayDepths} = useGlobalStore.getState()
-  const textureData = data ? data : useGlobalStore.getState().textureData
+  const textureData = data 
   if (!textureData){
     return
   }
@@ -76,8 +74,8 @@ export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTe
 }
 
 export function ArrayToTexture(array: Array, valueScales?: {maxVal: number, minVal: number}): [ THREE.Data3DTexture[] | THREE.DataTexture[], {minVal: number, maxVal: number}]{
-    const scales = StoreData(array, valueScales);
-    const textures = CreateTexture(array.shape)
+    const {textureData, scales} = createData(array, valueScales)
+    const textures = CreateTexture(array.shape, textureData)
     return [textures as THREE.Data3DTexture[] | THREE.DataTexture[], scales];
 }
 


### PR DESCRIPTION
This removes the extra textureData state from the global store freeing up memory. It partially addresses #435 but ideally it would be nice to find a way of putting the data already in the textures explicitly on the vertices.

Also went back to 25 million points in drawcalls for the points. I misunderstood the limitation that was being addressed with that. 