### PR TITLE
new colormaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "color-schemes-js": "^0.1.2",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "fflate": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "gsap": "^3.13.0",
     "icechunk-js": "^0.6.0",
     "input-otp": "^1.4.2",
-    "js-colormaps-es": "^0.0.5",
     "lucide-react": "^0.562.0",
     "next": "^16.2.7",
     "next-themes": "^0.4.6",

--- a/src/GlobalStates/GlobalStore.ts
+++ b/src/GlobalStates/GlobalStore.ts
@@ -144,8 +144,18 @@ const createStore = () => create<StoreState>((set, get) => ({
   setShape: (shape) => set({ shape }),
   setValueScales: (valueScales) => set({ valueScales }),
   setColormap: (colormap) => set({ colormap }),
-  setColormapName: (colormapName) => set({ colormapName }),
-  setFlipColormap: (flipColormap) => set({ flipColormap }),
+  setColormapName: (colormapName) => {
+    const prev = get().colormap;
+    const palette = (colormapName === 'Default') ? 'Spectral' : colormapName;
+    const tex = GetColorMapTexture(prev, palette, 1, '#000000', 0, get().flipColormap);
+    set({ colormapName, colormap: tex });
+  },
+  setFlipColormap: (flipColormap) => {
+    const palette = (get().colormapName === 'Default') ? 'Spectral' : get().colormapName;
+    const prev = get().colormap;
+    const tex = GetColorMapTexture(prev, palette, 1, '#000000', 0, flipColormap);
+    set({ flipColormap, colormap: tex });
+  },
   setTimeSeries: (timeSeries) => set({ timeSeries }),
   updateTimeSeries: (newEntries) => {
     const merged = { ...newEntries, ...get().timeSeries  };

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -10,7 +10,7 @@ import { vertShader } from '@/components/computation/shaders'
 import { useShallow } from 'zustand/shallow'
 import { ThreeEvent } from '@react-three/fiber';
 import { coarsenFlatArray, GetCurrentArray, GetTimeSeries, parseUVCoords, deg2rad } from '@/utils/HelperFuncs';
-import { evaluate_cmap } from 'js-colormaps-es';
+import { evaluateColorMap } from '@/components/textures';
 import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { flatFrag } from '../textures/shaders';
 import { SquareMeshes } from './TransectMeshes';
@@ -153,8 +153,8 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
               dimCoords = dimCoords.filter(val => val !== null)
               const tsID = `${dimCoords[0]}_${dimCoords[1]}`
               const tsObj = {
-                color:evaluate_cmap(getColorIdx()/10,"Paired"),
-                data:tempTS,
+                color: evaluateColorMap(getColorIdx() / 10, 'Paired'),
+                data: tempTS,
                 normal,
                 uv: tsUV,
               }

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -5,7 +5,7 @@ import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow'
 import { parseUVCoords, GetTimeSeries, GetCurrentArray, deg2rad } from '@/utils/HelperFuncs';
-import { evaluate_cmap } from 'js-colormaps-es';
+import { evaluateColorMap } from '@/components/textures';
 import { useCoordBounds } from '@/hooks/useCoordBounds'
 import { SquareMeshes } from './TransectMeshes';
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
@@ -175,8 +175,8 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
         dimCoords = dimCoords.filter(val => val !== null)
         const tsID = `${dimCoords[0]}_${dimCoords[1]}`
         const tsObj = {
-          color:evaluate_cmap(getColorIdx()/10,"Paired"),
-          data:tempTS,
+          color: evaluateColorMap(getColorIdx() / 10, 'Paired'),
+          data: tempTS,
           normal,
           uv: tsUV,
         }

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -5,7 +5,7 @@ import { useAnalysisStore } from '@/GlobalStates/AnalysisStore';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow';
-import { evaluate_cmap } from 'js-colormaps-es';
+import { evaluateColorMap } from '@/components/textures';
 
 function normalizeUV(uv:number, scale:number, pos:number){
   return (uv*scale) + (pos-0.5*scale+0.5)
@@ -121,10 +121,10 @@ export const UVCube = ( {scale} : {scale?:THREE.Vector3} )=>{
     dimCoords = dimCoords.filter(val => val !== null)
     const tsID = `${dimCoords[0]}_${dimCoords[1]}`
     const tsObj = {
-      color:evaluate_cmap(getColorIdx()/10,"Paired"),
+      color: evaluateColorMap(getColorIdx() / 10, 'Paired'),
       normal,
       uv,
-      data:tempTS
+      data: tempTS
     }
     updateTimeSeries({ [tsID] : tsObj})
     incrementColorIdx();

--- a/src/components/textures/colormap.tsx
+++ b/src/components/textures/colormap.tsx
@@ -1,9 +1,59 @@
 import * as THREE from 'three';
-// https://github.com/vasturiano/three-globe/blob/master/src/utils/color-utils.js
-import { evaluate_cmap } from 'js-colormaps-es';
-// import { rgbToHex } from './updateColorbar';
+import { colorschemes, get, findColorScheme } from 'color-schemes-js';
 
-export const colormaps = ['magma', 'inferno', 'plasma', 'viridis', 'cividis', 'twilight', 'twilight_shifted', 'turbo', 'Blues', 'BrBG', 'BuGn', 'BuPu', 'CMRmap', 'GnBu', 'Greens', 'Greys', 'OrRd', 'Oranges', 'PRGn', 'PiYG', 'PuBu', 'PuBuGn', 'PuOr', 'PuRd', 'Purples', 'RdBu', 'RdGy', 'RdPu', 'RdYlBu', 'RdYlGn', 'Reds', 'Spectral', 'Wistia', 'YlGn', 'YlGnBu', 'YlOrBr', 'YlOrRd', 'afmhot', 'autumn', 'binary', 'bone', 'brg', 'bwr', 'cool', 'coolwarm', 'copper', 'cubehelix', 'flag', 'gist_earth', 'gist_gray', 'gist_heat', 'gist_ncar', 'gist_rainbow', 'gist_stern', 'gist_yarg', 'gnuplot', 'gnuplot2', 'gray', 'hot', 'hsv', 'jet', 'nipy_spectral', 'ocean', 'pink', 'prism', 'rainbow', 'seismic', 'spring', 'summer', 'terrain', 'winter', 'Accent', 'Dark2', 'Paired', 'Pastel1', 'Pastel2', 'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b', 'tab20c']
+export const colormaps = ['magma', 'inferno', 'plasma', 'viridis', 'cividis', 'twilight', 'twilight_shifted', 'turbo', 'Blues', 'BrBG', 'BuGn', 'BuPu', 'CMRmap', 'GnBu', 'Greens', 'Greys', 'OrRd', 'Oranges', 'PRGn', 'PiYG', 'PuBu', 'PuBuGn', 'PuOr', 'PuRd', 'Purples', 'RdBu', 'RdGy', 'RdPu', 'RdYlBu', 'RdYlGn', 'Reds', 'Spectral', 'Wistia', 'YlGn', 'YlGnBu', 'YlOrBr', 'YlOrRd', 'afmhot', 'autumn', 'binary', 'bone', 'brg', 'bwr', 'cool', 'coolwarm', 'copper', 'cubehelix', 'flag', 'gist_earth', 'gist_gray', 'gist_heat', 'gist_ncar', 'gist_rainbow', 'gist_stern', 'gist_yarg', 'gnuplot', 'gnuplot2', 'gray', 'hot', 'hsv', 'jet', 'nipy_spectral', 'ocean', 'pink', 'prism', 'rainbow', 'seismic', 'spring', 'summer', 'terrain', 'winter', 'Accent', 'Dark2', 'Paired', 'Pastel1', 'Pastel2', 'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b', 'tab20c'];
+export const availableColorMapNames = Object.keys(colorschemes).sort();
+
+const legacySchemeMap: Record<string, string> = {
+  Spectral: 'Spectral_11',
+  Paired: 'Paired_12',
+  Set1: 'Set1_9',
+  Set2: 'Set2_8',
+  Set3: 'Set3_12',
+  Accent: 'Accent_8',
+  Dark2: 'Dark2_8',
+  Pastel1: 'Pastel1_9',
+  Pastel2: 'Pastel2_8',
+  twilight_shifted: 'twilight',
+  gray: 'grays',
+  winter: 'Winter',
+};
+
+export function resolveColorSchemeName(name: string): string {
+  const trimmed = name?.trim();
+  if (!trimmed) return 'viridis';
+  if (legacySchemeMap[trimmed]) return legacySchemeMap[trimmed];
+  if (colorschemes[trimmed]) return trimmed;
+  const exact = Object.keys(colorschemes).find((key) => key.toLowerCase() === trimmed.toLowerCase());
+  if (exact) return exact;
+  const results = findColorScheme(trimmed);
+  if (results.length > 0) {
+    return results.sort((a, b) => b.scheme.length - a.scheme.length)[0].name;
+  }
+  return 'viridis';
+}
+
+export function evaluateColorMap(value: number, palette: string, reverse = false): [number, number, number] {
+  const schemeName = resolveColorSchemeName(palette);
+  const scheme = colorschemes[schemeName];
+  const color = get(scheme, reverse ? 1 - value : value);
+  const rgb = color.toRgb255();
+  return [rgb.r, rgb.g, rgb.b];
+}
+
+export function getColormapGradientCss(name: string): string {
+  const schemeName = resolveColorSchemeName(name);
+  const scheme = colorschemes[schemeName];
+  if (!scheme) {
+    return 'linear-gradient(to right, #222, #999)';
+  }
+  const stops = Array.from({ length: 16 }, (_, idx) => {
+    const t = idx / 15;
+    const { r, g, b } = get(scheme, t).toRgb255();
+    return `rgb(${r}, ${g}, ${b}) ${(t * 100).toFixed(1)}%`;
+  });
+  return `linear-gradient(to right, ${stops.join(', ')})`;
+}
 
 export function minMax(values: number[]): { min: number | undefined, max: number | undefined } {
     // Filter out NaN values
@@ -24,7 +74,7 @@ export function GetColorMapTexture(
 ): THREE.DataTexture {
   let unitInterval = Array.from({ length: 255 }, (_, index) => index / 254);
   unitInterval = reverse ? unitInterval.reverse() : unitInterval
-  const rgbv = unitInterval.map(value => evaluate_cmap(value, palette, false));
+  const rgbv = unitInterval.map(value => evaluateColorMap(value, palette, false));
   const colData = new Uint8Array((rgbv.length + 1) * 4);
 
   for (let i = 0; i < rgbv.length; i++) {

--- a/src/components/textures/colormap.tsx
+++ b/src/components/textures/colormap.tsx
@@ -2,7 +2,24 @@ import * as THREE from 'three';
 import { colorschemes, get, findColorScheme } from 'color-schemes-js';
 
 export const colormaps = ['magma', 'inferno', 'plasma', 'viridis', 'cividis', 'twilight', 'twilight_shifted', 'turbo', 'Blues', 'BrBG', 'BuGn', 'BuPu', 'CMRmap', 'GnBu', 'Greens', 'Greys', 'OrRd', 'Oranges', 'PRGn', 'PiYG', 'PuBu', 'PuBuGn', 'PuOr', 'PuRd', 'Purples', 'RdBu', 'RdGy', 'RdPu', 'RdYlBu', 'RdYlGn', 'Reds', 'Spectral', 'Wistia', 'YlGn', 'YlGnBu', 'YlOrBr', 'YlOrRd', 'afmhot', 'autumn', 'binary', 'bone', 'brg', 'bwr', 'cool', 'coolwarm', 'copper', 'cubehelix', 'flag', 'gist_earth', 'gist_gray', 'gist_heat', 'gist_ncar', 'gist_rainbow', 'gist_stern', 'gist_yarg', 'gnuplot', 'gnuplot2', 'gray', 'hot', 'hsv', 'jet', 'nipy_spectral', 'ocean', 'pink', 'prism', 'rainbow', 'seismic', 'spring', 'summer', 'terrain', 'winter', 'Accent', 'Dark2', 'Paired', 'Pastel1', 'Pastel2', 'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b', 'tab20c'];
+
 export const availableColorMapNames = Object.keys(colorschemes).sort();
+
+export type ColormapEntry = {
+  name: string;
+  category?: string;
+  notes?: string;
+};
+
+// Single searchable index, built once at module load from the color-schemes-js data
+export const colormapIndex: ColormapEntry[] = availableColorMapNames.map((name) => {
+  const scheme = colorschemes[name];
+  return {
+    name,
+    category: scheme.category,
+    notes: scheme.notes,
+  };
+});
 
 const legacySchemeMap: Record<string, string> = {
   Spectral: 'Spectral_11',

--- a/src/components/textures/colormap.tsx
+++ b/src/components/textures/colormap.tsx
@@ -36,24 +36,43 @@ const legacySchemeMap: Record<string, string> = {
   winter: 'Winter',
 };
 
+const resolutionCache = new Map<string, string>();
 export function resolveColorSchemeName(name: string): string {
   const trimmed = name?.trim();
   if (!trimmed) return 'viridis';
-  if (legacySchemeMap[trimmed]) return legacySchemeMap[trimmed];
-  if (colorschemes[trimmed]) return trimmed;
-  const exact = Object.keys(colorschemes).find((key) => key.toLowerCase() === trimmed.toLowerCase());
-  if (exact) return exact;
-  const results = findColorScheme(trimmed);
-  if (results.length > 0) {
-    return results.sort((a, b) => b.scheme.length - a.scheme.length)[0].name;
+
+  const cached = resolutionCache.get(trimmed);
+  if (cached) return cached;
+
+  let resolved = 'viridis';
+  if (legacySchemeMap[trimmed]) {
+    resolved = legacySchemeMap[trimmed];
+  } else if (colorschemes[trimmed]) {
+    resolved = trimmed;
+  } else {
+    const exact = Object.keys(colorschemes).find((key) => key.toLowerCase() === trimmed.toLowerCase());
+    if (exact) {
+      resolved = exact;
+    } else {
+      const results = findColorScheme(trimmed);
+      if (results.length > 0) {
+        resolved = results.sort((a, b) => b.scheme.length - a.scheme.length)[0].name;
+      }
+    }
   }
-  return 'viridis';
+
+  resolutionCache.set(trimmed, resolved);
+  return resolved;
 }
 
 export function evaluateColorMap(value: number, palette: string, reverse = false): [number, number, number] {
   const schemeName = resolveColorSchemeName(palette);
-  const scheme = colorschemes[schemeName];
-  const color = get(scheme, reverse ? 1 - value : value);
+  const scheme = colorschemes[schemeName] || colorschemes['viridis'];
+  if (!scheme) {
+    return [0, 0, 0];
+  }
+  const t = Math.max(0, Math.min(1, reverse ? 1 - value : value));
+  const color = get(scheme, t);
   const rgb = color.toRgb255();
   return [rgb.r, rgb.g, rgb.b];
 }

--- a/src/components/textures/index.ts
+++ b/src/components/textures/index.ts
@@ -1,9 +1,12 @@
-import { GetColorMapTexture, colormaps } from './colormap';
-import {ArrayToTexture, CreateTexture} from './TextureMakers'
+import { GetColorMapTexture, colormaps, evaluateColorMap, availableColorMapNames, getColormapGradientCss } from './colormap';
+import {ArrayToTexture, CreateTexture}from './TextureMakers'
 
 export {
     GetColorMapTexture,
     colormaps,
+    evaluateColorMap,
+    availableColorMapNames,
+    getColormapGradientCss,
     ArrayToTexture,
     CreateTexture
 }

--- a/src/components/textures/index.ts
+++ b/src/components/textures/index.ts
@@ -1,4 +1,4 @@
-import { GetColorMapTexture, colormaps, evaluateColorMap, availableColorMapNames, getColormapGradientCss } from './colormap';
+import { GetColorMapTexture, colormaps, evaluateColorMap, availableColorMapNames, getColormapGradientCss, colormapIndex } from './colormap';
 import {ArrayToTexture, CreateTexture}from './TextureMakers'
 
 export {
@@ -7,6 +7,7 @@ export {
     evaluateColorMap,
     availableColorMapNames,
     getColormapGradientCss,
+    colormapIndex,
     ArrayToTexture,
     CreateTexture
 }

--- a/src/components/textures/js-colormaps-es.d.ts
+++ b/src/components/textures/js-colormaps-es.d.ts
@@ -1,4 +1,0 @@
-declare module 'js-colormaps-es' {
-    export function evaluate_cmap(value: number, name: string, reverse?: boolean): [number, number, number];
-    export const data: Record<string, unknown>;
-  }

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -10,7 +10,7 @@ import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover
 import { Button } from "@/components/ui/button-enhanced";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { Search } from "lucide-react"
+import { Search, X } from "lucide-react"
 import {
   InputGroup,
   InputGroupAddon,
@@ -107,10 +107,18 @@ const Colormaps = () => {
       <PopoverContent
         side={popoverSide}
         className="colormaps"
+        style={{
+          width: '280px',
+          maxWidth: 'calc(100vw - 1.5rem)',
+          overflow: 'hidden',
+          overscrollBehavior: 'contain',
+          padding: 0,
+          boxSizing: 'border-box',
+        }}
       >
-        <style>{`\n.colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n  border: 1px solid rgba(0,0,0,0.08);\n}\n@media (prefers-color-scheme: dark) {\n  .colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n    border: 1px solid rgba(255,255,255,0.12);\n  }\n}\n`}</style>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '0.6rem' }}>
-          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <style>{`\n.colormaps {\n  scrollbar-width: none;\n}\n.colormaps::-webkit-scrollbar {\n  display: none;\n}\n.colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n  border: 1px solid rgba(0,0,0,0.08);\n}\n@media (prefers-color-scheme: dark) {\n  .colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n    border: 1px solid rgba(255,255,255,0.12);\n  }\n}\n`}</style>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '0.6rem', width: '100%', padding: '0.75rem 0.75rem 0' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', width: '100%', flexWrap: 'wrap', padding: 0 }}>
             <ButtonGroup className="justify-start gap-0.25">
               <Button
                 type="button"
@@ -139,7 +147,10 @@ const Colormaps = () => {
             <div style={{ marginLeft: 'auto' }}>
               <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
-                  <Button size="sm" variant="outline" style={{ cursor: 'default' }}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                  >
                     {displayColormapName}
                   </Button>
                 </TooltipTrigger>
@@ -152,32 +163,43 @@ const Colormaps = () => {
             </div>
           </div>
           <Separator/>
-          <InputGroup className="max-w-xs">
+          <InputGroup className="w-full">
             <InputGroupInput 
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search..."
-             />
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search..."
+            />
             <InputGroupAddon>
               <Search />
             </InputGroupAddon>
-          </InputGroup>
+            {searchQuery ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-9 w-9 p-0"
+            onClick={() => setSearchQuery('')}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
+        </InputGroup>
         <Separator/>
         </div>
         {searchQuery.trim() && (
-          <div className="search-results-summary" style={{ marginBottom: '0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
+          <div className="search-results-summary" style={{ margin: '0 0.75rem 0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
             Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong> matches for{' "'}{searchQuery}{'"'}
             {hasMoreResults && ' — first 64 shown'}
           </div>
         )}
 
-        <div className="colormap-list-container" style={{ marginTop: '0.5rem' }}>
-          <div style={{ maxHeight: '40vh', overflowY: 'auto', paddingRight: '0.25rem' }}>
-            <div className="colormaps-grid" style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
+        <div className="colormap-list-container" style={{ marginTop: '0.5rem', width: '100%', padding: '0 0.75rem 0.75rem' }}>
+          <div style={{ maxHeight: 'min(50vh, 360px)', overflowY: 'auto', paddingRight: 0, width: '100%', boxSizing: 'border-box' }}>
+            <div className="colormaps-grid" style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))', width: '100%', boxSizing: 'border-box' }}>
           {visibleMatches.map((val) => (
             <button
               key={val}
-              className={`cmap rendered-cmap ${flipColormap ? "flipped" : ""}`}
+              className="cmap rendered-cmap"
               type="button"
               onClick={() => {
                 setPrevColormapName(colormapName);
@@ -186,26 +208,57 @@ const Colormaps = () => {
               }}
               onMouseEnter={() => setHoveredCmap(val)}
               onMouseLeave={() => setHoveredCmap(null)}
-                style={{
+              style={{
                 width: '100%',
+                minWidth: 0,
                 height: '34px',
                 borderRadius: '0.5rem',
-                backgroundImage: getColormapGradientCss(val),
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'center',
-                backgroundSize: '100% 100%',
                 color: 'var(--ui-text-highlighted)',
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: '0 0.75rem',
+                justifyContent: 'flex-start',
+                padding: '0',
                 fontSize: '0.85rem',
                 fontWeight: 700,
                 textShadow: '0 1px 3px rgba(0,0,0,0.45)',
                 overflow: 'hidden',
+                position: 'relative',
               }}
             >
-              <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{val}</span>
+              <div
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  borderRadius: 'inherit',
+                  backgroundImage: getColormapGradientCss(val),
+                  backgroundRepeat: 'no-repeat',
+                  backgroundPosition: 'center',
+                  backgroundSize: '100% 100%',
+                  transform: flipColormap ? 'scaleX(-1)' : undefined,
+                  pointerEvents: 'none',
+                }}
+              />
+              <span
+                style={{
+                  position: 'relative',
+                  zIndex: 1,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  padding: '0.05rem 0.75rem',
+                  marginLeft: 0,
+                  borderRadius: '0.38rem',
+                  background: 'rgba(244, 237, 237, 0.13)',
+                  backdropFilter: 'blur(8px) saturate(140%)',
+                  WebkitBackdropFilter: 'blur(8px) saturate(140%)',
+                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.2)',
+                  fontWeight: 400,
+                  color: 'rgba(241, 237, 237, 0.96)',
+                }}
+              >
+                {val}
+              </span>
             </button>
           ))}
             </div>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, {useEffect, useState, useMemo} from 'react'
-import { GetColorMapTexture, colormaps, availableColorMapNames, getColormapGradientCss } from '@/components/textures';
+import { GetColorMapTexture, colormaps, availableColorMapNames, getColormapGradientCss, colormapIndex } from '@/components/textures';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { useShallow } from 'zustand/shallow';
 import { MdOutlineSwapVert } from "react-icons/md";
@@ -49,7 +49,20 @@ const Colormaps = () => {
   const filteredColormaps = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     if (!query) return colormaps;
-    return availableColorMapNames.filter((name) => name.toLowerCase().includes(query));
+
+    const nameMatches: string[] = [];
+    const otherMatches: string[] = [];
+
+    for (const entry of colormapIndex) {
+      const nameHit = entry.name.toLowerCase().includes(query);
+      const categoryHit = entry.category?.toLowerCase().includes(query);
+      const notesHit = entry.notes?.toLowerCase().includes(query);
+
+      if (nameHit) nameMatches.push(entry.name);
+      else if (categoryHit || notesHit) otherMatches.push(entry.name);
+    }
+
+    return [...nameMatches, ...otherMatches];
   }, [searchQuery]);
 
   const visibleMatches = useMemo(() => filteredColormaps.slice(0, 64), [filteredColormaps]);
@@ -167,7 +180,7 @@ const Colormaps = () => {
             <InputGroupInput 
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search..."
+              placeholder="Search by name or category..."
             />
             <InputGroupAddon>
               <Search />
@@ -184,14 +197,16 @@ const Colormaps = () => {
           </Button>
         ) : null}
         </InputGroup>
-        <Separator/>
         </div>
         {searchQuery.trim() && (
           <div className="search-results-summary" style={{ margin: '0 0.75rem 0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
             Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong> matches for{' "'}{searchQuery}{'"'}
             {hasMoreResults && ' — first 64 shown'}
           </div>
-        )}
+          
+        )
+        }
+        <Separator/>
 
         <div className="colormap-list-container" style={{ marginTop: '0.5rem', width: '100%', padding: '0 0.75rem 0.75rem' }}>
           <div style={{ maxHeight: 'min(50vh, 360px)', overflowY: 'auto', paddingRight: 0, width: '100%', boxSizing: 'border-box' }}>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, {useEffect, useState, useMemo} from 'react'
+import React, { useEffect, useState, useMemo } from 'react'
 import { GetColorMapTexture, colormaps, availableColorMapNames, getColormapGradientCss, colormapIndex } from '@/components/textures';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { useShallow } from 'zustand/shallow';
@@ -16,6 +16,13 @@ import {
   InputGroupAddon,
   InputGroupInput,
 } from "@/components/ui/input-group"
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 
 // Render gradients directly instead of using pre-generated icon images
 import {
@@ -28,6 +35,7 @@ const Colormaps = () => {
 
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [hoveredCmap, setHoveredCmap] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string>('None');
   const { colormap, setColormap, colormapName, flipColormap, setColormapName, setFlipColormap } = useGlobalStore(
     useShallow((state) => ({
       setColormap: state.setColormap,
@@ -42,18 +50,30 @@ const Colormaps = () => {
 
   const [prevColormapName, setPrevColormapName] = useState<string>(colormapName || '');
 
-  const displayColormapName = (colormapName || '').length > 5
-    ? `${(colormapName || '').slice(0, 5)}…`
-    : (colormapName || '');
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    colormapIndex.forEach((entry) => {
+      if (entry.category) set.add(entry.category);
+    });
+    return ['None', ...Array.from(set).sort()];
+  }, []);
 
   const filteredColormaps = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
-    if (!query) return colormaps;
+
+    // "None" + no query => original curated default list
+    if (selectedCategory === 'None' && !query) return colormaps;
+
+    const scoped = selectedCategory === 'None'
+      ? colormapIndex
+      : colormapIndex.filter((entry) => entry.category === selectedCategory);
+
+    if (!query) return scoped.map((entry) => entry.name);
 
     const nameMatches: string[] = [];
     const otherMatches: string[] = [];
 
-    for (const entry of colormapIndex) {
+    for (const entry of scoped) {
       const nameHit = entry.name.toLowerCase().includes(query);
       const categoryHit = entry.category?.toLowerCase().includes(query);
       const notesHit = entry.notes?.toLowerCase().includes(query);
@@ -63,7 +83,7 @@ const Colormaps = () => {
     }
 
     return [...nameMatches, ...otherMatches];
-  }, [searchQuery]);
+  }, [searchQuery, selectedCategory]);
 
   const visibleMatches = useMemo(() => filteredColormaps.slice(0, 64), [filteredColormaps]);
   const hasMoreResults = filteredColormaps.length > visibleMatches.length;
@@ -127,6 +147,7 @@ const Colormaps = () => {
           overscrollBehavior: 'contain',
           padding: 0,
           boxSizing: 'border-box',
+          maxHeight: popoverSide === 'top' ? '80vh' : undefined,
         }}
       >
         <style>{`\n.colormaps {\n  scrollbar-width: none;\n}\n.colormaps::-webkit-scrollbar {\n  display: none;\n}\n.colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n  border: 1px solid rgba(0,0,0,0.08);\n}\n@media (prefers-color-scheme: dark) {\n  .colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n    border: 1px solid rgba(255,255,255,0.12);\n  }\n}\n`}</style>
@@ -157,21 +178,35 @@ const Colormaps = () => {
               </Button>
             </ButtonGroup>
 
-            <div style={{ marginLeft: 'auto' }}>
+            <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+              <SelectTrigger size="sm" className="w-[110px] cursor-pointer">
+                <SelectValue placeholder="Category" />
+              </SelectTrigger>
+              <SelectContent>
+                {categories.map((cat) => (
+                  <SelectItem key={cat} value={cat} className="cursor-pointer">
+                    {cat}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div style={{ marginRight: 'auto' }}>
               <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="secondary"
+                    className="border-b-1 border-amber-400"
                   >
-                    {displayColormapName}
+                    <span className="max-w-[230px] truncate">
+                      {colormapName}
+                    </span>
                   </Button>
                 </TooltipTrigger>
-                {colormapName && colormapName.length > 5 && (
                   <TooltipContent side="top" align="center">
                     <span>{colormapName}</span>
                   </TooltipContent>
-                )}
               </Tooltip>
             </div>
           </div>
@@ -180,7 +215,7 @@ const Colormaps = () => {
             <InputGroupInput 
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search by name or category..."
+              placeholder="Search..."
             />
             <InputGroupAddon>
               <Search />
@@ -197,16 +232,16 @@ const Colormaps = () => {
           </Button>
         ) : null}
         </InputGroup>
+        <Separator/>
         </div>
-        {searchQuery.trim() && (
+        {(searchQuery.trim() || selectedCategory !== 'None') && (
           <div className="search-results-summary" style={{ margin: '0 0.75rem 0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
-            Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong> matches for{' "'}{searchQuery}{'"'}
+            Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong>
+            {selectedCategory !== 'None' && <> in <strong>{selectedCategory}</strong></>}
+            {searchQuery.trim() && <> matching &quot;{searchQuery}&quot;</>}
             {hasMoreResults && ' — first 64 shown'}
           </div>
-          
-        )
-        }
-        <Separator/>
+        )}
 
         <div className="colormap-list-container" style={{ marginTop: '0.5rem', width: '100%', padding: '0 0.75rem 0.75rem' }}>
           <div style={{ maxHeight: 'min(50vh, 360px)', overflowY: 'auto', paddingRight: 0, width: '100%', boxSizing: 'border-box' }}>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useEffect, useState, useMemo, useRef } from 'react'
 import { GetColorMapTexture, colormaps, availableColorMapNames, getColormapGradientCss, colormapIndex } from '@/components/textures';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { useShallow } from 'zustand/shallow';
@@ -10,7 +10,7 @@ import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover
 import { Button } from "@/components/ui/button-enhanced";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { Search, X } from "lucide-react"
+import { Search, X, Eye, EyeOff } from "lucide-react"
 import {
   InputGroup,
   InputGroupAddon,
@@ -36,6 +36,7 @@ const Colormaps = () => {
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [hoveredCmap, setHoveredCmap] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string>('None');
+  const [showNames, setShowNames] = useState(true);
   const { colormap, setColormap, colormapName, flipColormap, setColormapName, setFlipColormap } = useGlobalStore(
     useShallow((state) => ({
       setColormap: state.setColormap,
@@ -49,6 +50,7 @@ const Colormaps = () => {
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
 
   const [prevColormapName, setPrevColormapName] = useState<string>(colormapName || '');
+  const previousTextureRef = useRef(colormap);
 
   const categories = useMemo(() => {
     const set = new Set<string>();
@@ -61,25 +63,31 @@ const Colormaps = () => {
   const filteredColormaps = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
 
-    // "None" + no query => original curated default list
-    if (selectedCategory === 'None' && !query) return colormaps;
+    // No search: category filtering works normally
+    if (!query) {
+      if (selectedCategory === 'None') {
+        return colormaps;
+      }
 
-    const scoped = selectedCategory === 'None'
-      ? colormapIndex
-      : colormapIndex.filter((entry) => entry.category === selectedCategory);
+      return colormapIndex
+        .filter((entry) => entry.category === selectedCategory)
+        .map((entry) => entry.name);
+    }
 
-    if (!query) return scoped.map((entry) => entry.name);
-
+    // Search ALWAYS uses the complete collection
     const nameMatches: string[] = [];
     const otherMatches: string[] = [];
 
-    for (const entry of scoped) {
+    for (const entry of colormapIndex) {
       const nameHit = entry.name.toLowerCase().includes(query);
       const categoryHit = entry.category?.toLowerCase().includes(query);
       const notesHit = entry.notes?.toLowerCase().includes(query);
 
-      if (nameHit) nameMatches.push(entry.name);
-      else if (categoryHit || notesHit) otherMatches.push(entry.name);
+      if (nameHit) {
+        nameMatches.push(entry.name);
+      } else if (categoryHit || notesHit) {
+        otherMatches.push(entry.name);
+      }
     }
 
     return [...nameMatches, ...otherMatches];
@@ -89,10 +97,14 @@ const Colormaps = () => {
   const hasMoreResults = filteredColormaps.length > visibleMatches.length;
 
   useEffect(() => {
+    previousTextureRef.current = colormap;
+  }, [colormap]);
+
+  useEffect(() => {
     setColormap(
-      GetColorMapTexture(colormap, (hoveredCmap || colormapName) === "Default" ? "Spectral" : (hoveredCmap || colormapName), 1, "#000000", 0, flipColormap)
+      GetColorMapTexture(previousTextureRef.current, (hoveredCmap || colormapName) === "Default" ? "Spectral" : (hoveredCmap || colormapName), 1, "#000000", 0, flipColormap)
     );
-  }, [colormapName, flipColormap, hoveredCmap]);
+  }, [colormapName, flipColormap, hoveredCmap, setColormap]);
 
   useEffect(() => {
       const handleResize = () => {
@@ -191,7 +203,27 @@ const Colormaps = () => {
               </SelectContent>
             </Select>
 
-            <div style={{ marginRight: 'auto' }}>
+            <div style={{ marginRight: 'auto', display: 'flex', gap: '0.35rem', alignItems: 'center' }}>
+              <Tooltip delayDuration={200}>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="secondary"
+                    className="cursor-pointer"
+                    onClick={() => setShowNames(prev => !prev)}
+                  >
+                    {showNames ? (
+                      <Eye className="h-4 w-4" />
+                    ) : (
+                      <EyeOff className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" align="center">
+                  <span>{showNames ? "Hide names" : "Show names"}</span>
+                </TooltipContent>
+              </Tooltip>
+
               <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                   <Button
@@ -199,14 +231,14 @@ const Colormaps = () => {
                     variant="secondary"
                     className="border-b-1 border-amber-400"
                   >
-                    <span className="max-w-[230px] truncate">
+                    <span className="max-w-[188px] truncate">
                       {colormapName}
                     </span>
                   </Button>
                 </TooltipTrigger>
-                  <TooltipContent side="top" align="center">
-                    <span>{colormapName}</span>
-                  </TooltipContent>
+                <TooltipContent side="top" align="center">
+                  <span>{colormapName}</span>
+                </TooltipContent>
               </Tooltip>
             </div>
           </div>
@@ -237,7 +269,7 @@ const Colormaps = () => {
         {(searchQuery.trim() || selectedCategory !== 'None') && (
           <div className="search-results-summary" style={{ margin: '0 0.75rem 0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
             Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong>
-            {selectedCategory !== 'None' && <> in <strong>{selectedCategory}</strong></>}
+            {selectedCategory !== 'None' && !searchQuery.trim() && <> in <strong>{selectedCategory}</strong></>}
             {searchQuery.trim() && <> matching &quot;{searchQuery}&quot;</>}
             {hasMoreResults && ' — first 64 shown'}
           </div>
@@ -259,7 +291,7 @@ const Colormaps = () => {
               onMouseEnter={() => setHoveredCmap(val)}
               onMouseLeave={() => setHoveredCmap(null)}
               style={{
-                width: '100%',
+                width: '96%',
                 minWidth: 0,
                 height: '34px',
                 borderRadius: '0.5rem',
@@ -289,26 +321,28 @@ const Colormaps = () => {
                   pointerEvents: 'none',
                 }}
               />
-              <span
-                style={{
-                  position: 'relative',
-                  zIndex: 1,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  padding: '0.05rem 0.75rem',
-                  marginLeft: 0,
-                  borderRadius: '0.38rem',
-                  background: 'rgba(244, 237, 237, 0.13)',
-                  backdropFilter: 'blur(8px) saturate(140%)',
-                  WebkitBackdropFilter: 'blur(8px) saturate(140%)',
-                  boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.2)',
-                  fontWeight: 400,
-                  color: 'rgba(241, 237, 237, 0.96)',
-                }}
-              >
-                {val}
-              </span>
+              {showNames && (
+                <span
+                  style={{
+                    position: 'relative',
+                    zIndex: 1,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    padding: '0.05rem 0.75rem',
+                    marginLeft: 0,
+                    borderRadius: '0.38rem',
+                    background: 'rgba(244, 237, 237, 0.13)',
+                    backdropFilter: 'blur(8px) saturate(140%)',
+                    WebkitBackdropFilter: 'blur(8px) saturate(140%)',
+                    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.2)',
+                    fontWeight: 400,
+                    color: 'rgba(241, 237, 237, 0.96)',
+                  }}
+                >
+                  {val}
+                </span>
+              )}
             </button>
           ))}
             </div>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import React, {useEffect, useState} from 'react'
-import { GetColorMapTexture } from '@/components/textures';
+import React, {useEffect, useState, useMemo} from 'react'
+import { GetColorMapTexture, colormaps, availableColorMapNames, getColormapGradientCss } from '@/components/textures';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
-import { colormaps } from '@/components/textures';
 import { useShallow } from 'zustand/shallow';
 import { MdOutlineSwapVert } from "react-icons/md";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
@@ -17,6 +16,7 @@ import {
 
 const Colormaps = () => {
 
+  const [searchQuery, setSearchQuery] = useState<string>('');
   const [hoveredCmap, setHoveredCmap] = useState<string | null>(null);
   const { colormap, setColormap, colormapName, flipColormap, setColormapName, setFlipColormap } = useGlobalStore(
     useShallow((state) => ({
@@ -29,6 +29,17 @@ const Colormaps = () => {
     }))
   );
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
+
+  const [prevColormapName, setPrevColormapName] = useState<string>(colormapName || '');
+
+  const filteredColormaps = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return colormaps;
+    return availableColorMapNames.filter((name) => name.toLowerCase().includes(query));
+  }, [searchQuery]);
+
+  const visibleMatches = useMemo(() => filteredColormaps.slice(0, 64), [filteredColormaps]);
+  const hasMoreResults = filteredColormaps.length > visibleMatches.length;
 
   useEffect(() => {
     setColormap(
@@ -81,7 +92,56 @@ const Colormaps = () => {
         side={popoverSide}
         className="colormaps"
       >
-            {colormaps.map((val) => (
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.6rem' }}>
+          <button
+            type="button"
+            onClick={() => setFlipColormap(!flipColormap)}
+            style={{ padding: '0.5rem 0.75rem', borderRadius: '0.55rem', border: '1px solid var(--ui-border)', background: 'var(--ui-bg-accented)', cursor: 'pointer' }}
+          >
+            {flipColormap ? 'Unflip' : 'Flip'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setColormapName(prevColormapName);
+              setFlipColormap(false);
+              setHoveredCmap(null);
+            }}
+            style={{ padding: '0.5rem 0.75rem', borderRadius: '0.55rem', border: '1px solid var(--ui-border)', background: 'transparent', cursor: 'pointer' }}
+          >
+            Revert
+          </button>
+          <div style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
+            {colormapName}{flipColormap ? ' (flipped)' : ''}
+          </div>
+        </div>
+        <div className="colormap-search-bar" style={{ marginBottom: '0.9rem' }}>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search colormap names"
+            className="search-input"
+            style={{
+              width: '100%',
+              padding: '0.85rem 1rem',
+              borderRadius: '0.75rem',
+              border: '1px solid var(--ui-border)',
+              background: 'var(--ui-bg-code)',
+              color: 'var(--ui-text-highlighted)',
+            }}
+          />
+        </div>
+        {searchQuery.trim() && (
+          <div className="search-results-summary" style={{ marginBottom: '0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
+            Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong> matches for{' "'}{searchQuery}{'"'}
+            {hasMoreResults && ' — first 64 shown'}
+          </div>
+        )}
+        <div className="colormaps-grid" style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
+          {visibleMatches.map((val) => {
+            const hasIcon = colormaps.includes(val);
+            return hasIcon ? (
               <Image
                 key={val}
                 className={`cmap ${flipColormap ? "flipped" : ""}`}
@@ -92,11 +152,47 @@ const Colormaps = () => {
                 onMouseEnter={() => setHoveredCmap(val)}
                 onMouseLeave={() => setHoveredCmap(null)}
                 onClick={() => {
+                  setPrevColormapName(colormapName);
                   setColormapName(val);
                   setHoveredCmap(null);
                 }}
               />
-            ))}
+            ) : (
+              <button
+                key={val}
+                className="cmap fallback-cmap"
+                type="button"
+                onClick={() => {
+                  setPrevColormapName(colormapName);
+                  setColormapName(val);
+                  setHoveredCmap(null);
+                }}
+                onMouseEnter={() => setHoveredCmap(val)}
+                onMouseLeave={() => setHoveredCmap(null)}
+                style={{
+                  width: '100%',
+                  height: '100px',
+                  borderRadius: '0.75rem',
+                  border: '1px solid var(--ui-border)',
+                  background: getColormapGradientCss(val),
+                  color: 'var(--ui-text-highlighted)',
+                  textAlign: 'left',
+                  padding: '0.75rem',
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                  textShadow: '0 1px 3px rgba(0,0,0,0.45)',
+                }}
+              >
+                <span style={{ fontSize: '0.85rem', fontWeight: 700 }}>{val}</span>
+              </button>
+            )
+          })}
+        </div>
+        {filteredColormaps.length === 0 && (
+          <div style={{ padding: '1rem 0', color: 'var(--ui-text-muted)' }}>
+            No colormaps found. Try a different search term.
+          </div>
+        )}
         <MdOutlineSwapVert
             className="flipper"
             style={{

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -51,6 +51,9 @@ const Colormaps = () => {
 
   const [prevColormapName, setPrevColormapName] = useState<string>(colormapName || '');
   const previousTextureRef = useRef(colormap);
+  const colormapNameRef = useRef(colormapName);
+  const flipColormapRef = useRef(flipColormap);
+  const lastHoveredCmap = useRef<string | null>(null);
 
   const categories = useMemo(() => {
     const set = new Set<string>();
@@ -96,15 +99,44 @@ const Colormaps = () => {
   const visibleMatches = useMemo(() => filteredColormaps.slice(0, 64), [filteredColormaps]);
   const hasMoreResults = filteredColormaps.length > visibleMatches.length;
 
+  // Keep refs in sync with store state changes
+  useEffect(() => {
+    colormapNameRef.current = colormapName;
+    flipColormapRef.current = flipColormap;
+  }, [colormapName, flipColormap]);
+
   useEffect(() => {
     previousTextureRef.current = colormap;
   }, [colormap]);
 
   useEffect(() => {
-    setColormap(
-      GetColorMapTexture(previousTextureRef.current, (hoveredCmap || colormapName) === "Default" ? "Spectral" : (hoveredCmap || colormapName), 1, "#000000", 0, flipColormap)
-    );
-  }, [colormapName, flipColormap, hoveredCmap, setColormap]);
+    if (hoveredCmap !== null) {
+      // Show hovered colormap preview
+      setColormap(
+        GetColorMapTexture(
+          previousTextureRef.current,
+          hoveredCmap === "Default" ? "Spectral" : hoveredCmap,
+          1,
+          "#000000",
+          0,
+          flipColormapRef.current
+        )
+      );
+    } else if (lastHoveredCmap.current !== null) {
+      // Mouse left hover: revert to selected colormap
+      setColormap(
+        GetColorMapTexture(
+          previousTextureRef.current,
+          colormapNameRef.current === "Default" ? "Spectral" : colormapNameRef.current,
+          1,
+          "#000000",
+          0,
+          flipColormapRef.current
+        )
+      );
+    }
+    lastHoveredCmap.current = hoveredCmap;
+  }, [hoveredCmap, setColormap]);
 
   useEffect(() => {
       const handleResize = () => {

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -9,6 +9,14 @@ import { ButtonGroup } from "@/components/ui/button-group";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button-enhanced";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Search } from "lucide-react"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group"
+
 // Render gradients directly instead of using pre-generated icon images
 import {
   Tooltip,
@@ -33,6 +41,10 @@ const Colormaps = () => {
   const [popoverSide, setPopoverSide] = useState<"left" | "top">("left");
 
   const [prevColormapName, setPrevColormapName] = useState<string>(colormapName || '');
+
+  const displayColormapName = (colormapName || '').length > 5
+    ? `${(colormapName || '').slice(0, 5)}…`
+    : (colormapName || '');
 
   const filteredColormaps = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
@@ -99,12 +111,13 @@ const Colormaps = () => {
         <style>{`\n.colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n  border: 1px solid rgba(0,0,0,0.08);\n}\n@media (prefers-color-scheme: dark) {\n  .colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n    border: 1px solid rgba(255,255,255,0.12);\n  }\n}\n`}</style>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '0.6rem' }}>
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-            <ButtonGroup className="justify-start" style={{ gap: '0.5rem' }}>
+            <ButtonGroup className="justify-start gap-0.25">
               <Button
                 type="button"
                 onClick={() => setFlipColormap(!flipColormap)}
                 size="sm"
                 variant="secondary"
+                className="cursor-pointer"
               >
                 {flipColormap ? 'Unflip' : 'Flip'}
               </Button>
@@ -116,26 +129,40 @@ const Colormaps = () => {
                   setHoveredCmap(null);
                 }}
                 size="sm"
-                variant="ghost"
+                variant="secondary"
+                className="cursor-pointer"
               >
                 Revert
               </Button>
             </ButtonGroup>
 
             <div style={{ marginLeft: 'auto' }}>
-              <Button size="sm" variant="ghost" style={{ cursor: 'default' }}>{colormapName}{flipColormap ? ' (flipped)' : ''}</Button>
+              <Tooltip delayDuration={200}>
+                <TooltipTrigger asChild>
+                  <Button size="sm" variant="outline" style={{ cursor: 'default' }}>
+                    {displayColormapName}
+                  </Button>
+                </TooltipTrigger>
+                {colormapName && colormapName.length > 5 && (
+                  <TooltipContent side="top" align="center">
+                    <span>{colormapName}</span>
+                  </TooltipContent>
+                )}
+              </Tooltip>
             </div>
           </div>
-
-          <div>
-            <Input
-              type="search"
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search colormap names"
-              className="search-input"
-            />
-          </div>
+          <Separator/>
+          <InputGroup className="max-w-xs">
+            <InputGroupInput 
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search..."
+             />
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+          </InputGroup>
+        <Separator/>
         </div>
         {searchQuery.trim() && (
           <div className="search-results-summary" style={{ marginBottom: '0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -5,8 +5,10 @@ import { GetColorMapTexture, colormaps, availableColorMapNames, getColormapGradi
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { useShallow } from 'zustand/shallow';
 import { MdOutlineSwapVert } from "react-icons/md";
+import { ButtonGroup } from "@/components/ui/button-group";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button-enhanced";
+import { Input } from "@/components/ui/input";
 // Render gradients directly instead of using pre-generated icon images
 import {
   Tooltip,
@@ -66,7 +68,7 @@ const Colormaps = () => {
             <div>
               <Button
                 size="icon"
-                className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out rounded-full'
+                className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out rounded-full cmap-trigger'
                 style={{
                   backgroundImage: getColormapGradientCss((colormapName === 'Default' ? 'Spectral' : colormapName) || 'Spectral'),
                   backgroundRepeat: 'no-repeat',
@@ -75,7 +77,6 @@ const Colormaps = () => {
                   transform: flipColormap ? "scaleX(-1)" : "",
                   width: "32px",
                   height: "32px",
-                  border: '1px solid var(--ui-border)'
                 }} /> 
             </div>
           </TooltipTrigger>
@@ -95,45 +96,46 @@ const Colormaps = () => {
         side={popoverSide}
         className="colormaps"
       >
-        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.6rem' }}>
-          <button
-            type="button"
-            onClick={() => setFlipColormap(!flipColormap)}
-            style={{ padding: '0.5rem 0.75rem', borderRadius: '0.55rem', border: '1px solid var(--ui-border)', background: 'var(--ui-bg-accented)', cursor: 'pointer' }}
-          >
-            {flipColormap ? 'Unflip' : 'Flip'}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setColormapName(prevColormapName);
-              setFlipColormap(false);
-              setHoveredCmap(null);
-            }}
-            style={{ padding: '0.5rem 0.75rem', borderRadius: '0.55rem', border: '1px solid var(--ui-border)', background: 'transparent', cursor: 'pointer' }}
-          >
-            Revert
-          </button>
-          <div style={{ marginLeft: 'auto', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
-            {colormapName}{flipColormap ? ' (flipped)' : ''}
+        <style>{`\n.colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n  border: 1px solid rgba(0,0,0,0.08);\n}\n@media (prefers-color-scheme: dark) {\n  .colormaps .rendered-cmap, .colormaps .cmap-trigger, .colormaps .search-input {\n    border: 1px solid rgba(255,255,255,0.12);\n  }\n}\n`}</style>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '0.6rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <ButtonGroup className="justify-start" style={{ gap: '0.5rem' }}>
+              <Button
+                type="button"
+                onClick={() => setFlipColormap(!flipColormap)}
+                size="sm"
+                variant="secondary"
+              >
+                {flipColormap ? 'Unflip' : 'Flip'}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  setColormapName(prevColormapName);
+                  setFlipColormap(false);
+                  setHoveredCmap(null);
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                Revert
+              </Button>
+            </ButtonGroup>
+
+            <div style={{ marginLeft: 'auto' }}>
+              <Button size="sm" variant="ghost" style={{ cursor: 'default' }}>{colormapName}{flipColormap ? ' (flipped)' : ''}</Button>
+            </div>
           </div>
-        </div>
-        <div className="colormap-search-bar" style={{ marginBottom: '0.9rem' }}>
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder="Search colormap names"
-            className="search-input"
-            style={{
-              width: '100%',
-              padding: '0.85rem 1rem',
-              borderRadius: '0.75rem',
-              border: '1px solid var(--ui-border)',
-              background: 'var(--ui-bg-code)',
-              color: 'var(--ui-text-highlighted)',
-            }}
-          />
+
+          <div>
+            <Input
+              type="search"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search colormap names"
+              className="search-input"
+            />
+          </div>
         </div>
         {searchQuery.trim() && (
           <div className="search-results-summary" style={{ marginBottom: '0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
@@ -141,7 +143,10 @@ const Colormaps = () => {
             {hasMoreResults && ' — first 64 shown'}
           </div>
         )}
-        <div className="colormaps-grid" style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
+
+        <div className="colormap-list-container" style={{ marginTop: '0.5rem' }}>
+          <div style={{ maxHeight: '40vh', overflowY: 'auto', paddingRight: '0.25rem' }}>
+            <div className="colormaps-grid" style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
           {visibleMatches.map((val) => (
             <button
               key={val}
@@ -158,7 +163,6 @@ const Colormaps = () => {
                 width: '100%',
                 height: '34px',
                 borderRadius: '0.5rem',
-                border: '1px solid var(--ui-border)',
                 backgroundImage: getColormapGradientCss(val),
                 backgroundRepeat: 'no-repeat',
                 backgroundPosition: 'center',
@@ -177,27 +181,14 @@ const Colormaps = () => {
               <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{val}</span>
             </button>
           ))}
+            </div>
         </div>
         {filteredColormaps.length === 0 && (
           <div style={{ padding: '1rem 0', color: 'var(--ui-text-muted)' }}>
             No colormaps found. Try a different search term.
           </div>
         )}
-        <MdOutlineSwapVert
-            className="flipper"
-            style={{
-              position: "absolute",
-              top:"-2rem",
-              right: "80%",
-              bottom: "90%",
-              height: "50px",
-              width: "50px",
-              cursor: "pointer",
-              transform: `${flipColormap ? "rotate(270deg)" : "rotate(90deg)"}`,
-              transition: ".25s",
-            }}
-            onClick={() => setFlipColormap(!flipColormap)}
-        />
+        </div>
       </PopoverContent>
       
       </Popover>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -68,11 +68,14 @@ const Colormaps = () => {
                 size="icon"
                 className='cursor-pointer hover:scale-90 transition-transform duration-100 ease-out rounded-full'
                 style={{
-                  backgroundImage: `url(./colormap_icons/${colormapName}.webp)` ,
-                  backgroundSize: "100%",
+                  backgroundImage: getColormapGradientCss((colormapName === 'Default' ? 'Spectral' : colormapName) || 'Spectral'),
+                  backgroundRepeat: 'no-repeat',
+                  backgroundPosition: 'center',
+                  backgroundSize: '100% 100%',
                   transform: flipColormap ? "scaleX(-1)" : "",
                   width: "32px",
                   height: "32px",
+                  border: '1px solid var(--ui-border)'
                 }} /> 
             </div>
           </TooltipTrigger>
@@ -151,12 +154,15 @@ const Colormaps = () => {
               }}
               onMouseEnter={() => setHoveredCmap(val)}
               onMouseLeave={() => setHoveredCmap(null)}
-              style={{
+                style={{
                 width: '100%',
                 height: '34px',
                 borderRadius: '0.5rem',
                 border: '1px solid var(--ui-border)',
-                background: getColormapGradientCss(val),
+                backgroundImage: getColormapGradientCss(val),
+                backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'center',
+                backgroundSize: '100% 100%',
                 color: 'var(--ui-text-highlighted)',
                 display: 'flex',
                 alignItems: 'center',

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -7,7 +7,7 @@ import { useShallow } from 'zustand/shallow';
 import { MdOutlineSwapVert } from "react-icons/md";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Button } from "@/components/ui/button-enhanced";
-import Image from 'next/image';
+// Render gradients directly instead of using pre-generated icon images
 import {
   Tooltip,
   TooltipContent,
@@ -138,55 +138,39 @@ const Colormaps = () => {
             {hasMoreResults && ' — first 64 shown'}
           </div>
         )}
-        <div className="colormaps-grid" style={{ display: 'grid', gap: '0.75rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
-          {visibleMatches.map((val) => {
-            const hasIcon = colormaps.includes(val);
-            return hasIcon ? (
-              <Image
-                key={val}
-                className={`cmap ${flipColormap ? "flipped" : ""}`}
-                src={`./colormap_icons/${val}.webp`}
-                alt={val}
-                height={100}
-                width={256}
-                onMouseEnter={() => setHoveredCmap(val)}
-                onMouseLeave={() => setHoveredCmap(null)}
-                onClick={() => {
-                  setPrevColormapName(colormapName);
-                  setColormapName(val);
-                  setHoveredCmap(null);
-                }}
-              />
-            ) : (
-              <button
-                key={val}
-                className="cmap fallback-cmap"
-                type="button"
-                onClick={() => {
-                  setPrevColormapName(colormapName);
-                  setColormapName(val);
-                  setHoveredCmap(null);
-                }}
-                onMouseEnter={() => setHoveredCmap(val)}
-                onMouseLeave={() => setHoveredCmap(null)}
-                style={{
-                  width: '100%',
-                  height: '100px',
-                  borderRadius: '0.75rem',
-                  border: '1px solid var(--ui-border)',
-                  background: getColormapGradientCss(val),
-                  color: 'var(--ui-text-highlighted)',
-                  textAlign: 'left',
-                  padding: '0.75rem',
-                  display: 'flex',
-                  alignItems: 'flex-end',
-                  textShadow: '0 1px 3px rgba(0,0,0,0.45)',
-                }}
-              >
-                <span style={{ fontSize: '0.85rem', fontWeight: 700 }}>{val}</span>
-              </button>
-            )
-          })}
+        <div className="colormaps-grid" style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
+          {visibleMatches.map((val) => (
+            <button
+              key={val}
+              className={`cmap rendered-cmap ${flipColormap ? "flipped" : ""}`}
+              type="button"
+              onClick={() => {
+                setPrevColormapName(colormapName);
+                setColormapName(val);
+                setHoveredCmap(null);
+              }}
+              onMouseEnter={() => setHoveredCmap(val)}
+              onMouseLeave={() => setHoveredCmap(null)}
+              style={{
+                width: '100%',
+                height: '34px',
+                borderRadius: '0.5rem',
+                border: '1px solid var(--ui-border)',
+                background: getColormapGradientCss(val),
+                color: 'var(--ui-text-highlighted)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '0 0.75rem',
+                fontSize: '0.85rem',
+                fontWeight: 700,
+                textShadow: '0 1px 3px rgba(0,0,0,0.45)',
+                overflow: 'hidden',
+              }}
+            >
+              <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{val}</span>
+            </button>
+          ))}
         </div>
         {filteredColormaps.length === 0 && (
           <div style={{ padding: '1rem 0', color: 'var(--ui-text-muted)' }}>

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -35,7 +35,7 @@ const Colormaps = () => {
 
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [hoveredCmap, setHoveredCmap] = useState<string | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState<string>('None');
+  const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [showNames, setShowNames] = useState(true);
   const { colormap, setColormap, colormapName, flipColormap, setColormapName, setFlipColormap } = useGlobalStore(
     useShallow((state) => ({
@@ -65,7 +65,7 @@ const Colormaps = () => {
 
     // No search: category filtering works normally
     if (!query) {
-      if (selectedCategory === 'None') {
+      if (!selectedCategory || selectedCategory === 'None') {
         return colormaps;
       }
 
@@ -190,7 +190,10 @@ const Colormaps = () => {
               </Button>
             </ButtonGroup>
 
-            <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+            <Select
+              value={selectedCategory === 'None' ? '' : selectedCategory}
+              onValueChange={(value) => setSelectedCategory(value === 'None' ? '' : value)}
+            >
               <SelectTrigger size="sm" className="w-[110px] cursor-pointer">
                 <SelectValue placeholder="Category" />
               </SelectTrigger>
@@ -269,7 +272,7 @@ const Colormaps = () => {
         {(searchQuery.trim() || selectedCategory !== 'None') && (
           <div className="search-results-summary" style={{ margin: '0 0.75rem 0.75rem', fontSize: '0.85rem', color: 'var(--ui-text-muted)' }}>
             Showing <strong>{visibleMatches.length}</strong> of <strong>{filteredColormaps.length}</strong>
-            {selectedCategory !== 'None' && !searchQuery.trim() && <> in <strong>{selectedCategory}</strong></>}
+            {selectedCategory && selectedCategory !== 'None' && !searchQuery.trim() && <> in <strong>{selectedCategory}</strong></>}
             {searchQuery.trim() && <> matching &quot;{searchQuery}&quot;</>}
             {hasMoreResults && ' — first 64 shown'}
           </div>

--- a/src/components/ui/css/MainPanel.css
+++ b/src/components/ui/css/MainPanel.css
@@ -62,7 +62,7 @@
 }
 
 .colormaps{
-    max-height: 50vh;
+    max-height: 70vh;
     width: 234px;
     display:grid;
     gap:3px;

--- a/src/components/ui/css/MainPanel.css
+++ b/src/components/ui/css/MainPanel.css
@@ -45,7 +45,7 @@
 .cmap{
     padding: 0px 0px;
     cursor: pointer;
-    max-width: 200px;
+    max-width: 95%;
     height: 36px;
     border-radius: 6px;
     transition: 0.25s;

--- a/src/utils/updateColorbar.tsx
+++ b/src/utils/updateColorbar.tsx
@@ -1,4 +1,4 @@
-import { evaluate_cmap } from 'js-colormaps-es';
+import { evaluateColorMap } from '@/components/textures';
 
 interface UpdateColorbarParams {
   colorbarId: string;
@@ -66,7 +66,7 @@ export function updateColorbar(params: UpdateColorbarParams) {
 
 export function getColors(palette: string): [number, number, number][] {
   const unitInterval = Array.from({ length: 32 }, (_, index) => index / 31);
-  return unitInterval.map(value => evaluate_cmap(value, palette, false));
+  return unitInterval.map((value) => evaluateColorMap(value, palette, false));
 }
 
 export function rgbToHex(color: [number, number, number]): string {


### PR DESCRIPTION
This PR moves us away from using `js-colormaps-es` and predefined colormap icons. Now all is handle in the browser directly via `color-schemes-js` with more than 1k colormaps to choose from. 

Unfortunately, I could not find an existing package with all the colormaps I would like to have, so I did the port [color-schemes-js](https://lazarusa.github.io/color-schemes-js/latest/) from the Julia package, [ColorSchemes.jl](https://juliagraphics.github.io/ColorSchemes.jl/stable/). 

This mainly closes #419 (other requests there should be considered in different issues).

The new added package will also allow us to easily do categorical sampling and other advance color shenanigans, see #264 (this should be addressed in a different PR).

<img width="331" height="528" alt="Screenshot 2026-07-21 at 18 03 52" src="https://github.com/user-attachments/assets/5e962f59-99ad-48c9-ae5f-1be82c8804c8" />
<img width="333" height="544" alt="Screenshot 2026-07-21 at 18 03 25" src="https://github.com/user-attachments/assets/981485fc-ac92-43c3-8922-a0e4b80d9554" />
<img width="335" height="527" alt="Screenshot 2026-07-21 at 18 02 52" src="https://github.com/user-attachments/assets/8dec5572-1f34-409c-9e4d-f8123ead96b2" />
<img width="335" height="511" alt="Screenshot 2026-07-21 at 18 02 43" src="https://github.com/user-attachments/assets/b362b058-6fa8-42d1-98ea-7944b2825074" />
<img width="334" height="512" alt="Screenshot 2026-07-21 at 18 02 30" src="https://github.com/user-attachments/assets/735e1d28-3eba-4ff6-8791-275f99078fb2" />
