### PR TITLE
Implemented DDA Renderer

### DIFF
--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -25,7 +25,7 @@ type PlotState ={
   animProg: number;
   cOffset: number;
   cScale: number;
-  useFragOpt: boolean;
+  useRayMarch: boolean;
   resetCamera: boolean;
   useCustomColor: boolean;
   useCustomPointColor: boolean;
@@ -93,7 +93,7 @@ type PlotState ={
   setAnimProg: (animProg: number) => void; 
   setCOffset: (cOffset: number) => void;
   setCScale: (cScale: number) => void;
-  setUseFragOpt: (useFragOpt: boolean) => void;
+  setUseRayMarch: (useRayMarch: boolean) => void;
   setResetCamera: (resetCamera: boolean) => void;
   setUseCustomColor: (useCustomColor: boolean) => void;
   setUseCustomPointColor: (useCustomPointColor: boolean) => void;
@@ -152,7 +152,7 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   animProg: 0,
   cOffset: 0,
   cScale: 1,
-  useFragOpt: false,
+  useRayMarch: false,
   resetCamera: false,
   useCustomColor: false,
   useCustomPointColor: false,
@@ -223,7 +223,7 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   setAnimProg: (animProg) => set({ animProg }),
   setCOffset: (cOffset) => set({ cOffset }),
   setCScale: (cScale) => set({ cScale }),
-  setUseFragOpt: (useFragOpt) => set({ useFragOpt }),
+  setUseRayMarch: (useRayMarch) => set({ useRayMarch }),
   setResetCamera: (resetCamera) => set({ resetCamera }),
   setUseCustomColor: (useCustomColor) => set({ useCustomColor }),
   setUseCustomPointColor: (useCustomPointColor) => set({ useCustomPointColor}),

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -1,6 +1,6 @@
 import {  useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three'
-import { vertexShader, fragmentShader, fragOpt, orthoVertex } from '@/components/textures/shaders';
+import { vertexShader, fragmentShader, fragOpt, orthoVertex , ddaFrag} from '@/components/textures/shaders';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow';
@@ -17,10 +17,10 @@ interface DataCubeProps {
 
 export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
     const volTexture = usePaddedTextures(propVolTexture);
-    const {shape, colormap, flipY, textureArrayDepths, remapTexture} = useGlobalStore(useShallow(s => s)) //We have to useShallow when returning an object instead of a state. I don't fully know the logic yet
+    const {shape, colormap, flipY, textureArrayDepths, remapTexture, dataShape} = useGlobalStore(useShallow(s => s)) //We have to useShallow when returning an object instead of a state. I don't fully know the logic yet
     const {
-      valueRange, xRange, yRange, zRange, quality, useOrtho, 
-      animProg, cScale, cOffset, useFragOpt, transparency, maskTexture, maskValue,
+      valueRange, xRange, yRange, zRange, quality, useOrtho, interpPixels,
+      animProg, cScale, cOffset, useRayMarch, transparency, maskTexture, maskValue,
       nanTransparency, nanColor, vTransferRange, vTransferScale, fillValue} = usePlotStore(useShallow(s => s))
     const meshRef = useRef<THREE.Mesh>(null!);
     const aspectRatio = shape.y/shape.x
@@ -33,6 +33,7 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
           map: { value: volTexture},
           maskTexture: { value: maskTexture },
           maskValue: {value: maskValue },
+          dataShape: {value: new THREE.Vector3(dataShape[2], dataShape[1], dataShape[0])},
           textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
           cmap:{value: colormap},
           remapTexture: { value: remapTexture},
@@ -59,12 +60,12 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
         ...(remapTexture ? { REPROJECT: true } : {})
       },
       vertexShader: useOrtho ? orthoVertex : vertexShader,
-      fragmentShader: useFragOpt ?  fragOpt : fragmentShader,
+      fragmentShader: useRayMarch ? fragmentShader : ddaFrag,
       transparent: true,
       blending: THREE.NormalBlending,
       depthWrite: false,
       side: useOrtho ? THREE.FrontSide : THREE.BackSide,
-    }),[useFragOpt, useOrtho, volTexture, remapTexture]);
+    }),[useRayMarch, useOrtho, volTexture, remapTexture]);
 
     const geometry = useMemo(() => new THREE.BoxGeometry(shape.x, shape.y, shape.z), [shape]);
     useEffect(() => {

--- a/src/components/textures/shaders/DDAFrag.glsl
+++ b/src/components/textures/shaders/DDAFrag.glsl
@@ -1,0 +1,209 @@
+// by Jeran Poehls
+precision highp float;
+precision highp sampler3D;
+
+in vec3 vOrigin;
+in vec3 vDirection;
+
+out vec4 color;
+
+uniform sampler3D map[12]; // We are limited to 16 textures. Cmap counts as one. 15 is weird so we use 12.
+uniform sampler2D maskTexture;
+uniform sampler2D cmap;
+uniform sampler2D remapTexture;
+uniform vec3 textureDepths;
+
+uniform vec3 dataShape;
+uniform float cOffset;
+uniform float cScale;
+uniform vec3 scale;
+uniform vec2 threshold;
+uniform float steps;
+uniform vec4 flatBounds;
+uniform vec2 vertBounds;
+uniform float animateProg;
+uniform float transparency;
+uniform float nanAlpha;
+uniform vec3 nanColor;
+uniform float opacityMag;
+uniform bool useClipScale;
+uniform float fillValue;
+uniform int maskValue;
+uniform vec2 latBounds;
+uniform vec2 lonBounds;
+
+#define EPSILON 0.000001
+#define PI 3.1415926535
+
+vec2 hitBox(vec3 orig, vec3 dir) {
+    vec3 boxMin = -(scale * 0.5);
+    vec3 boxMax = scale * 0.5;
+    vec3 invDir = 1.0 / dir;
+    vec3 tMinTmp = (boxMin - orig) * invDir;
+    vec3 tMaxTmp = (boxMax - orig) * invDir;
+    vec3 tMin = min(tMinTmp, tMaxTmp);
+    vec3 tMax = max(tMinTmp, tMaxTmp);
+    float t0 = max(tMin.x, max(tMin.y, tMin.z));
+    float t1 = min(tMax.x, min(tMax.y, tMax.z));
+    return vec2(t0, t1);
+}
+
+vec2 realCoords(vec2 uv) {
+    vec2 normalizedLon = lonBounds / (2.0 * PI) + 0.5;
+    vec2 normalizedLat = latBounds / PI + 0.5;
+    float lonScale = normalizedLon.y - normalizedLon.x;
+    float latScale = normalizedLat.y - normalizedLat.x;
+
+    float u = uv.x * lonScale + normalizedLon.x;
+    float v = uv.y * latScale + normalizedLat.x;
+
+    return vec2(u, v);
+}
+
+
+float sample1(vec3 p, int index) {
+    if (index == 0) return texture(map[0], p).r;
+    if (index == 1) return texture(map[1], p).r;
+    if (index == 2) return texture(map[2], p).r;
+    if (index == 3) return texture(map[3], p).r;
+    if (index == 4) return texture(map[4], p).r;
+    if (index == 5) return texture(map[5], p).r;
+    if (index == 6) return texture(map[6], p).r;
+    if (index == 7) return texture(map[7], p).r;
+    if (index == 8) return texture(map[8], p).r;
+    if (index == 9) return texture(map[9], p).r;
+    if (index == 10) return texture(map[10], p).r;
+    if (index == 11) return texture(map[11], p).r;
+    return 0.0;
+}
+
+bool shouldSkip(vec3 p, out vec3 texCoord) {
+    // This functions creates denormalized texCoord while also checking for early skipping
+    texCoord = vec3(0.0);
+
+    if (p.x > -flatBounds.x || p.x < -flatBounds.y) return true;
+    if (-p.z > -flatBounds.z || -p.z < -flatBounds.w) return true;
+    if (p.y < vertBounds.x || p.y > vertBounds.y) return true;
+
+    texCoord = p / scale + 0.5;
+
+    #ifdef REPROJECT
+        vec3 remap = texture2D(remapTexture, texCoord.xy).rgb;
+        texCoord.xy = remap.rg;
+        if (remap.b < 0.5) return true;
+    #endif
+
+    if (maskValue != 0) {
+        vec2 realV = realCoords(texCoord.xy);
+        float mask = texture(maskTexture, realV).r;
+        bool masked = maskValue == 1 ? mask < 0.5 : mask >= 0.5;
+        if (masked) return true;
+    }
+
+    texCoord.z = mod(texCoord.z + animateProg, 1.0001);
+    texCoord = clamp(texCoord, vec3(0.0), 1.0 - vec3(EPSILON));
+
+    return false;
+}
+
+bool sampleVoxel(vec3 texCoord, out float d) {
+    // This gets the sample value. If d is clipped by value-range return false
+    ivec3 depths = ivec3(textureDepths);
+    int yStepSize = depths.x;
+    int zStepSize = depths.y * depths.x;
+
+    ivec3 idx = clamp(ivec3(texCoord * textureDepths), ivec3(0), depths - 1);
+    int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;
+    vec3 localCoord = fract(texCoord * textureDepths);
+
+    d = sample1(localCoord, textureIdx);
+    return d >= threshold.x && d <= threshold.y;
+}
+
+void main() {
+    vec3 rayDir = normalize(vDirection);
+    vec2 bounds = hitBox(vOrigin, rayDir);
+    if (bounds.x > bounds.y) discard;
+    bounds.x = max(bounds.x, 0.0);
+
+    vec3 gridRes = dataShape;
+    vec3 boxMin = -(scale * 0.5);
+    vec3 voxelSize = scale / gridRes;
+
+    // Initial voxel from the ray's entry point into the box.
+    vec3 p0 = vOrigin + bounds.x * rayDir;
+    vec3 localPos = clamp((p0 - boxMin) / scale, vec3(0.0), vec3(1.0) - vec3(EPSILON)) * gridRes;
+    ivec3 voxel = clamp(ivec3(floor(localPos)), ivec3(0), ivec3(gridRes) - 1);
+
+    // Standard 3D DDA (Amanatides & Woo) setup.
+    vec3 stepDir = sign(rayDir);
+    ivec3 stepDirI = ivec3(stepDir);
+    vec3 nextBoundary = boxMin + (vec3(voxel) + max(stepDir, 0.0)) * voxelSize;
+
+    vec3 tMax = (nextBoundary - vOrigin) / rayDir;
+    vec3 tDelta = voxelSize / abs(rayDir);
+
+    // Handle parallel rays. If ray has < eps component in an axis, it will never cross that axis
+    // If it is degen just manually set the interesction distance to someting arbitrarly high
+    bvec3 degenerate = lessThan(abs(rayDir), vec3(EPSILON));
+    tMax = mix(tMax, vec3(1e30), degenerate);
+    tDelta = mix(tDelta, vec3(1e30), degenerate);
+
+    float t = bounds.x;
+    int maxSteps = int(gridRes.x + gridRes.y + gridRes.z) * 2 + 8;
+
+    vec3 accumColor = vec3(0.0);
+    float alphaAcc = 0.0;
+
+    for (int i = 0; i < maxSteps; i++) {
+        if (t > bounds.y) break;
+
+        // Sample at the center of the current voxel. 
+        vec3 pCenter = boxMin + (vec3(voxel) + 0.5) * voxelSize;
+        vec3 texCoord;
+
+        if (!shouldSkip(pCenter, texCoord)) {
+            float d;
+            if (sampleVoxel(texCoord, d)) {
+                bool isNan = (d == 1.0) || (abs(d - fillValue) < 0.005);
+
+                if (isNan) {
+                    if (nanAlpha > 0.0) {
+                        float nanA = pow(nanAlpha, 5.0);
+                        accumColor += (1.0 - alphaAcc) * nanA * nanColor;
+                        alphaAcc += nanA;
+                    }
+                } else {
+                    float sampLoc = min(d * cScale + cOffset, 0.99);
+                    vec3 col = texture(cmap, vec2(sampLoc, 0.5)).rgb;
+
+                    float alpha = pow(max(sampLoc, 0.001), transparency * opacityMag);
+                    accumColor += (1.0 - alphaAcc) * alpha * col;
+                    alphaAcc += alpha * (1.0 - alphaAcc);
+                }
+
+                if (alphaAcc >= 1.0) break;
+            }
+        }
+
+        // Advance to next voxel boundary AND update the tracked voxel index.
+        if (tMax.x < tMax.y && tMax.x < tMax.z) {
+            t = tMax.x;
+            tMax.x += tDelta.x;
+            voxel.x += stepDirI.x;
+        } else if (tMax.y < tMax.z) {
+            t = tMax.y;
+            tMax.y += tDelta.y;
+            voxel.y += stepDirI.y;
+        } else {
+            t = tMax.z;
+            tMax.z += tDelta.z;
+            voxel.z += stepDirI.z;
+        }
+
+        if (any(lessThan(voxel, ivec3(0))) || any(greaterThanEqual(voxel, ivec3(gridRes)))) break;
+    }
+
+    if (alphaAcc <= 0.0) discard;
+    color = vec4(accumColor, alphaAcc);
+}

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -11,6 +11,7 @@ import sphereBlocksVert from './sphereBlocksVert.glsl';
 import sphereBlocksFrag from './sphereBlocksFrag.glsl';
 import orthoVertex from './orthoVertex.glsl';
 import flatBlocksVert from './flatBlocksVert.glsl';
+import ddaFrag from './DDAFrag.glsl'
 export {
     pointFrag,
     pointVert,
@@ -25,4 +26,5 @@ export {
     sphereBlocksFrag,
     orthoVertex,
     flatBlocksVert,
+    ddaFrag
 }

--- a/src/components/textures/shaders/volFragment.glsl
+++ b/src/components/textures/shaders/volFragment.glsl
@@ -7,7 +7,7 @@ in vec3 vDirection;
 
 out vec4 color;
 
-uniform sampler3D map[12]; // We are limited to 16 textures. Cmap counts as one. 15 is weird so we use 14. 
+uniform sampler3D map[12]; // We are limited to 16 textures. Cmap counts as one. 15 is weird so we use 12. 
 uniform sampler2D maskTexture;
 uniform sampler2D cmap;
 uniform sampler2D remapTexture;
@@ -98,6 +98,7 @@ void main() {
 
     int zStepSize = int(textureDepths.y) * int(textureDepths.x); 
     int yStepSize = int(textureDepths.x); 
+    vec3 scaler = 1.0/scale; // Avoid division in loops
 
     for (float t = bounds.x; t < bounds.y; t += delta) {
         p = vOrigin + rayDir * t;
@@ -110,7 +111,7 @@ void main() {
         if (p.y < vertBounds.x || p.y > vertBounds.y) {
             continue;
         }
-        vec3 texCoord = p / scale + 0.5;
+        vec3 texCoord = p * scaler + 0.5;
         #ifdef REPROJECT
             vec3 remap = texture2D(remapTexture, texCoord.xy).rgb;
             texCoord.xy = remap.rg;
@@ -127,7 +128,7 @@ void main() {
             }
         }
         texCoord.z = mod(texCoord.z + animateProg, 1.0001);
-        texCoord = clamp(texCoord, vec3(0.0), 1. - vec3(epsilon)); // This prevents the the very end of the dimensions having floating point errors
+        texCoord = clamp(texCoord, vec3(0.0), 1. - vec3(epsilon)); // This prevents the very end of the dimensions having floating point errors
 
         ivec3 idx = clamp(ivec3(texCoord * textureDepths), ivec3(0), ivec3(textureDepths) - 1);
         int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;
@@ -138,7 +139,8 @@ void main() {
         bool cond = (d >= threshold.x) && (d <= threshold.y); 
 
         if (cond) {
-            if (d == 1. || abs(d - fillValue) < 0.005){
+            bool isNan = d == 1. || abs(d - fillValue) < 0.005;
+            if (isNan && nanAlpha > 0.0){
                 accumColor.rgb += (1.0 - alphaAcc) * pow(nanAlpha, 5.) * nanColor.rgb;
                 alphaAcc += pow(nanAlpha, 5.);
             }

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -9,7 +9,7 @@ import { SliderThumbs } from '@/components/ui/Widgets/SliderThumbs';
 import { LuSettings } from "react-icons/lu";
 import { RxReset } from "react-icons/rx";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
-import { Input, Switch, Hider, Button, Slider as UISlider, Switcher, Slider } from '@/components/ui';
+import { Input, Switch, Hider, Button, Slider as UISlider, Switcher, Slider, QuickTip } from '@/components/ui';
 import {
   Tooltip,
   TooltipContent,
@@ -151,34 +151,44 @@ const DimSlicer = () =>{
 }
 
 const VolumeOptions = ()=>{
-  const { useFragOpt, quality, transparency, vTransferRange, vTransferScale, setQuality, setUseFragOpt, setTransparency, setVTransferRange, setVTransferScale} = usePlotStore(useShallow(s => s))
+  const { useRayMarch, quality, transparency, vTransferRange, vTransferScale, interpPixels, setQuality, setUseRayMarch, setTransparency, setVTransferRange, setVTransferScale} = usePlotStore(useShallow(s => s))
+  useEffect(()=>{
+    if (!useRayMarch && interpPixels) setUseRayMarch(true)
+  }, [interpPixels, useRayMarch])
   return(
     <>
     <div className='grid gap-y-[5px] items-center w-50 text-center mb-8'>
-      <b>Quality</b>
-      <div className='w-full flex justify-between text-xs items-center gap-2'>
-          Worse
-          <UISlider
-              min={50}
-              max={1000}
-              step={50}
-              value={[quality]}
-              className='flex-1 mb-2'
-              onValueChange={(vals:number[]) => setQuality(vals[0])}
-          />
-          Better
-      </div>
-      <Tooltip delayDuration={500} >
-        <TooltipTrigger asChild>
-          <Button variant="pink" size="sm" className="w-[100%] cursor-[pointer] mb-2 mt-2" onClick={() => setUseFragOpt(!useFragOpt)}>
-            {useFragOpt ? "Revert to Normal" : "Use Optimized Shader"}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side='left'>
-          Enable this for better performance while navigating. Switch back for exports or still images. 
-        </TooltipContent>
-      </Tooltip>
-      
+      <b className='flex justify-center'>Renderer
+        <QuickTip message={<div className='flex flex-col'>
+          <span>Change between DDA or Raymarching render method.</span>
+          <span>DDA is more performant than Raymarching and doesn't produce artifacts.</span>
+          <span>Raymarching can interpolate and show smoother animations</span>
+        </div>}>
+          <BsFillQuestionCircleFill/>
+        </QuickTip>
+
+      </b>
+      <Hider show={useRayMarch}>
+        <b className='flex pb-1 justify-center font-mono'>Quality 
+          <QuickTip message='Increase the accuracy of Raymarching steps. Reduces performance'>
+            <BsFillQuestionCircleFill/>
+          </QuickTip>
+        </b>
+
+        <div className='w-full flex justify-between text-xs items-center gap-2'>
+            Worse
+            <UISlider
+                min={50}
+                max={1000}
+                step={50}
+                value={[quality]}
+                className='flex-1 mb-2'
+                onValueChange={(vals:number[]) => setQuality(vals[0])}
+            />
+            Better
+        </div>
+      </Hider>
+      <Switcher className={interpPixels ? 'opacity-40 !cursor-default' : undefined} leftText='DDA' rightText='Raymarch' state={!useRayMarch} onClick={()=> setUseRayMarch(!useRayMarch)}/>
       <b>Transparency</b>
       <UISlider
               min={0}
@@ -189,32 +199,24 @@ const VolumeOptions = ()=>{
           onValueChange={(vals:number[]) => setTransparency(vals[0])}
       />
       <div className='grid grid-cols-[auto_60px] items-center text-left'>
-        <h1><span>Transparency Scale </span> 
-        <Tooltip>
-          <TooltipTrigger>
-            <BsFillQuestionCircleFill/>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-60 break-words whitespace-normal">
-            {`This is the raised power for transparency. Higher values "Squash" lower values while lower values help bring them out. 1 is linear.`}  
-          </TooltipContent>
-        </Tooltip>
+        <h1 className='flex'><span>Transparency Scale </span> 
+        <QuickTip message='This is the raised power for transparency. Higher values "Squash" lower values while lower values help bring them out. 1 is linear.'>
+          <BsFillQuestionCircleFill/>
+        </QuickTip>
         </h1>
         <Input type='number' value={vTransferScale} step={0.1} min={0} onChange={e => setVTransferScale(parseFloat(e.target.value))} />
       </div>
       <div className="grid grid-cols-[auto_20%] items-center gap-2 mt-2 text-left">
         <label htmlFor="compress-data"> 
-          <h1> <span>Scale by clip </span> 
-            <Tooltip>
-              <TooltipTrigger>
-                <BsFillQuestionCircleFill/>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-60 break-words whitespace-normal">
-                Transparency is scaled from dataset minimum to maximum. Lower values are more transparent. When enabled - transparency scales based on the cropped values below. 
-              </TooltipContent>
-            </Tooltip>
+          <h1 className='flex'> <span>Scale by clip </span> 
+            <QuickTip 
+              className='max-w-80'
+              message='Transparency is scaled from dataset minimum to maximum. Lower values are more transparent. When enabled - transparency scales based on the cropped values below. '>
+              <BsFillQuestionCircleFill/>
+            </QuickTip>
           </h1> 
         </label>
-        <Switch className='h-5'  id="compress-data" checked={vTransferRange} onCheckedChange={e=>setVTransferRange(e)}/>
+        <Switch className='h-5 cursor-pointer'  id="compress-data" checked={vTransferRange} onCheckedChange={e=>setVTransferRange(e)}/>
       </div>
       
     </div>

--- a/src/components/ui/Widgets/QuickTip.tsx
+++ b/src/components/ui/Widgets/QuickTip.tsx
@@ -12,12 +12,14 @@ export const QuickTip = ({
     message,
     side = 'right',
     delay = 500,
+    className,
     ...props
 }: {
     children: React.ReactNode;
-    message: string;
+    message: string | React.ReactNode;
     side?: Side;
     delay?: number;
+    className?: string
 } & React.ComponentPropsWithoutRef<typeof TooltipTrigger>) => {
   return (
     <Tooltip 
@@ -25,7 +27,7 @@ export const QuickTip = ({
         <TooltipTrigger asChild {...props}>
             {children}
         </TooltipTrigger>
-        <TooltipContent side={side} align="start">
+        <TooltipContent className={className} side={side} align="start">
             {message}
         </TooltipContent>
     </Tooltip>

--- a/src/hooks/useDataFetcher.tsx
+++ b/src/hooks/useDataFetcher.tsx
@@ -82,6 +82,10 @@ export const useDataFetcher = () => {
 
                     setPlotOn(true);
                     setStatus(null);
+                }).then(()=>{
+                    // For larger datasets this will fire last.
+                    setShow(true)
+
                 })
             } catch (error) {
                 console.error(error);
@@ -109,7 +113,7 @@ export const useDataFetcher = () => {
                 ParseExtent(dimUnits, dimArrays);
                 if(preProject)reproject();
                 else handleIrregularGrid(dimArrays);
-                // We don't show/mount any components until all of the essential data has been set
+                // For smaller datasets this will fire last.
                 setShow(true)
             });
 

--- a/src/hooks/useDataFetcher.tsx
+++ b/src/hooks/useDataFetcher.tsx
@@ -113,7 +113,7 @@ export const useDataFetcher = () => {
                 ParseExtent(dimUnits, dimArrays);
                 if(preProject)reproject();
                 else handleIrregularGrid(dimArrays);
-                // For smaller datasets this will fire last.
+                // We don't show/mount any components until all of the essential data has been set
                 setShow(true)
             });
 


### PR DESCRIPTION
This update replaced the optimized fragment raymarcher with a DDA renderer. 
DDA is now the default with Raymarching and its settings hidden. Enabling pixel interpolation switches the Renderer to Raymarching and you cannot switch back. 

DDA has greater performance than Raymarching and doesn't produce artifacts. It doesn't provide smooth animation playback though as it is discretized. But this may be circumventable if needed 