### PR TITLE
Common Uniforms

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,6 @@
 name: Deploy main docs → gh-pages/docs
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions: write-all

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -10,6 +10,7 @@ import { useCoordBounds } from '@/hooks/useCoordBounds';
 import { UVCube } from '@/components/plots'
 import { ColumnMeshes } from './TransectMeshes';
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
+import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
 
 interface DataCubeProps {
   volTexture: THREE.Data3DTexture[] | THREE.DataTexture[] | null,
@@ -26,39 +27,28 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
     const aspectRatio = shape.y/shape.x
     const timeRatio = shape.z/shape.x;
     const {lonBounds, latBounds} = useCoordBounds()
-	const gridShape = useMemo(()=>{
-		if (remapTexture){
-			return new THREE.Vector3(remapTexture.image.width, remapTexture.image.height, dataShape[0])
-		} else return new THREE.Vector3(dataShape[2], dataShape[1], dataShape[0])
-		
-	},[remapTexture, dataShape])
+    const gridShape = useMemo(()=>{
+      if (remapTexture){
+        return new THREE.Vector3(remapTexture.image.width, remapTexture.image.height, dataShape[0])
+      } else return new THREE.Vector3(dataShape[2], dataShape[1], dataShape[0])
+      
+    },[remapTexture, dataShape])
+	const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
       glslVersion: THREE.GLSL3,
       uniforms: {
           modelViewMatrixInverse: { value: new THREE.Matrix4() }, // Used for Orthographic RayMarcher
           map: { value: volTexture},
-          maskTexture: { value: maskTexture },
-          maskValue: {value: maskValue },
           dataShape: {value: gridShape},
-          textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
-          cmap:{value: colormap},
           remapTexture: { value: remapTexture},
-          cOffset:{value: cOffset},
-          cScale: {value: cScale},
-          threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
           scale: {value: shape},
           flatBounds:{value: new THREE.Vector4(-xRange[1],-xRange[0],zRange[0] * timeRatio, zRange[1] * timeRatio)},
           vertBounds:{value: new THREE.Vector2(yRange[0]*aspectRatio,yRange[1]*aspectRatio)},
-          latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
-          lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
           steps: { value: quality },
-          animateProg: {value: animProg},
           transparency: {value: transparency},
           opacityMag: {value: vTransferScale},
           useClipScale: {value: vTransferRange},
-          nanAlpha: {value: 1-nanTransparency},
-          nanColor: {value: new THREE.Color(nanColor)},
-          fillValue: {value: fillValue?? NaN}
+		  ...uniforms
       },
       defines: {
         USE_VORIGIN: 1,
@@ -74,31 +64,21 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
     }),[useRayMarch, useOrtho, volTexture, remapTexture]);
 
     const geometry = useMemo(() => new THREE.BoxGeometry(shape.x, shape.y, shape.z), [shape]);
+	updateCommonUniforms(shaderMaterial)
     useEffect(() => {
       if (shaderMaterial) {
         const uniforms = shaderMaterial.uniforms
 		uniforms.dataShape.value = gridShape;
-        uniforms.cmap.value = colormap;
-        uniforms.cOffset.value = cOffset;
-        uniforms.cScale.value = cScale;
-        uniforms.threshold.value.set(valueRange[0], valueRange[1]);
         uniforms.scale.value = shape;
         uniforms.flatBounds.value.set(-xRange[1], -xRange[0], zRange[0] * timeRatio, zRange[1] * timeRatio);
         uniforms.vertBounds.value.set(yRange[0] * aspectRatio, yRange[1] * aspectRatio);
-        uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
-        uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
         uniforms.steps.value = quality;
-        uniforms.animateProg.value = animProg;
         uniforms.transparency.value = transparency;
-        uniforms.nanAlpha.value = 1 - nanTransparency;
-        uniforms.nanColor.value.set(nanColor);
         uniforms.opacityMag.value = vTransferScale;
         uniforms.useClipScale.value = vTransferRange;
-        uniforms.fillValue.value = fillValue?? NaN;
-        uniforms.maskValue.value = maskValue
         invalidate() // Needed because Won't trigger re-render if camera is stationary. 
       }
-    }, [shape, colormap, gridShape, cOffset, cScale, valueRange, xRange, yRange, zRange, aspectRatio, latBounds, lonBounds, quality, animProg, transparency, nanTransparency, nanColor, maskValue, fillValue, vTransferScale, vTransferRange]);
+    }, [shape, gridShape, xRange, yRange, zRange, aspectRatio, quality, transparency, vTransferScale, vTransferRange]);
     useFrame(({camera})=>{ // This calculates InverseModel matrix for the orthographic raymarcher
       if (!useOrtho || !meshRef.current || !shaderMaterial) return;
       meshRef.current.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, meshRef.current.matrixWorld);

--- a/src/components/plots/FlatBlocks.tsx
+++ b/src/components/plots/FlatBlocks.tsx
@@ -11,6 +11,7 @@ import { deg2rad } from '@/utils/HelperFuncs'
 import { useCoordBounds } from '@/hooks/useCoordBounds'
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { useAxisIndices } from '@/hooks';
+import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
 
 const FlatBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] | THREE.DataTexture[] | null}) => {
     const textures = usePaddedTextures(propTextures);
@@ -64,28 +65,17 @@ const FlatBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] 
             return geo
         },[width, height])
     const {lonBounds, latBounds} = useCoordBounds()
+    const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>{
         const shader = new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms: {
                 map: { value: textures },
                 remapTexture: { value: remapTexture },
-                maskTexture: {value: maskTexture},
-                maskValue: {value: maskValue},
-                threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
-                latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
-                lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
                 aspect: {value: width/height},
-                textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
-                cmap:{value: colormap},
-                cOffset:{value: cOffset},
-                cScale: {value: cScale},
-                animateProg: {value: animProg},
-                nanColor: {value: new THREE.Color(nanColor)},
-                nanAlpha: {value: 1 - nanTransparency},
                 displaceZero: {value: offsetNegatives ? 0 : (-valueScales.minVal/(valueScales.maxVal-valueScales.minVal)) },
                 displacement: {value: displacement},
-                fillValue: {value: fillValue?? NaN},
+                ...uniforms
             },
             defines:{
                 ...(isFlat ? { IS_FLAT: true } : {}),
@@ -99,27 +89,18 @@ const FlatBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] 
         })
         return shader
     },[width, height, isFlat, remapTexture])
-
+    updateCommonUniforms(shaderMaterial);
     useEffect(()=>{
         if (shaderMaterial){
             const uniforms = shaderMaterial.uniforms;
-            uniforms.map.value = textures;
-            uniforms.animateProg.value =  animProg
+            uniforms.map.value = textures;           
             uniforms.displaceZero.value = -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)
             uniforms.displacement.value = displacement
-            uniforms.cmap.value =  colormap
-            uniforms.cOffset.value = cOffset
-            uniforms.cScale.value = cScale
-            uniforms.threshold.value.set(valueRange[0], valueRange[1])
-            uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
-            uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
             uniforms.displaceZero.value = offsetNegatives ? 0 : (-valueScales.minVal/(valueScales.maxVal-valueScales.minVal))
             uniforms.aspect.value = width/height;
-            uniforms.maskValue.value = maskValue;
-            uniforms.fillValue.value = fillValue?? NaN;
         }
         invalidate();
-    },[animProg, valueScales, displacement, colormap, cScale, cOffset, offsetNegatives, valueRange, textures, fillValue, analysisMode, axis, width, height, latBounds, lonBounds, maskValue])
+    },[valueScales, displacement, offsetNegatives, textures, width, height])
 
   return (
 

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -17,6 +17,7 @@ import { flatFrag } from '../textures/shaders';
 import { SquareMeshes } from './TransectMeshes';
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { useAxisIndices } from '@/hooks';
+import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
 interface InfoSettersProps{
   setLoc: React.Dispatch<React.SetStateAction<number[]>>;
   setShowInfo: React.Dispatch<React.SetStateAction<boolean>>;
@@ -28,18 +29,16 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
     // ---- Imports ---- //
     const textures = usePaddedTextures(propTextures);
     const {setLoc, setShowInfo, val, coords} = infoSetters;
-    const {flipY, colormap, dimArrays, dimNames, dimUnits, 
-      isFlat, dataShape, textureArrayDepths, strides, remapTexture, shape,
+    const {flipY, dimArrays, dimNames, dimUnits, isFlat, dataShape, strides, remapTexture, shape,
       setPlotDim,updateDimCoords, updateTimeSeries} = useGlobalStore(useShallow(s => s))
 
-    const {cScale, cOffset, animProg, nanTransparency, nanColor, 
-      zSlice, ySlice, xSlice, selectTS, fillValue, coarsen, maskTexture, maskValue, valueRange,
+    const {animProg, zSlice, ySlice, xSlice, selectTS, coarsen,
       getColorIdx, incrementColorIdx} = usePlotStore(useShallow(s => s))
     const {axis, analysisMode, analysisArray} = useAnalysisStore(useShallow(s => s))
     const {kernelSize, kernelDepth} = useZarrStore(useShallow(s => s))
 
     const {xIdx, yIdx, zIdx} = useAxisIndices()
-
+    
     const dimSlices = useMemo (() => {
       let slices = isFlat
         ? [
@@ -82,7 +81,6 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
       return slices;
     }, [analysisMode, dimSlices, dimArrays, zSlice, ySlice, xSlice, axis, coarsen, kernelDepth, kernelSize, xIdx, yIdx, zIdx])
 
-    const {lonBounds, latBounds} = useCoordBounds()
     useEffect(()=>{
         geometry.dispose()
     },[geometry])
@@ -169,24 +167,13 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
       
     }
     // ----- SHADER MATERIAL ----- //
+    const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms:{
-              cScale: {value: cScale},
-              cOffset: {value: cOffset},
-              map : {value: textures},
-              remapTexture: { value: remapTexture},
-              maskTexture: {value: maskTexture},
-              maskValue: {value: maskValue},
-              threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
-              latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
-              lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
-              textureDepths: {value:  new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
-              cmap : { value : colormap},
-              animateProg: {value:animProg},
-              nanColor: {value : new THREE.Color(nanColor)},
-              nanAlpha: {value: 1 - nanTransparency},
-              fillValue: {value: fillValue?? NaN},
+              map: {value: textures},
+              remapTexture: {value: remapTexture},
+              ...uniforms
             },
             defines:{
               ...(isFlat ? { IS_FLAT: true } : {}),
@@ -195,24 +182,9 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
             vertexShader: vertShader,
             fragmentShader: flatFrag,
             side: THREE.DoubleSide,
-        }),[isFlat, remapTexture, textures])
+        }),[isFlat, textures, remapTexture])
+    updateCommonUniforms(shaderMaterial)
     
-    useEffect(()=>{
-      if(shaderMaterial){
-        const uniforms = shaderMaterial.uniforms
-        uniforms.cOffset.value = cOffset;
-        uniforms.cmap. value = colormap;
-        uniforms.animateProg.value = animProg;
-        uniforms.nanColor.value = new THREE.Color(nanColor);
-        uniforms.nanAlpha.value = 1 - nanTransparency;
-        uniforms.cScale.value = cScale;
-        uniforms.threshold.value.set(valueRange[0], valueRange[1]);
-        uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
-        uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
-        uniforms.maskValue.value = maskValue;
-        uniforms.fillValue.value = fillValue?? NaN
-      }
-    },[cScale, cOffset, colormap, animProg, nanColor, nanTransparency, latBounds, lonBounds, fillValue, maskValue, valueRange])
     useEffect(()=>{
       // This is duplicated. Probably shoud just move it to Plot.tsx
       useGlobalStore.setState({timeSeries:{}, dimCoords:{}})

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -10,6 +10,7 @@ import { UVCube } from './UVCube';
 import { ColumnMeshes } from './TransectMeshes';
 
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
+import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
 
 interface PCProps {
   texture: THREE.Data3DTexture[] | null,
@@ -80,29 +81,22 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       }
       return list;
     }, [depth, width, height]);
-
+    const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=> (new THREE.ShaderMaterial({
       glslVersion: THREE.GLSL3,
       uniforms: {
         map: { value: volTexture },
         remapTexture: { value: remapTexture },
-        textureDepths: { value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0]) },
-        maskTexture: {value: maskTexture},
-        maskValue: {value: maskValue},
         pointSize: {value: pointSize},
-        cmap: {value: colormap},
-        cOffset: {value: cOffset},
-        cScale: {value: cScale},
         valueRange: {value: new THREE.Vector2(valueRange[0], valueRange[1])},
         scalePoints:{value: scalePoints},
         scaleIntensity: {value: scaleIntensity},
         timeScale: {value: depthRatio},
-        animateProg: {value: animProg},
         aspect: {value: shape.x/shape.y},
         shape: {value: new THREE.Vector3(depth, height, width)},
         flatBounds:{value: new THREE.Vector4(xRange[0], xRange[1], zRange[0], zRange[1])},
         vertBounds:{value: new THREE.Vector2(yRange[0], yRange[1])},
-        fillValue: {value: fillValue?? NaN}
+        ...uniforms
       },
       defines: {
         GLOBAL_SCALE: globalscale*2,
@@ -116,34 +110,28 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
       blending:THREE.NoBlending,
     })
     ),[disablePointScale, remapTexture]);
-  
-   useEffect(() => {
-    if (shaderMaterial) {
-      const uniforms = shaderMaterial.uniforms;
-      uniforms.map.value = volTexture;
-      shaderMaterial.needsUpdate = true;
-      uniforms.shape.value.set(depth, height, width);
-      uniforms.pointSize.value = pointSize;
-      uniforms.cmap.value = colormap;
-      uniforms.cOffset.value = cOffset;
-      uniforms.cScale.value = cScale;
-      uniforms.valueRange.value.set(valueRange[0], valueRange[1]);
-      uniforms.scalePoints.value = scalePoints;
-      uniforms.scaleIntensity.value = scaleIntensity;
-      uniforms.timeScale.value = depthRatio;
-      uniforms.animateProg.value = animProg;
-      uniforms.flatBounds.value.set(
-        xRange[0], xRange[1], 
-        zRange[0], zRange[1]
-      );
-      uniforms.vertBounds.value.set(
-        yRange[0], yRange[1]
-      );
-      uniforms.fillValue.value = fillValue?? NaN
-      uniforms.maskValue.value = maskValue
-      uniforms.aspect.value = shape.x/shape.y;
-    }
-  }, [volTexture, depthRatio, depth, height, shape, width, pointSize, colormap, cOffset, cScale, valueRange, scalePoints, scaleIntensity, animProg, xRange, yRange, fillValue, zRange, maskValue]);
+    updateCommonUniforms(shaderMaterial);
+    useEffect(() => {
+      if (shaderMaterial) {
+        const uniforms = shaderMaterial.uniforms;
+        uniforms.map.value = volTexture;
+        shaderMaterial.needsUpdate = true;
+        uniforms.shape.value.set(depth, height, width);
+        uniforms.pointSize.value = pointSize;
+        uniforms.valueRange.value.set(valueRange[0], valueRange[1]);
+        uniforms.scalePoints.value = scalePoints;
+        uniforms.scaleIntensity.value = scaleIntensity;
+        uniforms.timeScale.value = depthRatio;
+        uniforms.flatBounds.value.set(
+          xRange[0], xRange[1], 
+          zRange[0], zRange[1]
+        );
+        uniforms.vertBounds.value.set(
+          yRange[0], yRange[1]
+        );
+        uniforms.aspect.value = shape.x/shape.y;
+      }
+  }, [volTexture, depthRatio, depth, height, shape, width, pointSize, valueRange, scalePoints, scaleIntensity, xRange, yRange, zRange]);
   
   return (
     <group>

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -11,6 +11,7 @@ import { SquareMeshes } from './TransectMeshes';
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { useAxisIndices } from '@/hooks';
 import { sphereVertex, sphereFrag } from '@/components/textures/shaders'
+import { useCommonUniforms } from '@/hooks/useCommonUniforms';
 function XYZtoRemap(xyz : THREE.Vector3, latBounds: number[], lonBounds : number[]){
     const lon = Math.atan2(xyz.z,xyz.x)
     const lat = Math.asin(xyz.y);
@@ -24,10 +25,10 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
     const {setPlotDim,updateDimCoords, updateTimeSeries} = useGlobalStore(useShallow(s => s))
     const {analysisMode, analysisArray} = useAnalysisStore(useShallow(s => s))
     const {colormap, isFlat, dimArrays, dimNames, dimUnits, valueScales, 
-          dataShape, strides, flipY, textureArrayDepths, remapTexture} = useGlobalStore(useShallow(s => s))
+          dataShape, strides, flipY, remapTexture} = useGlobalStore(useShallow(s => s))
     
     const {animate, animProg, cOffset, cScale, valueRange, selectTS, nanColor, nanTransparency, displacement, sphereResolution,
-      zSlice, ySlice, xSlice, fillValue, borderTexture, maskTexture, maskValue,
+      zSlice, ySlice, xSlice, fillValue, borderTexture, maskValue,
       getColorIdx, incrementColorIdx} = usePlotStore(useShallow(s => s))
 
     const {xIdx, yIdx, zIdx} = useAxisIndices()
@@ -44,27 +45,16 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
     const {lonBounds, latBounds} = useCoordBounds()
 
     const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, sphereResolution), [sphereResolution]);
+    const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>{
         const shader = new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms: {
                 map: { value: textures },
                 remapTexture: { value: remapTexture },
-                maskTexture: { value: maskTexture},
-                maskValue: { value: maskValue },
-                threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
-                textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
-                cmap:{value: colormap},
-                cOffset:{value: cOffset},
-                cScale: {value: cScale},
-                animateProg: {value: animProg},
-                latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
-                lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
-                nanColor: {value: new THREE.Color(nanColor)},
-                nanAlpha: {value: 1 - nanTransparency},
                 displaceZero: {value: -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)},
                 displacement: {value: displacement},
-                fillValue: {value: NaN},
+                ...uniforms
             },
             defines:{
                 ...(isFlat ? { IS_FLAT: true } : {}),
@@ -78,7 +68,8 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
             depthWrite:true,
         })
         return shader
-    },[isFlat, textures, borderTexture])
+    },[isFlat, textures])
+    // No reprojection on Sphere. Remains static and can't update
 
     const backMaterial = useMemo(()=>{
       const mat = shaderMaterial.clone()

--- a/src/components/plots/SphereBlocks.tsx
+++ b/src/components/plots/SphereBlocks.tsx
@@ -6,14 +6,12 @@ import { useShallow } from 'zustand/shallow'
 import * as THREE from 'three'
 import { sphereBlocksFrag, sphereBlocksVert } from '../textures/shaders'
 import { invalidate } from '@react-three/fiber'
-import { deg2rad } from '@/utils/HelperFuncs'
-import { useCoordBounds } from '@/hooks/useCoordBounds'
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
+import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
 const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] | THREE.DataTexture[] | null}) => {
     const textures = usePaddedTextures(propTextures);
-    const {colormap, isFlat, valueScales, 
-            dataShape, textureArrayDepths, flipY, remapTexture} = useGlobalStore(useShallow(s => s))
-    const { animProg, cOffset, cScale, nanColor, nanTransparency, displacement, offsetNegatives, fillValue, valueRange, maskTexture, maskValue} = usePlotStore(
+    const {isFlat, valueScales, dataShape, remapTexture} = useGlobalStore(useShallow(s => s))
+    const { nanColor, nanTransparency, displacement, offsetNegatives} = usePlotStore(
         useShallow(s => s))
 
     const count = useMemo(()=>{
@@ -55,29 +53,16 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
         return geo
     },[dataShape])
 
-    const {lonBounds, latBounds} = useCoordBounds()
-
+    const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>{
         const shader = new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms: {
                 map: { value: textures },
                 remapTexture: { value: remapTexture },
-                maskTexture: {value: maskTexture},
-                maskValue: {value: maskValue},
-                threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
-                textureDepths: {value: new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
-                latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
-                lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
-                cmap:{value: colormap},
-                cOffset:{value: cOffset},
-                cScale: {value: cScale},
-                animateProg: {value: animProg},
-                nanColor: {value: new THREE.Color(nanColor)},
-                nanAlpha: {value: 1 - nanTransparency},
                 displaceZero: {value: offsetNegatives ? 0 : (-valueScales.minVal/(valueScales.maxVal-valueScales.minVal))},
                 displacement: {value: displacement},
-                fillValue: {value: fillValue?? NaN},
+                ...uniforms
             },
             defines:{
                 ...(isFlat ? { IS_FLAT: true } : {}),
@@ -91,33 +76,16 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
         })
         return shader
     },[count, isFlat])
-
+    updateCommonUniforms(shaderMaterial);
     useEffect(()=>{
         if (shaderMaterial){
             const uniforms = shaderMaterial.uniforms;
             uniforms.map.value = textures;
-            uniforms.remapTexture.value = remapTexture;
-            if (remapTexture) {
-                shaderMaterial.defines.REPROJECT = true;
-            } else {
-                delete shaderMaterial.defines.REPROJECT;
-            }
-            shaderMaterial.needsUpdate = true;
-            uniforms.animateProg.value =  animProg
-            uniforms.displaceZero.value = -valueScales.minVal/(valueScales.maxVal-valueScales.minVal)
             uniforms.displacement.value = displacement
-            uniforms.cmap.value =  colormap
-            uniforms.cOffset.value = cOffset
-            uniforms.cScale.value = cScale
-            uniforms.threshold.value.set(valueRange[0], valueRange[1])
-            uniforms.latBounds.value =  new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))
-            uniforms.lonBounds.value =  new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))
             uniforms.displaceZero.value = offsetNegatives ? 0 : (-valueScales.minVal/(valueScales.maxVal-valueScales.minVal))
-            uniforms.fillValue.value = fillValue?? NaN
-            uniforms.maskValue.value = maskValue
         }
         invalidate();
-    },[animProg, valueScales, displacement, colormap, cScale, cOffset, latBounds, lonBounds, valueRange, offsetNegatives, textures, remapTexture, maskValue, fillValue])
+    },[valueScales, displacement, offsetNegatives, textures])
 
     const nanMaterial = useMemo(()=>new THREE.MeshBasicMaterial({color:nanColor}),[])
     nanMaterial.transparent = true;

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -283,26 +283,13 @@ const FlatOptions = () =>{
     setResetCamera} = usePlotStore(useShallow(s => s))
    return(
    <>
+   
    <div className='grid gap-2 mb-2'>
-    <div 
-      className='relative w-full text-center h-10 bg-primary rounded-full cursor-pointer mb-2 flex items-center justify-between px-4'
-      onClick={() => {if (!displaceFaces){setResetCamera(!usePlotStore.getState().resetCamera)}; setDisplaceFaces(!displaceFaces); usePlotStore.setState({rotateFlat: false}) }}  
-    >
-      <span className={`z-10 font-semibold transition-colors ${displaceFaces ? 'text-primary' : 'text-secondary'}`}>
-        Flat
-      </span>
-      <span className={`z-10 font-semibold transition-colors ${!displaceFaces ? 'text-primary' : 'text-secondary'}`}>
-        Displace
-      </span>
-      <div 
-        className={`absolute top-1 h-8 w-[calc(50%-8px)] bg-secondary shadow-xs hover:bg-secondary/80 rounded-full transition-all duration-300 ${
-          displaceFaces ? 'left-1' : 'left-[calc(50%+4px)]'
-        }`}
-      />
-    </div>
-    <Hider show={!displaceFaces}>
+    <Switcher leftText='Flat' rightText='Displace' state={!displaceFaces} onClick={()=>{
+      if (displaceFaces){setResetCamera(!usePlotStore.getState().resetCamera)}; setDisplaceFaces(!displaceFaces); usePlotStore.setState({rotateFlat: false}) }} 
+    />
+    <Hider show={displaceFaces}>
       <div className='grid gap-2'>
-
         <b>Displacement</b>
         <UISlider
           min={0}
@@ -352,23 +339,23 @@ const SphereOptions = () =>{
       className='w-full mb-2'
       onValueChange={(vals:number[]) => (setDisplacement(vals[0]))}
     />
-    {!displaceFaces && 
-    <div className='grid grid-cols-[auto_20%] items-center gap-2 text-left'>
-      <label htmlFor="offset-switch">Offset Negatives</label>
-      <Switch id='offset-switch' checked={offsetNegatives} onCheckedChange={e=>setOffsetNegatives(e)} />
-    </div>
-    }
-    {displaceFaces && <>
-      <b>Displacement Resolution</b>
-      <UISlider
-        min={4}
-        max={100}
-        step={4}
-        value={[sphereResolution]}
-        className='w-full mb-2'
-        onValueChange={(vals:number[]) => (setSphereResolution(vals[0]))}
-      />
-    </>}
+    <Hider show={displaceFaces}>
+        <div className='grid grid-cols-[auto_20%] items-center gap-2 text-left'>
+          <label htmlFor="offset-switch">Offset Negatives</label>
+          <Switch id='offset-switch' checked={offsetNegatives} onCheckedChange={e=>setOffsetNegatives(e)} />
+      </div>
+    </Hider>
+    <Hider show={!displaceFaces}>
+        <b>Displacement Resolution</b>
+        <UISlider
+          min={4}
+          max={100}
+          step={4}
+          value={[sphereResolution]}
+          className='w-full mb-2'
+          onValueChange={(vals:number[]) => (setSphereResolution(vals[0]))}
+        />
+    </Hider>
   </div>
   </>)
 }

--- a/src/hooks/useCommonUniforms.tsx
+++ b/src/hooks/useCommonUniforms.tsx
@@ -1,0 +1,63 @@
+// useCommonUniforms.ts
+import { useGlobalStore } from '@/GlobalStates/GlobalStore'
+import { usePlotStore } from '@/GlobalStates/PlotStore'
+import { useEffect, useMemo } from 'react'
+import * as THREE from 'three'
+import { useShallow } from 'zustand/shallow'
+import { useCoordBounds } from './useCoordBounds'
+import { deg2rad } from '@/utils/HelperFuncs'
+
+export function useCommonUniforms() {
+	const {cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,} = usePlotStore(useShallow(s=>s))
+	const {remapTexture, textureArrayDepths, colormap} = useGlobalStore(useShallow(s => s))
+	const {lonBounds, latBounds} = useCoordBounds()
+
+	const uniforms = useMemo(() => ({
+		cScale: {value: cScale},
+		cOffset: {value: cOffset},
+		maskTexture: {value: maskTexture},
+		maskValue: {value: maskValue},
+		threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
+		latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
+		lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
+		textureDepths: {value:  new THREE.Vector3(textureArrayDepths[2], textureArrayDepths[1], textureArrayDepths[0])},
+		cmap : { value : colormap},
+		animateProg: {value: animProg},
+		nanColor: {value : new THREE.Color(nanColor)},
+		nanAlpha: {value: 1 - nanTransparency},
+		fillValue: {value: fillValue?? NaN},
+	}), [
+		cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
+		remapTexture, textureArrayDepths, colormap, lonBounds, latBounds
+	])
+
+	return uniforms
+
+}
+
+export function updateCommonUniforms(material: THREE.ShaderMaterial){
+	const {cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,} = usePlotStore(useShallow(s=>s))
+	const {textureArrayDepths, colormap} = useGlobalStore(useShallow(s => s))
+	const {lonBounds, latBounds} = useCoordBounds()
+
+	useEffect(()=>{
+		if (!material) return;
+		const uniforms = material.uniforms;
+		uniforms.cOffset.value = cOffset;
+		uniforms.cmap. value = colormap;
+		uniforms.animateProg.value = animProg;
+		uniforms.nanColor.value = new THREE.Color(nanColor);
+		uniforms.nanAlpha.value = 1 - nanTransparency;
+		uniforms.cScale.value = cScale;
+		uniforms.threshold.value.set(valueRange[0], valueRange[1]);
+		uniforms.latBounds.value = new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]));
+		uniforms.lonBounds.value = new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]));
+		uniforms.maskValue.value = maskValue;
+		uniforms.fillValue.value = fillValue?? NaN
+	},[[
+		cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
+		textureArrayDepths, colormap, lonBounds, latBounds
+	]])
+	
+	return;
+}

--- a/src/hooks/useCoordBounds.tsx
+++ b/src/hooks/useCoordBounds.tsx
@@ -1,8 +1,6 @@
 import { useMemo } from "react";
 import { usePlotStore } from "@/GlobalStates/PlotStore";
 import { useShallow } from "zustand/shallow";
-
-
 import { useGlobalStore } from "@/GlobalStates/GlobalStore";
 
 export const useCoordBounds = ()=>{


### PR DESCRIPTION
This PR is to clean-up and reduce duplicate code. 
Common uniforms between plots are now stored in a hook along with an updater hook to update materials as needed. 

Disabled the docs workflow from running everytime on a push. Will explicitly run that when docs are updated.

Since changing `displaceFaces` name the UI logic was backwards for that boolean. So also fixed that