### PR TITLE
Handle Param Inputs

### DIFF
--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -68,6 +68,7 @@ type PlotState ={
   nativeCRS: string | undefined;
   destCRS: string | undefined;
   overRideCamera: boolean; // Prevent Camera from resetting until initial position is set. 
+  preProject: boolean;
 
   setQuality: (quality: number) => void;
   setTimeScale: (timeScale : number) =>void;
@@ -195,7 +196,7 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   nativeCRS: undefined,
   destCRS: undefined,
   overRideCamera: false,
-
+  preProject : false, // reproject data on dataloader before 'show' is true;
 
   setVTransferRange: (vTransferRange) => set({ vTransferRange }),
   setVTransferScale: (vTransferScale) => set({ vTransferScale }),

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -70,11 +70,11 @@ function StoreInitializerInner() {
 	const data = searchParams.get("data");
 	const keyFramesPath = searchParams.get("keyFramesPath");
 	const exportPlot = searchParams.get("export")
+	const reproject = searchParams.get("reproject")
 	// ---- Handle States ---- //
 	if (data){
 		try{
 		const fullObj = JSON.parse(data);
-		console.log(fullObj)
 		if (fullObj.zarrState?.blobKey){ // If NC local must load file beforehand
 			const blobKey = fullObj.zarrState.blobKey
 			const isNC = fullObj.zarrState.useNC
@@ -124,7 +124,9 @@ function StoreInitializerInner() {
 		});
   	}
 	// ---- Handle Export ---- //
-	if (exportPlot) useImageExportStore.setState({exportOnLoad:true})
+	if (exportPlot === 'true') useImageExportStore.setState({exportOnLoad:true})
+	// ---- Reproject data ---- //
+	if (reproject === 'true') usePlotStore.setState({preProject:true})
 	// ---- Julia fallback ---- //
 	/* Remove this if Julia package does not stay maintained */
 	if (searchParams.get("format") === "nc") useZarrStore.setState({useNC:true});

--- a/src/components/StoreInitializer.tsx
+++ b/src/components/StoreInitializer.tsx
@@ -65,6 +65,7 @@ function StoreInitializerInner() {
   const setInitStore = useGlobalStore(s => s.setInitStore);
 
   useEffect(() => {
+	if (searchParams.size === 0) {initializeStore(); return;}
 	const store = searchParams.get("store");
 	const data = searchParams.get("data");
 	const keyFramesPath = searchParams.get("keyFramesPath");

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -41,80 +41,77 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
     /* overRideCamera is set when Browzarr is accessed via code. On this component mount, setCameraPosition
     /* sets the cameraPosition based either on value from code or default. Then overRideCamera
     /* is disabled and reset can function normally */
-    if (overRideCamera) return;
-    if (!hasMounted.current) {
+    if (!hasMounted.current){
       hasMounted.current = true;
-      return; // skip reset when changing between flat or not flat cameras
+      return; // never animate on the very first mount
     }
-    if (orbitRef.current){
-      const controls = orbitRef.current
-      let frameId: number;
-      const duration = 1000; 
-      const startTime = performance.now();
-      const startPos = controls.object.position.clone();
-      const endPos = isFlat ? new THREE.Vector3(0, 0, 5) : new THREE.Vector3(-4.5, 3, 4.5)
-      const startTarget = controls.target.clone();
-      const endTarget = controls.target0.clone()
+    if (overRideCamera) return // a URL/code-driven position is pending; let the position effect handle it
+    if (!orbitRef.current) return
+    const controls = orbitRef.current
+    let frameId: number;
+    const duration = 1000; 
+    const startTime = performance.now();
+    const startPos = controls.object.position.clone();
+    const endPos = isFlat ? new THREE.Vector3(0, 0, 5) : new THREE.Vector3(-4.5, 3, 4.5)
+    const startTarget = controls.target.clone();
+    const endTarget = controls.target0.clone()
 
-      const startZoom = controls.object.zoom
-      
-      const animate = (time: number) => {
-        invalidate();
-        const elapsed = time - startTime;
-        const t = Math.min(elapsed / duration, 1); // clamp between 0 and 1
-        controls.object.position.lerpVectors(startPos, endPos, t);
-        controls.target.lerpVectors(startTarget,endTarget,t)
+    const startZoom = controls.object.zoom
+    
+    const animate = (time: number) => {
+      invalidate();
+      const elapsed = time - startTime;
+      const t = Math.min(elapsed / duration, 1); // clamp between 0 and 1
+      controls.object.position.lerpVectors(startPos, endPos, t);
+      controls.target.lerpVectors(startTarget,endTarget,t)
 
-        if (isFlat && useOrtho) {
-          controls.object.zoom = THREE.MathUtils.lerp(startZoom, 50, t);
-          controls.object.updateProjectionMatrix();
-          controls.update()
-        } 
+      if (isFlat && useOrtho) {
+        controls.object.zoom = THREE.MathUtils.lerp(startZoom, 50, t);
+        controls.object.updateProjectionMatrix();
+        controls.update()
+      } 
 
-        if (t < 1) {
-          frameId = requestAnimationFrame(animate);
-        }
-      };
+      if (t < 1) {
+        frameId = requestAnimationFrame(animate);
+      }
+    };
 
-      frameId = requestAnimationFrame(animate);
-      return () => cancelAnimationFrame(frameId);
-    }
+    frameId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frameId);
   },[resetCamera, isFlat])
 
   // ---- Switch from Perspective to Orthographic ---- //
   useEffect(()=>{
-    if (hasMounted.current){
-      let newCamera;
-      const aspect = size.width / size.height
-      if (useOrtho){
-        newCamera = new THREE.OrthographicCamera()
-        
-        const frustumSize = 50 
-        newCamera.left = -frustumSize * aspect / 2
-        newCamera.right = frustumSize * aspect / 2
-        newCamera.top = frustumSize / 2
-        newCamera.bottom = -frustumSize / 2
-        newCamera.zoom = 10;
-        
-        // For orthographic, use the target direction but normalize the position
-        const target = orbitRef.current?.target || new THREE.Vector3(0, 0, 0)
-        const direction = camera.position.clone().sub(target).normalize()
-        newCamera.position.copy(target).add(direction.multiplyScalar(10)) // Fixed distance
-        newCamera.lookAt(target)
-        
-        newCamera.updateProjectionMatrix()
-      } else {
-        newCamera = new THREE.PerspectiveCamera(50, aspect)
-        newCamera.position.copy(camera.position.normalize().multiply(new THREE.Vector3(4, 4, 4))) // 4 seems like good distance
-        newCamera.rotation.copy(camera.rotation)
-      }
-    cameraRef.current = newCamera
-    setCameraRef(cameraRef)
-    set({ camera: newCamera})
-    if (orbitRef.current) {
-      orbitRef.current.object = newCamera
-      orbitRef.current.update()
+    let newCamera;
+    const aspect = size.width / size.height
+    if (useOrtho){
+      newCamera = new THREE.OrthographicCamera()
+      
+      const frustumSize = 50 
+      newCamera.left = -frustumSize * aspect / 2
+      newCamera.right = frustumSize * aspect / 2
+      newCamera.top = frustumSize / 2
+      newCamera.bottom = -frustumSize / 2
+      newCamera.zoom = 10;
+      
+      // For orthographic, use the target direction but normalize the position
+      const target = orbitRef.current?.target || new THREE.Vector3(0, 0, 0)
+      const direction = camera.position.clone().sub(target).normalize()
+      newCamera.position.copy(target).add(direction.multiplyScalar(10)) // Fixed distance
+      newCamera.lookAt(target)
+      
+      newCamera.updateProjectionMatrix()
+    } else {
+      newCamera = new THREE.PerspectiveCamera(50, aspect)
+      newCamera.position.copy(camera.position.normalize().multiply(new THREE.Vector3(4, 4, 4))) // 4 seems like good distance
+      newCamera.rotation.copy(camera.rotation)
     }
+  cameraRef.current = newCamera
+  setCameraRef(cameraRef)
+  set({ camera: newCamera})
+  if (orbitRef.current) {
+    orbitRef.current.object = newCamera
+    orbitRef.current.update()
   }
   },[useOrtho])
 
@@ -138,14 +135,6 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
     }
     usePlotStore.setState({overRideCamera: false}) // Allow camera updating
   },[cameraPosition])
-
-  // ---- Camera Ref for state saves ---- //
-  useEffect(()=>{
-    usePlotStore.setState({camera})
-    return () => {
-      usePlotStore.setState({camera: undefined})
-    }
-  },[camera])
 
   return (
     <OrbitControls 

--- a/src/components/textures/ProjectionTexture.ts
+++ b/src/components/textures/ProjectionTexture.ts
@@ -36,7 +36,6 @@ export function resetProjection(){
         remapBorders: undefined,
     })
     handleIrregularGrid(dimArrays)
-
     usePlotStore.setState({
         xSlice, 
         ySlice

--- a/src/components/ui/NavBar/ParameterExport.tsx
+++ b/src/components/ui/NavBar/ParameterExport.tsx
@@ -6,6 +6,7 @@ import { BiExport } from "react-icons/bi";
 import { FiCopy } from "react-icons/fi";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Button } from '../button';
+import { useImageExportStore } from '@/GlobalStates/ImageExportStore';
 
 function pick(obj: Record<string, any>, keys: string[]) {
     return Object.fromEntries(
@@ -99,8 +100,8 @@ export const ParameterExport = () => {
     const [copied, setCopied] = useState(false);
 
     function generateURL(){
-        const {camera} = usePlotStore.getState()
-        usePlotStore.setState({cameraPosition:camera?.position}) // Set Camera position first to copy visual state
+        const {cameraRef} = useImageExportStore.getState()
+        usePlotStore.setState({cameraPosition:cameraRef?.current?.position}) // Set Camera position first to copy visual state
         const fullObj = {
             globalState: pick(useGlobalStore.getState(), globalValues),
             plotState: pick(usePlotStore.getState(), plotValues),

--- a/src/hooks/useDataFetcher.tsx
+++ b/src/hooks/useDataFetcher.tsx
@@ -8,15 +8,14 @@ import { ParseExtent, GetDimInfo } from '@/utils/HelperFuncs';
 import { GetAttributes } from '@/components/zarr/ZarrLoaderLRU';
 import { GetArray } from '@/components/zarr/GetArray';
 import { ArrayToTexture } from '@/components/textures';
-import { handleIrregularGrid } from '@/components/textures/ProjectionTexture';
+import { handleIrregularGrid, reproject } from '@/components/textures/ProjectionTexture';
 
 export const useDataFetcher = () => {
     const {
-    setShape, setDataShape, setFlipY, setValueScales, setMetadata, setDimArrays, 
-    setDimNames, setDimUnits, setPlotOn, setStatus} = useGlobalStore(
+    setShape, setDataShape, setFlipY, setValueScales, setMetadata, setPlotOn, setStatus} = useGlobalStore(
     useShallow(s => s))
-    const {variable, is4D, setIsFlat} = useGlobalStore(useShallow(s => s))
-    const {plotType, interpPixels, setPlotType} = usePlotStore(useShallow(s => s))
+    const {variable, setIsFlat} = useGlobalStore(useShallow(s => s))
+    const {plotType, interpPixels, preProject, setPlotType} = usePlotStore(useShallow(s => s))
     const {zSlice, ySlice, xSlice, reFetch} = useZarrStore(useShallow(s => s))
 
     //---- Local State ----//
@@ -83,10 +82,7 @@ export const useDataFetcher = () => {
 
                     setPlotOn(true);
                     setStatus(null);
-                }).then(()=>
-                    // We don't show/mount any components until all of the essential data has been set
-                    setShow(true)
-                );
+                })
             } catch (error) {
                 console.error(error);
                 setStatus(null);
@@ -102,19 +98,19 @@ export const useDataFetcher = () => {
             //---- DimInfo ----//
             GetDimInfo(variable).then((arrays) => {
                 let { dimArrays, dimUnits, dimNames } = arrays;
-                setDimArrays(dimArrays);
-                setDimNames(dimNames);
-                setDimUnits(dimUnits);
-                useGlobalStore.setState({axisDimArrays: dimArrays, axisDimNames: dimNames, axisDimUnits: dimUnits});
+                useGlobalStore.setState({dimArrays, dimNames, dimUnits, 
+                    axisDimArrays: dimArrays, axisDimNames: dimNames, axisDimUnits: dimUnits});
 
                 const { axisMapping } = useZarrStore.getState();
                 const yIdx = (axisMapping.y >= 0 && axisMapping.y < dimArrays.length) ? axisMapping.y : Math.max(0, dimArrays.length - 2);
                 const targetDim = dimArrays[yIdx] || dimArrays[0];
                 const shouldFlip = (targetDim && targetDim.length >= 2) ? targetDim[1] < targetDim[0] : false;
                 setFlipY(shouldFlip);
-
                 ParseExtent(dimUnits, dimArrays);
-                handleIrregularGrid(dimArrays);
+                if(preProject)reproject();
+                else handleIrregularGrid(dimArrays);
+                // We don't show/mount any components until all of the essential data has been set
+                setShow(true)
             });
 
         } else {


### PR DESCRIPTION
Update to improve Browzarrs performance when being initialized with URL parameters.

overideCamera was being set to true when there were no params; i.e; not set by code. This was changed

when defining both CRS' browzarr will reproject the data before first display of information.

url params are always strings so changed boolean logic in URL param checker 

