### PR TITLE
Color scaler

### DIFF
--- a/src/GlobalStates/ErrorStore.ts
+++ b/src/GlobalStates/ErrorStore.ts
@@ -2,13 +2,16 @@ import { create } from "zustand";
 
 type ErrorState = {
   error : string | null;
-
+  customError: string | null;
   setError: (error: string | null) => void;
+  setCustomError: (customError: string | null) => void;
 }
 
 export const useErrorStore = create<ErrorState>((set) =>({
   error: null,
-  setError: (error) => set({ error })
+  customError: null,
+  setError: (error) => set({ error }),
+  setCustomError: (customError) => set({ customError }),
 }))
 
 export class ZarrError extends Error {

--- a/src/GlobalStates/GlobalStore.ts
+++ b/src/GlobalStates/GlobalStore.ts
@@ -54,8 +54,9 @@ type StoreState = {
   idx4D: number | null;
   titleDescription: { title: string | null; description: string | null };
   textureArrayDepths: number[];
-  textureData: Uint8Array;
+  textureData: Uint8Array | Uint16Array;
   clampExtremes: boolean;
+  useF16Textures: boolean;
   
   // setters
   setDataShape: (dataShape: number[]) => void;
@@ -93,10 +94,11 @@ type StoreState = {
   setIdx4D: (idx4D: number | null) => void;
   setTitleDescription: (titleDescription: { title: string | null; description: string | null }) => void;
   setTextureArrayDepths: (textureArrayResolution: number[] ) => void;
-  setTextureData: (textureData: Uint8Array ) => void;
+  setTextureData: (textureData: Uint8Array | Uint16Array ) => void;
   setDPR: (DPR: number) => void;
   setScalingFactor: (scalingFactor: number | null) => void;
   setClampExtremes: (clampExtremes: boolean) => void;
+  setUseF16Textures: (useF16Textures: boolean) => void;
 };
 
 const createStore = () => create<StoreState>((set, get) => ({
@@ -139,6 +141,7 @@ const createStore = () => create<StoreState>((set, get) => ({
   DPR: 1,
   scalingFactor: null,
   clampExtremes: false,
+  useF16Textures: false,
   // setters
 
   setDataShape: (dataShape) => set({ dataShape }),
@@ -209,6 +212,7 @@ const createStore = () => create<StoreState>((set, get) => ({
   setDPR: (DPR) => set({ DPR }),
   setScalingFactor: (scalingFactor) => set({ scalingFactor }),
   setClampExtremes: (clampExtremes) => set({ clampExtremes }),
+  setUseF16Textures: (useF16Textures) => set({ useF16Textures })
 }));
 
 declare global {

--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -70,6 +70,7 @@ type PlotState ={
   destCRS: string | undefined;
   overRideCamera: boolean; // Prevent Camera from resetting until initial position is set. 
   preProject: boolean;
+  colorScale: string | undefined;
 
   setQuality: (quality: number) => void;
   setTimeScale: (timeScale : number) =>void;
@@ -198,6 +199,7 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   destCRS: undefined,
   overRideCamera: false,
   preProject : false, // reproject data on dataloader before 'show' is true;
+  colorScale: undefined,
 
   setVTransferRange: (vTransferRange) => set({ vTransferRange }),
   setVTransferScale: (vTransferScale) => set({ vTransferScale }),

--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -126,6 +126,7 @@ type PlotState ={
   setUseOrtho: (useOrtho: boolean) => void;
   setFillValue: (fillValue: number | undefined) => void;
   setCameraPosition: (cameraPosition: THREE.Vector3) => void;
+  setColorScale: (colorScale: string | undefined) => void;
   
 }
 
@@ -257,5 +258,5 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   setUseOrtho: (useOrtho) => set({ useOrtho }),
   setFillValue: (fillValue) => set({ fillValue }),
   setCameraPosition: (cameraPosition) => set({ cameraPosition }),
-
+  setColorScale: (colorScale) => set({ colorScale })
 }))

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -9,7 +9,7 @@ import { UVCube } from '@/components/plots'
 import { ColumnMeshes } from './TransectMeshes';
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
-
+import { functionInjector } from '../ui/Elements/ColorAdjuster';
 interface DataCubeProps {
   volTexture: THREE.Data3DTexture[] | THREE.DataTexture[] | null,
 }
@@ -51,9 +51,7 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
         ...(remapTexture ? { REPROJECT: true } : {})
       },
       vertexShader: useOrtho ? orthoVertex : vertexShader,
-      fragmentShader: useRayMarch 
-		? fragmentShader.replace('//LOGIC', colorScale?? '//LOGIC') 
-		: ddaFrag.replace('//LOGIC', colorScale?? '//LOGIC') ,
+      fragmentShader: useRayMarch ? functionInjector(fragmentShader, colorScale): functionInjector(ddaFrag, colorScale),
       transparent: true,
       blending: THREE.NormalBlending,
       depthWrite: false,

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -1,6 +1,6 @@
 import {  useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three'
-import { vertexShader, fragmentShader, orthoVertex , ddaFrag} from '@/components/textures/shaders';
+import { vertexShader, rayMarchFrag, orthoVertex , ddaFrag} from '@/components/textures/shaders';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow';
@@ -51,7 +51,7 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
         ...(remapTexture ? { REPROJECT: true } : {})
       },
       vertexShader: useOrtho ? orthoVertex : vertexShader,
-      fragmentShader: useRayMarch ? functionInjector(fragmentShader, colorScale): functionInjector(ddaFrag, colorScale),
+      fragmentShader: useRayMarch ? functionInjector(rayMarchFrag, colorScale): functionInjector(ddaFrag, colorScale),
       transparent: true,
       blending: THREE.NormalBlending,
       depthWrite: false,

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -17,7 +17,7 @@ interface DataCubeProps {
 export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
     const volTexture = usePaddedTextures(propVolTexture);
     const {shape, flipY, remapTexture, dataShape} = useGlobalStore(useShallow(s => s)) //We have to useShallow when returning an object instead of a state. I don't fully know the logic yet
-    const {xRange, yRange, zRange, quality, useOrtho, useRayMarch, transparency, 
+    const {xRange, yRange, zRange, quality, useOrtho, useRayMarch, transparency, colorScale,
       vTransferRange, vTransferScale} = usePlotStore(useShallow(s => s))
     const meshRef = useRef<THREE.Mesh>(null!);
     const aspectRatio = shape.y/shape.x
@@ -51,12 +51,14 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
         ...(remapTexture ? { REPROJECT: true } : {})
       },
       vertexShader: useOrtho ? orthoVertex : vertexShader,
-      fragmentShader: useRayMarch ? fragmentShader : ddaFrag,
+      fragmentShader: useRayMarch 
+		? fragmentShader.replace('//LOGIC', colorScale?? '//LOGIC') 
+		: ddaFrag.replace('//LOGIC', colorScale?? '//LOGIC') ,
       transparent: true,
       blending: THREE.NormalBlending,
       depthWrite: false,
       side: useOrtho ? THREE.FrontSide : THREE.BackSide,
-    }),[useRayMarch, useOrtho, volTexture, remapTexture]);
+    }),[useRayMarch, useOrtho, volTexture, colorScale, remapTexture]);
 
     const geometry = useMemo(() => new THREE.BoxGeometry(shape.x, shape.y, shape.z), [shape]);
 	updateCommonUniforms(shaderMaterial)

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -63,7 +63,7 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
     useEffect(() => {
       if (shaderMaterial) {
         const uniforms = shaderMaterial.uniforms
-		uniforms.dataShape.value = gridShape;
+		    uniforms.dataShape.value = gridShape;
         uniforms.scale.value = shape;
         uniforms.flatBounds.value.set(-xRange[1], -xRange[0], zRange[0] * timeRatio, zRange[1] * timeRatio);
         uniforms.vertBounds.value.set(yRange[0] * aspectRatio, yRange[1] * aspectRatio);

--- a/src/components/plots/FlatBlocks.tsx
+++ b/src/components/plots/FlatBlocks.tsx
@@ -10,11 +10,12 @@ import { invalidate } from '@react-three/fiber'
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { useAxisIndices } from '@/hooks';
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
+import { functionInjector } from '../ui/Elements/ColorAdjuster';
 
 const FlatBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] | THREE.DataTexture[] | null}) => {
     const textures = usePaddedTextures(propTextures);
     const {isFlat, valueScales, flipY, dataShape, axisDimArrays, remapTexture, remapBorders} = useGlobalStore(useShallow(s => s))
-    const { displacement, offsetNegatives, rotateFlat} = usePlotStore(useShallow(s => s))
+    const { displacement, offsetNegatives, rotateFlat, colorScale} = usePlotStore(useShallow(s => s))
     const {analysisMode, axis} = useAnalysisStore(useShallow(s => s))
     const {xIdx, yIdx} = useAxisIndices()
     const {width, height} = useMemo(()=>{
@@ -76,14 +77,14 @@ const FlatBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] 
                 ...(isFlat ? { IS_FLAT: true } : {}),
                 ...(remapTexture ? { REPROJECT: true } : {})
             },
-            vertexShader: flatBlocksVert,
+            vertexShader: functionInjector(flatBlocksVert, colorScale),
             fragmentShader: sphereBlocksFrag,
             blending: THREE.NoBlending,
             depthWrite:true,
             depthTest:true,
         })
         return shader
-    },[isFlat, remapTexture])
+    },[isFlat, remapTexture, colorScale])
 
     updateCommonUniforms(shaderMaterial);
     useEffect(()=>{

--- a/src/components/plots/FlatMap.tsx
+++ b/src/components/plots/FlatMap.tsx
@@ -17,6 +17,7 @@ import { SquareMeshes } from './TransectMeshes';
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { useAxisIndices } from '@/hooks';
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
+import { functionInjector } from '../ui/Elements/ColorAdjuster';
 interface InfoSettersProps{
   setLoc: React.Dispatch<React.SetStateAction<number[]>>;
   setShowInfo: React.Dispatch<React.SetStateAction<boolean>>;
@@ -30,7 +31,7 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
     const {setLoc, setShowInfo, val, coords} = infoSetters;
     const {flipY, dimArrays, dimNames, dimUnits, isFlat, dataShape, strides, remapTexture, remapBorders, shape,
       setPlotDim,updateDimCoords, updateTimeSeries} = useGlobalStore(useShallow(s => s))
-    const {animProg, zSlice, ySlice, xSlice, selectTS, coarsen,
+    const {animProg, zSlice, ySlice, xSlice, selectTS, coarsen, colorScale,
       getColorIdx, incrementColorIdx} = usePlotStore(useShallow(s => s))
     const {axis, analysisMode, analysisArray} = useAnalysisStore(useShallow(s => s))
     const {kernelSize, kernelDepth} = useZarrStore(useShallow(s => s))
@@ -165,7 +166,6 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
     }
     // ----- SHADER MATERIAL ----- //
     const uniforms = useCommonUniforms()
-    
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
             uniforms:{
@@ -178,9 +178,9 @@ const FlatMap = ({textures: propTextures, infoSetters} : {textures : THREE.DataT
               ...(remapTexture ? { REPROJECT: true } : {})
             },
             vertexShader: vertShader,
-            fragmentShader: flatFrag,
+            fragmentShader: functionInjector(flatFrag, colorScale),
             side: THREE.DoubleSide,
-        }),[isFlat, textures, remapTexture])
+        }),[isFlat, textures, remapTexture, colorScale])
     updateCommonUniforms(shaderMaterial)
     
     useEffect(()=>{

--- a/src/components/plots/Plot.tsx
+++ b/src/components/plots/Plot.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useRef, useState, useEffect } from 'react';
 import * as THREE from 'three';
 import { PointCloud, DataCube, FlatMap, Sphere, CountryBorders, AxisLines, SphereBlocks, FlatBlocks, KeyFramePreviewer } from '@/components/plots';
 import { Canvas, invalidate, useThree } from '@react-three/fiber';
-import { CreateTexture } from '@/components/textures';
+import { ArrayToTexture, CreateTexture } from '@/components/textures';
 import { useAnalysisStore } from '@/GlobalStates/AnalysisStore';
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
 import { usePlotStore } from '@/GlobalStates/PlotStore';
@@ -16,6 +16,7 @@ import AnalysisWG from './AnalysisWG';
 import ExportCanvas from '@/utils/ExportCanvas';
 import { useDataFetcher } from '@/hooks/useDataFetcher';
 import { reproject } from '@/components/textures/ProjectionTexture';
+import { GetCurrentArray } from '@/utils/HelperFuncs';
 
 const TransectNotice = () =>{
   const {selectTS} = usePlotStore(useShallow(s => s))
@@ -151,7 +152,7 @@ const Orbiter = ({isFlat} : {isFlat  : boolean}) =>{
 const MemoOrbit = React.memo(Orbiter)
 
 const Plot = () => {
-  const {colormap, isFlat, DPR, valueScales, setIsFlat, dataShape} = useGlobalStore(useShallow(s => s))
+  const {colormap, isFlat, DPR, valueScales, setIsFlat, setStatus, dataShape, useF16Textures} = useGlobalStore(useShallow(s => s))
   const {keyFrameEditor} = useImageExportStore(useShallow(s => s))
   const {plotType, displaceFaces, setPlotType} = usePlotStore(useShallow(s => s))
   const {analysisMode, useEditor} = useAnalysisStore(useShallow(s => s))
@@ -186,6 +187,15 @@ const Plot = () => {
       }
     }
   },[analysisMode])
+
+  useEffect(()=>{ // Switch Texture array bit-depth
+    if(!analysisMode && show){
+      const [newText, _valueScales] = ArrayToTexture({data:GetCurrentArray(), shape:dataShape},undefined,useF16Textures);
+      if (newText){
+        setTextures(newText)
+      }
+      setStatus(null)
+  }},[useF16Textures])
 
   const infoSetters = useMemo(()=>({
     setLoc,

--- a/src/components/plots/PointCloud.tsx
+++ b/src/components/plots/PointCloud.tsx
@@ -11,6 +11,7 @@ import { ColumnMeshes } from './TransectMeshes';
 
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
+import { functionInjector } from '../ui/Elements/ColorAdjuster';
 
 interface PCProps {
   texture: THREE.Data3DTexture[] | null,
@@ -36,12 +37,10 @@ const MappingCube = () =>{
 }
 
 export const PointCloud = ({textures} : {textures:PCProps} )=>{
-    const { colormap } = textures;
     const volTexture = usePaddedTextures(textures.texture);
-    const { flipY, dataShape, remapTexture, textureArrayDepths, shape } = useGlobalStore(useShallow(s => s))
-    const {scalePoints, scaleIntensity, pointSize, cScale, cOffset, valueRange, animProg, 
-      timeScale, xRange, yRange, zRange, fillValue,
-      maskTexture, maskValue, disablePointScale} = usePlotStore(useShallow(s => s))
+    const { flipY, dataShape, remapTexture, shape } = useGlobalStore(useShallow(s => s))
+    const {scalePoints, scaleIntensity, pointSize, valueRange, colorScale,
+      timeScale, xRange, yRange, zRange, disablePointScale} = usePlotStore(useShallow(s => s))
 
     //Extract data and shape from Data3DTexture
     const { width, height, depth } = useMemo(() => {
@@ -88,7 +87,6 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
         map: { value: volTexture },
         remapTexture: { value: remapTexture },
         pointSize: {value: pointSize},
-        valueRange: {value: new THREE.Vector2(valueRange[0], valueRange[1])},
         scalePoints:{value: scalePoints},
         scaleIntensity: {value: scaleIntensity},
         timeScale: {value: depthRatio},
@@ -103,13 +101,13 @@ export const PointCloud = ({textures} : {textures:PCProps} )=>{
         ...(remapTexture ? { REPROJECT: true } : {}),
         ...(disablePointScale ? { NO_SCALE: true } : {})
       },
-      vertexShader: pointVert,
+      vertexShader: functionInjector(pointVert, colorScale),
       fragmentShader:pointFrag,
       depthWrite: true,
       depthTest: true,
       blending:THREE.NoBlending,
     })
-    ),[disablePointScale, remapTexture]);
+    ),[disablePointScale, remapTexture, colorScale]);
     updateCommonUniforms(shaderMaterial);
     useEffect(() => {
       if (shaderMaterial) {

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -76,9 +76,7 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
       mat.side = THREE.BackSide;
       return mat;
     },[shaderMaterial])
-    useEffect(()=>{
-      console.log("detected")
-    },[shaderMaterial])
+
     const updateMaterial = (material: THREE.ShaderMaterial) => {
       const uniforms = material.uniforms;
       uniforms.map.value = textures;

--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -12,6 +12,7 @@ import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { useAxisIndices } from '@/hooks';
 import { sphereVertex, sphereFrag } from '@/components/textures/shaders'
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
+import { functionInjector } from '../ui/Elements/ColorAdjuster';
 function XYZtoRemap(xyz : THREE.Vector3, latBounds: number[], lonBounds : number[]){
     const lon = Math.atan2(xyz.z,xyz.x)
     const lat = Math.asin(xyz.y);
@@ -27,7 +28,7 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
     const {isFlat, dimArrays, dimNames, dimUnits, valueScales, 
           dataShape, strides, flipY, remapTexture} = useGlobalStore(useShallow(s => s))
     
-    const { selectTS, displacement, sphereResolution, zSlice, ySlice, xSlice, fillValue,
+    const { selectTS, displacement, sphereResolution, zSlice, ySlice, xSlice, fillValue, colorScale,
       getColorIdx, incrementColorIdx} = usePlotStore(useShallow(s => s))
 
     const {xIdx, yIdx, zIdx} = useAxisIndices()
@@ -59,15 +60,15 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
                 ...(isFlat ? { IS_FLAT: true } : {}),
                 ...(remapTexture ? { REPROJECT: true } : {})
             },
-            vertexShader: sphereVertex,
-            fragmentShader: sphereFrag,
+            vertexShader: functionInjector(sphereVertex, colorScale),
+            fragmentShader: functionInjector(sphereFrag, colorScale),
             blending: THREE.NormalBlending,
             side:THREE.FrontSide,
             transparent: true,
             depthWrite:true,
         })
         return shader
-    },[isFlat, textures])
+    },[isFlat, colorScale])
     // No reprojection on Sphere. Remains static and can't update
     
     const backMaterial = useMemo(()=>{
@@ -75,7 +76,9 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
       mat.side = THREE.BackSide;
       return mat;
     },[shaderMaterial])
-
+    useEffect(()=>{
+      console.log("detected")
+    },[shaderMaterial])
     const updateMaterial = (material: THREE.ShaderMaterial) => {
       const uniforms = material.uniforms;
       uniforms.map.value = textures;

--- a/src/components/plots/SphereBlocks.tsx
+++ b/src/components/plots/SphereBlocks.tsx
@@ -93,8 +93,10 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
     nanMaterial.transparent = true;
 
     const nanSphereGeometry = useMemo(()=> new THREE.IcosahedronGeometry(1, 9),[])
+
     useEffect(()=>{
         if (nanMaterial ){
+            nanMaterial.dispose();
             nanMaterial.color.set(nanColor)
             nanMaterial.opacity = (1-nanTransparency)
             invalidate();

--- a/src/components/plots/SphereBlocks.tsx
+++ b/src/components/plots/SphereBlocks.tsx
@@ -8,10 +8,11 @@ import { sphereBlocksFrag, sphereBlocksVert } from '../textures/shaders'
 import { invalidate } from '@react-three/fiber'
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
+import { functionInjector } from '../ui/Elements/ColorAdjuster';
 const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] | THREE.DataTexture[] | null}) => {
     const textures = usePaddedTextures(propTextures);
     const {isFlat, valueScales, dataShape, remapTexture} = useGlobalStore(useShallow(s => s))
-    const { nanColor, nanTransparency, displacement, offsetNegatives} = usePlotStore(
+    const { nanColor, nanTransparency, displacement, offsetNegatives, colorScale} = usePlotStore(
         useShallow(s => s))
 
     const count = useMemo(()=>{
@@ -68,7 +69,7 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
                 ...(isFlat ? { IS_FLAT: true } : {}),
                 ...(remapTexture ? { REPROJECT: true } : {})
             },
-            vertexShader: sphereBlocksVert,
+            vertexShader: functionInjector(sphereBlocksVert, colorScale),
             fragmentShader: sphereBlocksFrag,
             blending:THREE.NoBlending,
             depthWrite:true,
@@ -76,7 +77,7 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
             side: THREE.BackSide,
         })
         return shader
-    },[count, isFlat])
+    },[count, isFlat, colorScale])
     updateCommonUniforms(shaderMaterial);
     useEffect(()=>{
         if (shaderMaterial){

--- a/src/components/textures/TextureMakers.tsx
+++ b/src/components/textures/TextureMakers.tsx
@@ -8,25 +8,29 @@ interface Array {
     shape: number[];
 }
 
-function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number}): {minVal: number, maxVal: number}{
-    const { setTextureData} = useGlobalStore.getState()
+function StoreData(array: Array, valueScales?: {maxVal: number, minVal: number}, useF16=false): {minVal: number, maxVal: number}{
+    const { setTextureData } = useGlobalStore.getState()
     const data = array.data;
-    const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data )
-    const textureData = new Uint8Array(data.length)
+    const [minVal,maxVal] = valueScales ? [valueScales.minVal, valueScales.maxVal] : ArrayMinMax(data)
+    const textureData = useF16 ? new Uint16Array(data.length) : new Uint8Array(data.length)
     const range = (maxVal - minVal)
     for (let i = 0; i < data.length; i++){
       const normed = (data[i] - minVal) / range;
       if (isNaN(normed)){
-        textureData[i] = 255;
+        textureData[i] = useF16 
+			?	THREE.DataUtils.toHalfFloat(NaN)
+			:	255;
       } else {
-        textureData[i] = normed * 254;
+        textureData[i] = useF16
+			?	THREE.DataUtils.toHalfFloat(normed)
+			:	normed * 254;
       }
     };
     setTextureData(textureData)
     return {minVal, maxVal}
 }
 
-export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTexture[] | THREE.Data3DTexture[] | undefined {
+export function CreateTexture(shape: number[], data?: Uint8Array | Uint16Array, useF16=false) : THREE.DataTexture[] | THREE.Data3DTexture[] | undefined {
   const {textureArrayDepths} = useGlobalStore.getState()
   const textureData = data ? data : useGlobalStore.getState().textureData
   if (!textureData){
@@ -39,7 +43,7 @@ export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTe
         y: Math.floor(height / textureArrayDepths[1]),
         x: Math.floor(width / textureArrayDepths[2])
     };
-    const chunkData = chunkArray2D(textureData as Uint8Array, {y:height, x:width}, chunkSize)
+    const chunkData = chunkArray2D(textureData as Uint8Array, {y:height, x:width}, chunkSize, useF16)
     const chunks = []
     for (const chunk of chunkData){
         const texture = new THREE.DataTexture(
@@ -47,7 +51,7 @@ export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTe
             chunk.dims.x,
             chunk.dims.y,
             THREE.RedFormat,
-            THREE.UnsignedByteType
+            useF16 ? THREE.HalfFloatType : THREE.UnsignedByteType
         );
         texture.needsUpdate = true;
         chunks.push(texture)
@@ -60,7 +64,7 @@ export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTe
         y: Math.floor(ly / textureArrayDepths[1]),
         x: Math.floor(lx / textureArrayDepths[2])
     };
-    const chunkData = chunkArray(textureData, {z:lz, y:ly, x:lx}, chunkSize, textureArrayDepths)
+    const chunkData = chunkArray(textureData, {z:lz, y:ly, x:lx}, chunkSize, textureArrayDepths, useF16)
     const chunks = []
     for (const chunk of chunkData){   
         //@ts-ignore stop whining
@@ -68,6 +72,7 @@ export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTe
         volTexture.format = THREE.RedFormat;
         volTexture.minFilter = THREE.NearestFilter;
         volTexture.magFilter = THREE.NearestFilter;
+		volTexture.type = useF16 ? THREE.HalfFloatType : THREE.UnsignedByteType
         volTexture.needsUpdate = true;
         chunks.push(volTexture)
     }
@@ -75,19 +80,20 @@ export function CreateTexture(shape: number[], data?: Uint8Array) : THREE.DataTe
   }
 }
 
-export function ArrayToTexture(array: Array, valueScales?: {maxVal: number, minVal: number}): [ THREE.Data3DTexture[] | THREE.DataTexture[], {minVal: number, maxVal: number}]{
-    const scales = StoreData(array, valueScales);
-    const textures = CreateTexture(array.shape)
+export function ArrayToTexture(array: Array, valueScales?: {maxVal: number, minVal: number}, useF16=false): [ THREE.Data3DTexture[] | THREE.DataTexture[], {minVal: number, maxVal: number}]{
+    const scales = StoreData(array, valueScales, useF16);
+    const textures = CreateTexture(array.shape, undefined, useF16)
     return [textures as THREE.Data3DTexture[] | THREE.DataTexture[], scales];
 }
 
 function chunkArray(
-  arr: Uint8Array,
+  arr: Uint8Array | Uint16Array,
   dims: { z: number; y: number; x: number },
   chunkSize: { z: number; y: number; x: number },
-  resolution: number[]
-): { data: Uint8Array; dims: { x: number; y: number; z: number } }[] {
-  const chunks: { data: Uint8Array; dims: { x: number; y: number; z: number } }[] = [];
+  resolution: number[],
+  useF16=false
+): { data: Uint8Array | Uint16Array; dims: { x: number; y: number; z: number } }[] {
+  const chunks: { data: Uint8Array | Uint16Array; dims: { x: number; y: number; z: number } }[] = [];
  
   // Strides for navigating the source array
   const sourceStride = {
@@ -114,7 +120,7 @@ function chunkArray(
         const chunkHeight = endY - startY;
         
         // Pre-allocate the typed array for this chunk
-        const chunk = new Uint8Array(chunkDepth * chunkHeight * rowLength);
+        const chunk = useF16 ? new Uint16Array(chunkDepth * chunkHeight * rowLength) : new Uint8Array(chunkDepth * chunkHeight * rowLength);
         let chunkOffset = 0;
         
         // Extract row by row
@@ -139,10 +145,11 @@ function chunkArray(
 function chunkArray2D(
   arr: Uint8Array,
   dims: { y: number; x: number },
-  chunkSize: { y: number; x: number }
-): { data: Uint8Array; dims: { x: number; y: number } }[] {
-  const chunks: { data: Uint8Array; dims: { x: number; y: number } }[] = [];
-
+  chunkSize: { y: number; x: number },
+  useF16=false
+): { data: Uint8Array | Uint16Array; dims: { x: number; y: number } }[] {
+  
+  const chunks: { data: Uint8Array | Uint16Array; dims: { x: number; y: number } }[] = [];
   // Calculate how many chunks there will be along each axis
   const numChunksY = Math.ceil(dims.y / chunkSize.y);
   const numChunksX = Math.ceil(dims.x / chunkSize.x);
@@ -168,7 +175,7 @@ function chunkArray2D(
       }
 
       // Pre-allocate the typed array for this chunk's data
-      const chunk = new Uint8Array(chunkHeight * rowLength);
+      const chunk = useF16 ? new Uint16Array(chunkHeight * rowLength) : new Uint8Array(chunkHeight * rowLength);
       let chunkOffset = 0;
 
       // Extract data row by row for this chunk

--- a/src/components/textures/shaders/DDAFrag.glsl
+++ b/src/components/textures/shaders/DDAFrag.glsl
@@ -57,7 +57,7 @@ bool shouldSkip(vec3 p, out vec3 texCoord) {
     return false;
 }
 
-float sampleVoxel(vec3 texCoord) {
+bool sampleVoxel(vec3 texCoord, out float d, out bool isnan) {
     // This gets the sample value. If d is clipped by value-range return false
     ivec3 depths = ivec3(textureDepths);
     int yStepSize = depths.x;
@@ -66,10 +66,11 @@ float sampleVoxel(vec3 texCoord) {
     ivec3 idx = clamp(ivec3(texCoord * textureDepths), ivec3(0), depths - 1);
     int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;
     vec3 localCoord = fract(texCoord * textureDepths);
-
-    float d = sample1(localCoord, textureIdx);
+    d = sample1(localCoord, textureIdx);
     rescaler(d);
-    return d;
+    isnan = isNaNBits(d);
+    d = max(min(d * cScale + cOffset, 0.995), 0.0);
+    return d >= threshold.x && d <= threshold.y;
 }
 
 void main() {
@@ -113,40 +114,45 @@ void main() {
         vec3 pCenter = boxMin + (vec3(voxel) + 0.5) * voxelSize;
         vec3 texCoord;
         if (!shouldSkip(pCenter, texCoord)) {
-            float d = sampleVoxel(texCoord);
-            bool isNan = (useF16 ? isNaNBits(d) : (d == 1.0)) || (abs(d - fillValue) < 0.005);
-            if (isNan) {
-                float nanA = pow(nanAlpha, 5.0);
-                accumColor += (1.0 - alphaAcc) * nanA * nanColor;
-                alphaAcc += nanA;
-            } else {
-                float sampLoc = max(min(d * cScale + cOffset, 0.995), 0.0);
-                if ((sampLoc < threshold.x) || (sampLoc > threshold.y)) continue;
-
-                vec3 col = texture(cmap, vec2(sampLoc, 0.5)).rgb;
-                float alpha = pow(max(sampLoc, 0.001), transparency * opacityMag);
-                accumColor += (1.0 - alphaAcc) * 1.0 * col;
-                alphaAcc += alpha * (1.0 - alphaAcc);
-            }
-            if (alphaAcc >= 1.0){
-                if (useBorderTexture) {
-                    vec3 pHit = vOrigin + t * rayDir;
-                    vec3 localPosContinuous = (pHit - boxMin) / scale;
-                    vec2 borderUV = localPosContinuous.xy;
-                    #ifdef REPROJECT
-                        borderUV = texture(remapTexture, borderUV).rg;
-                    #endif
-                    borderUV = realCoords(borderUV);
-                    float borderDist = texture(borderTexture, borderUV).r;
-                    if (borderDist <= borderWidth) {
-                        color = vec4(borderColor, 1.0);
-                        return;
+            float d;
+            bool isnan;
+            if (sampleVoxel(texCoord, d, isnan)) {
+                bool isNan =  
+                    isnan 
+                    || (!useF16 && d == 1.0)
+                    || (abs(d - fillValue) < 0.005);
+                if (isNan) {    
+                    if (nanAlpha > 0.0){ 
+                        float nanA = pow(nanAlpha, 5.0);
+                        accumColor += (1.0 - alphaAcc) * nanA * nanColor;
+                        alphaAcc += nanA;
                     }
+                } else {
+                    vec3 col = texture(cmap, vec2(d, 0.5)).rgb;
+                    float alpha = pow(max(d, 0.001), transparency * opacityMag);
+                    accumColor += (1.0 - alphaAcc) * alpha * col;
+                    alphaAcc += alpha * (1.0 - alphaAcc);
                 }
-                break;
-            } 
+            
+                if (alphaAcc >= 1.0){
+                    if (useBorderTexture) {
+                        vec3 pHit = vOrigin + t * rayDir;
+                        vec3 localPosContinuous = (pHit - boxMin) / scale;
+                        vec2 borderUV = localPosContinuous.xy;
+                        #ifdef REPROJECT
+                            borderUV = texture(remapTexture, borderUV).rg;
+                        #endif
+                        borderUV = realCoords(borderUV);
+                        float borderDist = texture(borderTexture, borderUV).r;
+                        if (borderDist <= borderWidth) {
+                            color = vec4(borderColor, 1.0);
+                            return;
+                        }
+                    }
+                    break;
+                } 
+            }
         }
-
         // Advance to next voxel boundary AND update the tracked voxel index.
         if (tMax.x < tMax.y && tMax.x < tMax.z) {
             t = tMax.x;

--- a/src/components/textures/shaders/DDAFrag.glsl
+++ b/src/components/textures/shaders/DDAFrag.glsl
@@ -7,39 +7,14 @@ in vec3 vDirection;
 
 out vec4 color;
 
-uniform sampler3D map[12]; // We are limited to 16 textures. Cmap counts as one. 15 is weird so we use 12.
-uniform sampler2D maskTexture;
-uniform sampler2D cmap;
-uniform sampler2D remapTexture;
-uniform sampler2D borderTexture;
-uniform bool useBorderTexture;
-uniform float borderWidth;
-uniform vec3 borderColor;
-
-uniform vec3 textureDepths;
-
 uniform vec3 dataShape;
-uniform float cOffset;
-uniform float cScale;
 uniform vec3 scale;
-uniform vec2 threshold;
 uniform float steps;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
-uniform float animateProg;
 uniform float transparency;
-uniform float nanAlpha;
-uniform vec3 nanColor;
 uniform float opacityMag;
 uniform bool useClipScale;
-uniform float fillValue;
-uniform int maskValue;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform vec2 valueRange;
-
-#define EPSILON 0.000001
-#define PI 3.1415926535
 
 vec2 hitBox(vec3 orig, vec3 dir) {
     vec3 boxMin = -(scale * 0.5);
@@ -52,53 +27,6 @@ vec2 hitBox(vec3 orig, vec3 dir) {
     float t0 = max(tMin.x, max(tMin.y, tMin.z));
     float t1 = min(tMax.x, min(tMax.y, tMax.z));
     return vec2(t0, t1);
-}
-
-
-vec2 realCoords(vec2 uv) {
-    vec2 normalizedLon = lonBounds / (2.0 * PI) + 0.5;
-    vec2 normalizedLat = latBounds / PI + 0.5;
-    float lonScale = normalizedLon.y - normalizedLon.x;
-    float latScale = normalizedLat.y - normalizedLat.x;
-
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
-
-    return vec2(u, v);
-}
-
-bool isNaN(float x) {
-    return x != x;
-}
-void denorm(out float x){
-    x *= (valueRange.y - valueRange.x);
-    x += valueRange.x;
-    x = isNaN(x) ? 1.0 : x;
-}
-
-void norm(out float x){
-    x -= valueRange.x;
-    x /= (valueRange.y - valueRange.x);
-}
-
-void rescaler(inout float x){
-    //LOGIC
-}
-
-float sample1(vec3 p, int index) {
-    if (index == 0) return texture(map[0], p).r;
-    if (index == 1) return texture(map[1], p).r;
-    if (index == 2) return texture(map[2], p).r;
-    if (index == 3) return texture(map[3], p).r;
-    if (index == 4) return texture(map[4], p).r;
-    if (index == 5) return texture(map[5], p).r;
-    if (index == 6) return texture(map[6], p).r;
-    if (index == 7) return texture(map[7], p).r;
-    if (index == 8) return texture(map[8], p).r;
-    if (index == 9) return texture(map[9], p).r;
-    if (index == 10) return texture(map[10], p).r;
-    if (index == 11) return texture(map[11], p).r;
-    return 0.0;
 }
 
 bool shouldSkip(vec3 p, out vec3 texCoord) {
@@ -129,7 +57,7 @@ bool shouldSkip(vec3 p, out vec3 texCoord) {
     return false;
 }
 
-bool sampleVoxel(vec3 texCoord, out float d) {
+float sampleVoxel(vec3 texCoord) {
     // This gets the sample value. If d is clipped by value-range return false
     ivec3 depths = ivec3(textureDepths);
     int yStepSize = depths.x;
@@ -139,9 +67,9 @@ bool sampleVoxel(vec3 texCoord, out float d) {
     int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;
     vec3 localCoord = fract(texCoord * textureDepths);
 
-    d = sample1(localCoord, textureIdx);
+    float d = sample1(localCoord, textureIdx);
     rescaler(d);
-    return d >= threshold.x && d <= threshold.y;
+    return d;
 }
 
 void main() {
@@ -181,48 +109,42 @@ void main() {
 
     for (int i = 0; i < maxSteps; i++) {
         if (t > bounds.y) break;
-
         // Sample at the center of the current voxel. 
         vec3 pCenter = boxMin + (vec3(voxel) + 0.5) * voxelSize;
         vec3 texCoord;
-
         if (!shouldSkip(pCenter, texCoord)) {
-            float d;
-            if (sampleVoxel(texCoord, d)) {
-                bool isNan = (d == 1.0) || (abs(d - fillValue) < 0.005);
-                if (isNan) {
-                    if (nanAlpha > 0.0) {
-                        float nanA = pow(nanAlpha, 5.0);
-                        accumColor += (1.0 - alphaAcc) * nanA * nanColor;
-                        alphaAcc += nanA;
-                    }
-                } else {
-                    float sampLoc = min(d * cScale + cOffset, 0.99);
-                    vec3 col = texture(cmap, vec2(sampLoc, 0.5)).rgb;
+            float d = sampleVoxel(texCoord);
+            bool isNan = (useF16 ? isNaNBits(d) : (d == 1.0)) || (abs(d - fillValue) < 0.005);
+            if (isNan) {
+                float nanA = pow(nanAlpha, 5.0);
+                accumColor += (1.0 - alphaAcc) * nanA * nanColor;
+                alphaAcc += nanA;
+            } else {
+                float sampLoc = max(min(d * cScale + cOffset, 0.995), 0.0);
+                if ((sampLoc < threshold.x) || (sampLoc > threshold.y)) continue;
 
-                    float alpha = pow(max(sampLoc, 0.001), transparency * opacityMag);
-                    accumColor += (1.0 - alphaAcc) * alpha * col;
-                    alphaAcc += alpha * (1.0 - alphaAcc);
-                }
-
-                if (alphaAcc >= 1.0){
-                    if (useBorderTexture) {
-                        vec3 pHit = vOrigin + t * rayDir;
-                        vec3 localPosContinuous = (pHit - boxMin) / scale;
-                        vec2 borderUV = localPosContinuous.xy;
-                        #ifdef REPROJECT
-                            borderUV = texture(remapTexture, borderUV).rg;
-                        #endif
-                        borderUV = realCoords(borderUV);
-                        float borderDist = texture(borderTexture, borderUV).r;
-                        if (borderDist <= borderWidth) {
-                            color = vec4(borderColor, 1.0);
-                            return;
-                        }
-                    }
-                    break;
-                } 
+                vec3 col = texture(cmap, vec2(sampLoc, 0.5)).rgb;
+                float alpha = pow(max(sampLoc, 0.001), transparency * opacityMag);
+                accumColor += (1.0 - alphaAcc) * 1.0 * col;
+                alphaAcc += alpha * (1.0 - alphaAcc);
             }
+            if (alphaAcc >= 1.0){
+                if (useBorderTexture) {
+                    vec3 pHit = vOrigin + t * rayDir;
+                    vec3 localPosContinuous = (pHit - boxMin) / scale;
+                    vec2 borderUV = localPosContinuous.xy;
+                    #ifdef REPROJECT
+                        borderUV = texture(remapTexture, borderUV).rg;
+                    #endif
+                    borderUV = realCoords(borderUV);
+                    float borderDist = texture(borderTexture, borderUV).r;
+                    if (borderDist <= borderWidth) {
+                        color = vec4(borderColor, 1.0);
+                        return;
+                    }
+                }
+                break;
+            } 
         }
 
         // Advance to next voxel boundary AND update the tracked voxel index.

--- a/src/components/textures/shaders/DDAFrag.glsl
+++ b/src/components/textures/shaders/DDAFrag.glsl
@@ -36,6 +36,7 @@ uniform float fillValue;
 uniform int maskValue;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
+uniform vec2 valueRange;
 
 #define EPSILON 0.000001
 #define PI 3.1415926535
@@ -53,6 +54,7 @@ vec2 hitBox(vec3 orig, vec3 dir) {
     return vec2(t0, t1);
 }
 
+
 vec2 realCoords(vec2 uv) {
     vec2 normalizedLon = lonBounds / (2.0 * PI) + 0.5;
     vec2 normalizedLat = latBounds / PI + 0.5;
@@ -65,7 +67,21 @@ vec2 realCoords(vec2 uv) {
     return vec2(u, v);
 }
 
-void rescaler(out float x){
+bool isNaN(float x) {
+    return x != x;
+}
+void denorm(out float x){
+    x *= (valueRange.y - valueRange.x);
+    x += valueRange.x;
+    x = isNaN(x) ? 1.0 : x;
+}
+
+void norm(out float x){
+    x -= valueRange.x;
+    x /= (valueRange.y - valueRange.x);
+}
+
+void rescaler(inout float x){
     //LOGIC
 }
 
@@ -124,6 +140,7 @@ bool sampleVoxel(vec3 texCoord, out float d) {
     vec3 localCoord = fract(texCoord * textureDepths);
 
     d = sample1(localCoord, textureIdx);
+    rescaler(d);
     return d >= threshold.x && d <= threshold.y;
 }
 
@@ -173,7 +190,6 @@ void main() {
             float d;
             if (sampleVoxel(texCoord, d)) {
                 bool isNan = (d == 1.0) || (abs(d - fillValue) < 0.005);
-
                 if (isNan) {
                     if (nanAlpha > 0.0) {
                         float nanA = pow(nanAlpha, 5.0);
@@ -182,7 +198,6 @@ void main() {
                     }
                 } else {
                     float sampLoc = min(d * cScale + cOffset, 0.99);
-                    rescaler(sampLoc);
                     vec3 col = texture(cmap, vec2(sampLoc, 0.5)).rgb;
 
                     float alpha = pow(max(sampLoc, 0.001), transparency * opacityMag);

--- a/src/components/textures/shaders/DDAFrag.glsl
+++ b/src/components/textures/shaders/DDAFrag.glsl
@@ -65,6 +65,9 @@ vec2 realCoords(vec2 uv) {
     return vec2(u, v);
 }
 
+void rescaler(out float x){
+    //LOGIC
+}
 
 float sample1(vec3 p, int index) {
     if (index == 0) return texture(map[0], p).r;
@@ -179,6 +182,7 @@ void main() {
                     }
                 } else {
                     float sampLoc = min(d * cScale + cOffset, 0.99);
+                    rescaler(sampLoc);
                     vec3 col = texture(cmap, vec2(sampLoc, 0.5)).rgb;
 
                     float alpha = pow(max(sampLoc, 0.001), transparency * opacityMag);

--- a/src/components/textures/shaders/chunks/commonHelpers.glsl
+++ b/src/components/textures/shaders/chunks/commonHelpers.glsl
@@ -37,10 +37,16 @@ bool isNaN(float x) {
     return x != x;
 }
 
+bool isNaNBits(float x) {
+    uint bits = floatBitsToUint(x);
+    uint exponent = bits & 0x7F800000u;
+    uint mantissa = bits & 0x007FFFFFu;
+    return (exponent == 0x7F800000u) && (mantissa != 0u);
+}
+
 void denorm(out float x){
     x *= (valueRange.y - valueRange.x);
     x += valueRange.x;
-    x = isNaN(x) ? 1.0 : x;
 }
 
 void norm(out float x){

--- a/src/components/textures/shaders/chunks/commonHelpers.glsl
+++ b/src/components/textures/shaders/chunks/commonHelpers.glsl
@@ -1,0 +1,53 @@
+vec2 realCoords(vec2 uv){
+    vec2 normalizedLon = lonBounds/2./PI+0.5;
+    vec2 normalizedLat = latBounds/PI+0.5;
+    float lonScale = normalizedLon.y-normalizedLon.x;
+    float latScale = normalizedLat.y-normalizedLat.x;
+    
+    float u = uv.x * lonScale + normalizedLon.x;
+    float v = uv.y * latScale + normalizedLat.x;
+
+    return vec2(u, v);
+}
+
+float sample1(
+     #ifdef IS_FLAT
+        vec2 p,
+    #else
+        vec3 p,
+    #endif
+    int index
+    ) { // Shader doesn't support dynamic indexing so we gotta use switching
+    if (index == 0) return texture(map[0], p).r;
+    else if (index == 1) return texture(map[1], p).r;
+    else if (index == 2) return texture(map[2], p).r;
+    else if (index == 3) return texture(map[3], p).r;
+    else if (index == 4) return texture(map[4], p).r;
+    else if (index == 5) return texture(map[5], p).r;
+    else if (index == 6) return texture(map[6], p).r;
+    else if (index == 7) return texture(map[7], p).r;
+    else if (index == 8) return texture(map[8], p).r;
+    else if (index == 9) return texture(map[9], p).r;
+    else if (index == 10) return texture(map[10], p).r;
+    else if (index == 11) return texture(map[11], p).r;
+    else return 0.0;
+}
+
+bool isNaN(float x) {
+    return x != x;
+}
+
+void denorm(out float x){
+    x *= (valueRange.y - valueRange.x);
+    x += valueRange.x;
+    x = isNaN(x) ? 1.0 : x;
+}
+
+void norm(out float x){
+    x -= valueRange.x;
+    x /= (valueRange.y - valueRange.x);
+}
+
+void rescaler(inout float x){
+    //LOGIC
+}

--- a/src/components/textures/shaders/chunks/commonUniforms.glsl
+++ b/src/components/textures/shaders/chunks/commonUniforms.glsl
@@ -1,0 +1,29 @@
+
+#ifdef IS_FLAT
+    uniform sampler2D map[12]; // We are limited to 16 textures. Cmap counts as one. 15 is weird so we use 12. 
+#else
+    uniform sampler3D map[12];
+#endif
+uniform sampler2D maskTexture;
+uniform sampler2D cmap;
+uniform sampler2D remapTexture;
+uniform sampler2D borderTexture;
+uniform bool useBorderTexture;
+uniform float borderWidth;
+uniform vec3 borderColor;
+uniform vec3 textureDepths;
+
+uniform float cOffset;
+uniform float cScale;
+uniform vec2 threshold;
+uniform float animateProg;
+uniform float nanAlpha;
+uniform vec3 nanColor;
+uniform int maskValue;
+uniform float fillValue;
+uniform vec2 latBounds;
+uniform vec2 lonBounds;
+uniform vec2 valueRange;
+
+#define EPSILON 0.000001
+#define PI 3.1415926535

--- a/src/components/textures/shaders/chunks/commonUniforms.glsl
+++ b/src/components/textures/shaders/chunks/commonUniforms.glsl
@@ -24,6 +24,7 @@ uniform float fillValue;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
 uniform vec2 valueRange;
+uniform bool useF16;
 
 #define EPSILON 0.000001
 #define PI 3.1415926535

--- a/src/components/textures/shaders/flatBlocksVert.glsl
+++ b/src/components/textures/shaders/flatBlocksVert.glsl
@@ -2,70 +2,19 @@
 
 attribute vec2 instanceUV;
 
-#ifdef IS_FLAT
-    uniform sampler2D map[12];
-#else
-    uniform sampler3D map[12];
-#endif
-uniform sampler2D remapTexture;
-uniform sampler2D maskTexture;
-uniform bool useBorderTexture;
 uniform bool is360;
 uniform bool remapBorders;
-
-uniform vec3 textureDepths;
 
 uniform float aspect;
 uniform float displaceZero;
 uniform float displacement;
-uniform float animateProg;
-uniform float fillValue;
-uniform int maskValue;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform vec2 threshold;
 
 
-#define PI 3.1415926535
 
 vec3 givePosition(vec2 uv) {
     return vec3(uv.x*2., uv.y/aspect*2., 0.);
 }
-vec2 realCoords(vec2 uv){
-    vec2 normalizedLon = lonBounds/2./PI+0.5;
-    vec2 normalizedLat = latBounds/PI+0.5;
-    float lonScale = normalizedLon.y-normalizedLon.x;
-    float latScale = normalizedLat.y-normalizedLat.x;
-    
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
 
-    return vec2(u, v);
-}
-
-
-float sample1(
-    #ifdef IS_FLAT
-        vec2 p,
-    #else
-        vec3 p,
-    #endif
-    int index
-    ) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
-}
 
 out float vStrength;
 out vec2 vUv;
@@ -124,6 +73,7 @@ void main() {
     localCoord = fract(localCoord);
 
     float dispStrength = sample1(localCoord, textureIdx);
+    rescaler(dispStrength);
     bool valid = (dispStrength >= threshold.x) && (dispStrength <= threshold.y); 
     if (!valid || dispStrength == 1.0 || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);

--- a/src/components/textures/shaders/flatBlocksVert.glsl
+++ b/src/components/textures/shaders/flatBlocksVert.glsl
@@ -74,20 +74,30 @@ void main() {
 
     float dispStrength = sample1(localCoord, textureIdx);
     rescaler(dispStrength);
+
+    bool isnan = isNaNBits(dispStrength)
+        || (!useF16 && dispStrength == 1.0);
+    if (isnan){gl_Position = vec4(2.0, 2.0, 2.0, 1.0); return;}// Invalid value. Just hide it
+
+    dispStrength *= cScale;
+    dispStrength = max(min(dispStrength+cOffset,0.995), 0.0);
+
     bool valid = (dispStrength >= threshold.x) && (dispStrength <= threshold.y); 
-    if (!valid || dispStrength == 1.0 || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
+    if (!valid || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    } else {
-        vec2 centeredUV = (instanceUV - vec2(0.5, 0.5)); 
-        vec3 planePosition = givePosition(centeredUV);
-        float heightFactor = (dispStrength - displaceZero) * displacement;
-        vec3 scaledPosition = position;
-        scaledPosition.z += 0.005;
-        scaledPosition.z *= heightFactor;
-        vStrength = dispStrength;
-        vec3 worldPosition = planePosition + scaledPosition;
-        
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+        return;
     }
+
+    vec2 centeredUV = (instanceUV - vec2(0.5, 0.5)); 
+    vec3 planePosition = givePosition(centeredUV);
+    float heightFactor = (dispStrength - displaceZero) * displacement;
+    vec3 scaledPosition = position;
+    scaledPosition.z += 0.005;
+    scaledPosition.z *= heightFactor;
+    vStrength = dispStrength;
+    vec3 worldPosition = planePosition + scaledPosition;
+    
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+    
 
 }

--- a/src/components/textures/shaders/flatFrag.glsl
+++ b/src/components/textures/shaders/flatFrag.glsl
@@ -1,71 +1,10 @@
 //This is for Flat Textures but with 3D textures to sample from i,e; animation
 
-#ifdef IS_FLAT
-    uniform sampler2D map[12];
-#else
-    uniform sampler3D map[12];
-#endif
-uniform sampler2D maskTexture;
-uniform sampler2D cmap;
-uniform sampler2D remapTexture;
-uniform sampler2D borderTexture;
-uniform bool useBorderTexture;
-uniform float borderWidth;
-uniform vec3 borderColor;
 uniform bool is360;
 uniform bool remapBorders;
-uniform vec3 textureDepths;
-
-
-uniform float cOffset;
-uniform float cScale;
-uniform float animateProg;
-uniform float nanAlpha;
-uniform vec3 nanColor;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform vec2 threshold;
-uniform int maskValue;
-uniform float fillValue;
 
 in vec2 vUv;
 out vec4 Color;
-#define epsilon 0.0001
-#define PI 3.14159265
-
-vec2 realCoords(vec2 uv){
-    vec2 normalizedLon = lonBounds/2./PI+0.5;
-    vec2 normalizedLat = latBounds/PI+0.5;
-    float lonScale = normalizedLon.y-normalizedLon.x;
-    float latScale = normalizedLat.y-normalizedLat.x;
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
-
-    return vec2(u, v);
-}
-
-float sample1(
-     #ifdef IS_FLAT
-        vec2 p,
-    #else
-        vec3 p,
-    #endif
-    int index
-    ) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
-}
 
 void main() {
     if (maskValue != 0 || useBorderTexture){
@@ -109,7 +48,7 @@ void main() {
             texCoord.xy = remap.rg;
             if (remap.b < 0.5) discard;
         #endif
-        texCoord.xy = clamp(texCoord.xy, vec2(0.0), 1. - vec2(epsilon)); // This prevent the very edges from looping around and causing line artifacts
+        texCoord.xy = clamp(texCoord.xy, vec2(0.0), 1. - vec2(EPSILON)); // This prevent the very edges from looping around and causing line artifacts
         ivec2 idx = clamp(ivec2(texCoord * textureDepths.xy), ivec2(0), ivec2(textureDepths.xy) - 1);
         int textureIdx = idx.y * yStepSize + idx.x;
         vec2 localCoord = texCoord * (textureDepths.xy); // Scale up
@@ -120,7 +59,7 @@ void main() {
             texCoord.xy = remap.rg;
             if (remap.b < 0.5) discard;
         #endif
-        texCoord.xy = clamp(texCoord.xy, vec2(0.0), 1. - vec2(epsilon)); // This prevent the very edges from looping around and causing line artifacts
+        texCoord.xy = clamp(texCoord.xy, vec2(0.0), 1. - vec2(EPSILON)); // This prevent the very edges from looping around and causing line artifacts
         ivec3 idx = clamp(ivec3(texCoord * textureDepths), ivec3(0), ivec3(textureDepths) - 1);
         int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;
         vec3 localCoord = texCoord * (textureDepths); // Scale up
@@ -128,6 +67,7 @@ void main() {
     localCoord = fract(localCoord);
 
     float strength = sample1(localCoord, textureIdx);
+    rescaler(strength);
     bool valid = (strength >= threshold.x) && (strength <= threshold.y); 
     if (!valid || abs(strength - fillValue) < 0.005){
         Color = vec4(0.);

--- a/src/components/textures/shaders/flatFrag.glsl
+++ b/src/components/textures/shaders/flatFrag.glsl
@@ -68,13 +68,17 @@ void main() {
 
     float strength = sample1(localCoord, textureIdx);
     rescaler(strength);
+    bool isNan = useF16 ? isNaNBits(strength) : strength == 1.;
+    if (!isNan){
+        strength *= cScale;
+        strength = min(strength+cOffset,0.995);
+        Color = vec4(texture2D(cmap, vec2(strength, 0.5)).rgb, 1.);
+    } else {
+        Color = vec4(nanColor, nanAlpha);
+    }
     bool valid = (strength >= threshold.x) && (strength <= threshold.y); 
     if (!valid || abs(strength - fillValue) < 0.005){
         Color = vec4(0.);
         return;
     }
-    bool isNaN = strength == 1.;
-    float sampLoc = isNaN ? strength: (strength)*cScale;
-    sampLoc = isNaN ? strength : min(sampLoc+cOffset,0.995);
-    Color = isNaN ? vec4(nanColor, nanAlpha) : vec4(texture2D(cmap, vec2(sampLoc, 0.5)).rgb, 1.);
 }

--- a/src/components/textures/shaders/flatFrag.glsl
+++ b/src/components/textures/shaders/flatFrag.glsl
@@ -68,7 +68,7 @@ void main() {
 
     float strength = sample1(localCoord, textureIdx);
     rescaler(strength);
-    bool isNan = useF16 ? isNaNBits(strength) : strength == 1.;
+    bool isNan = isNaNBits(strength) || (!useF16 && strength == 1.);
     if (!isNan){
         strength *= cScale;
         strength = min(strength+cOffset,0.995);

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -26,6 +26,7 @@ const wrappedSphereVert = wrapShader(sphereVertex);
 const wrappedSphereFrag = wrapShader(sphereFrag);
 const wrappedPointVert = wrapShader(pointVert);
 const wrappedPointFrag = wrapShader(pointFrag);
+const wrappedDDAFrag = wrapShader(ddaFrag);
 
 export {
     wrappedPointFrag as pointFrag,
@@ -40,5 +41,5 @@ export {
     sphereBlocksFrag,
     orthoVertex,
     wrappedFlatBlocksVert as flatBlocksVert,
-    ddaFrag
+    wrappedDDAFrag as ddaFrag
 }

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -24,10 +24,12 @@ const wrappedFlatBlocksVert = wrapShader(flatBlocksVert);
 const wrappedSphereBlocksVert = wrapShader(sphereBlocksVert);
 const wrappedSphereVert = wrapShader(sphereVertex);
 const wrappedSphereFrag = wrapShader(sphereFrag);
+const wrappedPointVert = wrapShader(pointVert);
+const wrappedPointFrag = wrapShader(pointFrag);
 
 export {
-    pointFrag,
-    pointVert,
+    wrappedPointFrag as pointFrag,
+    wrappedPointVert as pointVert,
     vertexShader,
     wrappedRayMarch as rayMarchFrag,
     wrappedSphereFrag as sphereFrag,

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -20,20 +20,23 @@ const wrapShader = (shader: string) => [commonPrefix, shader].join('\n')
 
 const wrappedRayMarch = wrapShader(rayMarchFrag);
 const wrappedFlat = wrapShader(flatFrag);
-const wrappedflatBlocksVert = wrapShader(flatBlocksVert);
+const wrappedFlatBlocksVert = wrapShader(flatBlocksVert);
+const wrappedSphereBlocksVert = wrapShader(sphereBlocksVert);
+const wrappedSphereVert = wrapShader(sphereVertex);
+const wrappedSphereFrag = wrapShader(sphereFrag);
 
 export {
     pointFrag,
     pointVert,
     vertexShader,
     wrappedRayMarch as rayMarchFrag,
-    sphereFrag,
-    sphereVertex,
+    wrappedSphereFrag as sphereFrag,
+    wrappedSphereVert as sphereVertex,
     bordersFrag,
     wrappedFlat as flatFrag,
-    sphereBlocksVert,
+    wrappedSphereBlocksVert as sphereBlocksVert,
     sphereBlocksFrag,
     orthoVertex,
-    wrappedflatBlocksVert as flatBlocksVert,
+    wrappedFlatBlocksVert as flatBlocksVert,
     ddaFrag
 }

--- a/src/components/textures/shaders/index.ts
+++ b/src/components/textures/shaders/index.ts
@@ -1,7 +1,7 @@
 import pointFrag from './pointFrag.glsl';
 import pointVert from './pointVertex.glsl';
 import vertexShader from './vertex.glsl';
-import fragmentShader from './volFragment.glsl';
+import rayMarchFrag from './rayMarchFragment.glsl';
 import sphereFrag from './sphereFrag.glsl';
 import sphereVertex from './sphereVertex.glsl';
 import bordersFrag from './bordersFrag.glsl'
@@ -11,18 +11,29 @@ import sphereBlocksFrag from './sphereBlocksFrag.glsl';
 import orthoVertex from './orthoVertex.glsl';
 import flatBlocksVert from './flatBlocksVert.glsl';
 import ddaFrag from './DDAFrag.glsl'
+
+import commonUniforms from './chunks/commonUniforms.glsl'
+import commonHelpers from './chunks/commonHelpers.glsl'
+
+const commonPrefix = [commonUniforms, commonHelpers].join('\n')
+const wrapShader = (shader: string) => [commonPrefix, shader].join('\n')
+
+const wrappedRayMarch = wrapShader(rayMarchFrag);
+const wrappedFlat = wrapShader(flatFrag);
+const wrappedflatBlocksVert = wrapShader(flatBlocksVert);
+
 export {
     pointFrag,
     pointVert,
     vertexShader,
-    fragmentShader,
+    wrappedRayMarch as rayMarchFrag,
     sphereFrag,
     sphereVertex,
     bordersFrag,
-    flatFrag,
+    wrappedFlat as flatFrag,
     sphereBlocksVert,
     sphereBlocksFrag,
     orthoVertex,
-    flatBlocksVert,
+    wrappedflatBlocksVert as flatBlocksVert,
     ddaFrag
 }

--- a/src/components/textures/shaders/pointFrag.glsl
+++ b/src/components/textures/shaders/pointFrag.glsl
@@ -3,30 +3,6 @@ out vec4 Color;
 in float vValue;
 in vec2 vUv;
 
-uniform sampler2D cmap;
-uniform sampler2D borderTexture;
-uniform float cScale;
-uniform float cOffset;
-uniform bool useBorderTexture;
-uniform float borderWidth;
-uniform vec3 borderColor;
-uniform vec2 lonBounds;
-uniform vec2 latBounds;
-
-#define PI 3.1415926535
-
-vec2 realCoords(vec2 uv) {
-    vec2 normalizedLon = lonBounds / (2.0 * PI) + 0.5;
-    vec2 normalizedLat = latBounds / PI + 0.5;
-    float lonScale = normalizedLon.y - normalizedLon.x;
-    float latScale = normalizedLat.y - normalizedLat.x;
-
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
-
-    return vec2(u, v);
-}
-
 void main() {
     if (useBorderTexture){
         vec2 borderUV = realCoords(vUv);

--- a/src/components/textures/shaders/pointFrag.glsl
+++ b/src/components/textures/shaders/pointFrag.glsl
@@ -12,9 +12,7 @@ void main() {
             return;
         }
     }
-    float sampLoc = vValue == 1. ? vValue : (vValue - 0.5)*cScale + 0.5;
-    sampLoc = vValue == 1. ? vValue : min(sampLoc+cOffset,0.99);
-    vec4 color = texture(cmap, vec2(sampLoc, 0.5));
+    vec4 color = texture(cmap, vec2(vValue, 0.5));
     color.a = 1.;
     Color = color;    
 }

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -4,28 +4,15 @@ in int vertexIdx;
 out float vValue;
 out vec2 vUv;
 
-uniform sampler2D maskTexture;
-uniform sampler3D map[12];
-uniform vec3 textureDepths;
-
 uniform float pointSize;
 uniform bool scalePoints;
 uniform float scaleIntensity;
-uniform vec2 valueRange;
 uniform float timeScale;
-uniform float animateProg;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
 uniform vec3 shape;
-uniform float fillValue;
-uniform int maskValue;
 uniform float aspect;
 
-#define PI 3.1415925
-
-#ifdef REPROJECT
-    uniform sampler2D remapTexture;
-#endif
 
 vec3 computeTexCoord(int vertexID) {
     int depth = int(shape.x);
@@ -56,22 +43,6 @@ vec3 givePosition(vec3 texCoord) {
     pz = (pz - 0.5) * timeScale;
 
     return vec3(px, py, pz) * GLOBAL_SCALE;
-}
-    
-float sample1(vec3 p, int index) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
 }
 
 bool boundsCheck(vec3 loc) {
@@ -121,7 +92,7 @@ void main() {
 
     localCoord = fract(localCoord);
     vValue = sample1(localCoord, textureIdx);
-
+    rescaler(vValue);
     bool fillCheck = abs(vValue - fillValue) < 0.005;
     if (vValue < valueRange.x || vValue > valueRange.y || fillCheck){ //Hide points that are outside of value range
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);

--- a/src/components/textures/shaders/pointVertex.glsl
+++ b/src/components/textures/shaders/pointVertex.glsl
@@ -13,7 +13,6 @@ uniform vec2 vertBounds;
 uniform vec3 shape;
 uniform float aspect;
 
-
 vec3 computeTexCoord(int vertexID) {
     int depth = int(shape.x);
     int height = int(shape.y);
@@ -93,8 +92,14 @@ void main() {
     localCoord = fract(localCoord);
     vValue = sample1(localCoord, textureIdx);
     rescaler(vValue);
+    bool isnan = isNaNBits(vValue) || (!useF16 && vValue == 1.0);
+    if (isnan){gl_Position = vec4(2.0, 2.0, 2.0, 1.0);return;}
+    vValue *= cScale;
+    vValue = max(min(vValue+cOffset,0.995), 0.0);
+    
     bool fillCheck = abs(vValue - fillValue) < 0.005;
-    if (vValue < valueRange.x || vValue > valueRange.y || fillCheck){ //Hide points that are outside of value range
+    bool valid = (vValue >= threshold.x) && (vValue <= threshold.y); 
+    if (!valid || fillCheck){ //Hide points that are outside of value range
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
         return;
     }
@@ -102,7 +107,7 @@ void main() {
         float pointScale = pointSize/gl_Position.w;
         pointScale = scalePoints ? pointScale*pow(vValue,scaleIntensity) : pointScale;
         
-        if (vValue == 1. || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scaled
+        if (isnan || (pointScale*gl_Position.w < 0.75 && scalePoints)){ //Hide points that are invisible or get too small when scaled
             gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
             return;
         }

--- a/src/components/textures/shaders/rayMarchFragment.glsl
+++ b/src/components/textures/shaders/rayMarchFragment.glsl
@@ -84,7 +84,9 @@ void main() {
         localCoord = fract(localCoord);
         float d = sample1(localCoord, textureIdx);
         rescaler(d);
-        bool isnan = (useF16 ? isNaNBits(d) : d == 1.0) || abs(d - fillValue) < 0.005;
+        bool isnan = isNaNBits(d) 
+            || (!useF16 && d == 1.0) 
+            || abs(d - fillValue) < 0.005;
         if (!isnan){
             d *= cScale;
             d = max(min(d+cOffset,0.995), 0.0);

--- a/src/components/textures/shaders/rayMarchFragment.glsl
+++ b/src/components/textures/shaders/rayMarchFragment.glsl
@@ -7,37 +7,14 @@ in vec3 vDirection;
 
 out vec4 color;
 
-uniform sampler3D map[12]; // We are limited to 16 textures. Cmap counts as one. 15 is weird so we use 12. 
-uniform sampler2D maskTexture;
-uniform sampler2D cmap;
-uniform sampler2D remapTexture;
-uniform sampler2D borderTexture;
-uniform bool useBorderTexture;
-uniform float borderWidth;
-uniform vec3 borderColor;
-uniform vec3 textureDepths;
-
-uniform float cOffset;
-uniform float cScale;
 uniform vec3 scale;
-uniform vec2 threshold;
 uniform float steps;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
-uniform float animateProg;
 uniform float transparency;
-uniform float nanAlpha;
-uniform vec3 nanColor;
 uniform float opacityMag;
 uniform bool useClipScale;
-uniform float fillValue;
-uniform int maskValue;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform vec2 valueRange;
 
-#define epsilon 0.000001
-#define pi 3.1415926535
 
 vec2 hitBox(vec3 orig, vec3 dir) {
     vec3 box_min = vec3(-(scale * 0.5));
@@ -50,53 +27,6 @@ vec2 hitBox(vec3 orig, vec3 dir) {
     float t0 = max(tmin.x, max(tmin.y, tmin.z));
     float t1 = min(tmax.x, min(tmax.y, tmax.z));
     return vec2(t0, t1);
-}
-
-vec2 realCoords(vec2 uv){
-    vec2 normalizedLon = lonBounds/2./pi+0.5;
-    vec2 normalizedLat = latBounds/pi+0.5;
-    float lonScale = normalizedLon.y-normalizedLon.x;
-    float latScale = normalizedLat.y-normalizedLat.x;
-    
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
-
-    return vec2(u, v);
-}
-
-float sample1(vec3 p, int index) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
-}
-
-bool isNaN(float x) {
-    return x != x;
-}
-
-void denorm(out float x){
-    x *= (valueRange.y - valueRange.x);
-    x += valueRange.x;
-    x = isNaN(x) ? 1.0 : x;
-}
-
-void norm(out float x){
-    x -= valueRange.x;
-    x /= (valueRange.y - valueRange.x);
-}
-
-void rescaler(inout float x){
-    //LOGIC
 }
 
 void main() {
@@ -146,7 +76,7 @@ void main() {
             }
         }
         texCoord.z = mod(texCoord.z + animateProg, 1.0001);
-        texCoord = clamp(texCoord, vec3(0.0), 1. - vec3(epsilon)); // This prevents the very end of the dimensions having floating point errors
+        texCoord = clamp(texCoord, vec3(0.0), 1. - vec3(EPSILON)); // This prevents the very end of the dimensions having floating point errors
 
         ivec3 idx = clamp(ivec3(texCoord * textureDepths), ivec3(0), ivec3(textureDepths) - 1);
         int textureIdx = idx.z * zStepSize + idx.y * yStepSize + idx.x;

--- a/src/components/textures/shaders/rayMarchFragment.glsl
+++ b/src/components/textures/shaders/rayMarchFragment.glsl
@@ -84,28 +84,26 @@ void main() {
         localCoord = fract(localCoord);
         float d = sample1(localCoord, textureIdx);
         rescaler(d);
+        bool isnan = (useF16 ? isNaNBits(d) : d == 1.0) || abs(d - fillValue) < 0.005;
+        if (!isnan){
+            d *= cScale;
+            d = max(min(d+cOffset,0.995), 0.0);
+        } else {
+            accumColor.rgb += (1.0 - alphaAcc) * pow(nanAlpha, 5.) * nanColor.rgb;
+            alphaAcc += pow(nanAlpha, 5.);
+        }
         bool cond = (d >= threshold.x) && (d <= threshold.y); 
-
         if (cond) {
-            bool isNan = d == 1. || abs(d - fillValue) < 0.005;
-            if (isNan && nanAlpha > 0.0){
-                accumColor.rgb += (1.0 - alphaAcc) * pow(nanAlpha, 5.) * nanColor.rgb;
-                alphaAcc += pow(nanAlpha, 5.);
+            vec4 col = texture(cmap, vec2(d, 0.5));
+            float alpha;
+            if (useClipScale){
+                float normalizedOpacity = clamp((d - threshold.x) / (threshold.y - threshold.x), 0.0, 1.0);
+                alpha = pow(max(normalizedOpacity, 0.001), transparency*opacityMag);
+            } else {
+                alpha = pow(max(d, 0.001), transparency*opacityMag);
             }
-            else{
-                float sampLoc = d*cScale;
-                sampLoc = min(sampLoc+cOffset,0.99);
-                vec4 col = texture(cmap, vec2(sampLoc, 0.5));
-                float alpha;
-                if (useClipScale){
-                    float normalizedOpacity = clamp((sampLoc - threshold.x) / (threshold.y - threshold.x), 0.0, 1.0);
-                    alpha = pow(max(normalizedOpacity, 0.001), transparency*opacityMag);
-                } else {
-                    alpha = pow(max(sampLoc, 0.001), transparency*opacityMag);
-                }
-                accumColor.rgb += (1.0 - alphaAcc) * alpha * col.rgb;
-                alphaAcc += alpha * (1.0 - alphaAcc);
-            }      
+            accumColor.rgb += (1.0 - alphaAcc) * alpha * col.rgb;
+            alphaAcc += alpha * (1.0 - alphaAcc);
             if (alphaAcc >= 1.0){
                 if (useBorderTexture){
                     float borderDist = texture(borderTexture, texCoord.xy).r;

--- a/src/components/textures/shaders/sphereBlocksFrag.glsl
+++ b/src/components/textures/shaders/sphereBlocksFrag.glsl
@@ -14,10 +14,6 @@ out vec4 Color;
 
 void main() {
     float strength = vStrength;
-
-    strength *= cScale;
-    strength = min(strength+cOffset,0.996);
-
     vec3 sampColor = texture(cmap, vec2(strength, 0.5)).rgb;
 
     if (useBorderTexture){

--- a/src/components/textures/shaders/sphereBlocksVert.glsl
+++ b/src/components/textures/shaders/sphereBlocksVert.glsl
@@ -70,8 +70,14 @@ void main() {
     localCoord = fract(localCoord);
     float dispStrength = sample1(localCoord, textureIdx);
     rescaler(dispStrength);
+    bool isnan = useF16 ? isNaNBits(dispStrength) : dispStrength == 1.0;
+    if (isnan){gl_Position = vec4(2.0, 2.0, 2.0, 1.0); }// Invalid value. Just hide it
+    else {
+        dispStrength *= cScale;
+        dispStrength = max(min(dispStrength+cOffset,0.995), 0.0);
+    }
     bool valid = (dispStrength >= threshold.x) && (dispStrength <= threshold.y); 
-    if (!valid || dispStrength == 1.0 || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
+    if (!valid || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
     } else {
         vec2 lonlat = giveLonLat(instanceUV);

--- a/src/components/textures/shaders/sphereBlocksVert.glsl
+++ b/src/components/textures/shaders/sphereBlocksVert.glsl
@@ -2,27 +2,11 @@
 
 attribute vec2 instanceUV;
 
-#ifdef IS_FLAT
-    uniform sampler2D map[12];
-#else
-    uniform sampler3D map[12];
-#endif
-uniform sampler2D maskTexture;
-uniform vec3 textureDepths;
-uniform sampler2D remapTexture;
-uniform bool useBorderTexture;
 uniform bool is360;
 
 uniform float displaceZero;
 uniform float displacement;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform vec2 threshold;
-uniform float animateProg;
-uniform float fillValue;
-uniform int maskValue;
 
-#define PI 3.1415926535
 
 vec2 giveLonLat(vec2 uv) {
     // Reverse the normalization using the bounds
@@ -42,41 +26,6 @@ vec3 givePosition(vec2 lonlat) {
     float z = cos(latitude) * sin(longitude);
     
     return vec3(x, y, z);
-}
-
-vec2 realCoords(vec2 uv){
-    vec2 normalizedLon = lonBounds/2./PI+0.5;
-    vec2 normalizedLat = latBounds/PI+0.5;
-    float lonScale = normalizedLon.y-normalizedLon.x;
-    float latScale = normalizedLat.y-normalizedLat.x;
-    
-    float u = uv.x * lonScale + normalizedLon.x;
-    float v = uv.y * latScale + normalizedLat.x;
-
-    return vec2(u, v);
-}
-
-float sample1(
-     #ifdef IS_FLAT
-        vec2 p,
-    #else
-        vec3 p,
-    #endif
-    int index
-    ) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
 }
 
 out float vStrength;
@@ -120,6 +69,7 @@ void main() {
     #endif
     localCoord = fract(localCoord);
     float dispStrength = sample1(localCoord, textureIdx);
+    rescaler(dispStrength);
     bool valid = (dispStrength >= threshold.x) && (dispStrength <= threshold.y); 
     if (!valid || dispStrength == 1.0 || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);

--- a/src/components/textures/shaders/sphereBlocksVert.glsl
+++ b/src/components/textures/shaders/sphereBlocksVert.glsl
@@ -70,40 +70,43 @@ void main() {
     localCoord = fract(localCoord);
     float dispStrength = sample1(localCoord, textureIdx);
     rescaler(dispStrength);
-    bool isnan = useF16 ? isNaNBits(dispStrength) : dispStrength == 1.0;
-    if (isnan){gl_Position = vec4(2.0, 2.0, 2.0, 1.0); }// Invalid value. Just hide it
-    else {
-        dispStrength *= cScale;
-        dispStrength = max(min(dispStrength+cOffset,0.995), 0.0);
-    }
+    bool isnan = isNaNBits(dispStrength)
+        || (!useF16 && dispStrength == 1.0);
+    if (isnan){gl_Position = vec4(2.0, 2.0, 2.0, 1.0); return;}// Invalid value. Just hide it
+
+    dispStrength *= cScale;
+    dispStrength = max(min(dispStrength+cOffset,0.995), 0.0);
+
     bool valid = (dispStrength >= threshold.x) && (dispStrength <= threshold.y); 
     if (!valid || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
         gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
-    } else {
-        vec2 lonlat = giveLonLat(instanceUV);
-        float latitudeFactor = cos(lonlat.y); // Maps -1..1 to proper latitude
-        vec2 centeredUV = (instanceUV - vec2(0.5, 0.5)) * vec2(2.0, 2.0); 
-        vec3 spherePosition = givePosition(lonlat);
-        float widthFactor = abs(lonBounds.y-lonBounds.x)/(2.0*PI);
-        float vertFactor = (latBounds.y-latBounds.x)/PI;
-        float heightFactor = (dispStrength - displaceZero) * displacement;
-        vec3 scaledPosition = position;
-        scaledPosition.x *= latitudeFactor * widthFactor;
-        scaledPosition.z *= vertFactor ;
-        scaledPosition.y += 0.025;
-        scaledPosition.y *= heightFactor;
-        vec3 normal = normalize(spherePosition);
-        // Create orientation matrix to point cube outward
-        vec3 up = vec3(0.0, 1.0, 0.0);
-        vec3 tangent = normalize(cross(up, normal));
-        vec3 bitangent = cross(normal, tangent);
-        mat3 orientation = mat3(tangent, normal, bitangent);
+        return;
+    } 
+    
+    vec2 lonlat = giveLonLat(instanceUV);
+    float latitudeFactor = cos(lonlat.y); // Maps -1..1 to proper latitude
+    vec2 centeredUV = (instanceUV - vec2(0.5, 0.5)) * vec2(2.0, 2.0); 
+    vec3 spherePosition = givePosition(lonlat);
+    float widthFactor = abs(lonBounds.y-lonBounds.x)/(2.0*PI);
+    float vertFactor = (latBounds.y-latBounds.x)/PI;
+    float heightFactor = (dispStrength - displaceZero) * displacement;
+    vec3 scaledPosition = position;
+    scaledPosition.x *= latitudeFactor * widthFactor;
+    scaledPosition.z *= vertFactor ;
+    scaledPosition.y += 0.025;
+    scaledPosition.y *= heightFactor;
+    vec3 normal = normalize(spherePosition);
+    // Create orientation matrix to point cube outward
+    vec3 up = vec3(0.0, 1.0, 0.0);
+    vec3 tangent = normalize(cross(up, normal));
+    vec3 bitangent = cross(normal, tangent);
+    mat3 orientation = mat3(tangent, normal, bitangent);
 
-        // Apply orientation and position
-        vec3 oriented = orientation * scaledPosition;
-        vec3 worldPosition = spherePosition + oriented;
-        vStrength = dispStrength;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+    // Apply orientation and position
+    vec3 oriented = orientation * scaledPosition;
+    vec3 worldPosition = spherePosition + oriented;
+    vStrength = dispStrength;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
 
-    }
+    
 }

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -3,35 +3,7 @@ out vec4 color;
 
 in vec3 aPosition;
 
-#ifdef IS_FLAT
-    uniform sampler2D map[12];
-#else
-    uniform sampler3D map[12];
-#endif
-
-uniform sampler2D maskTexture;
-uniform sampler2D cmap;
-uniform vec3 textureDepths;
-uniform sampler2D remapTexture;
-uniform sampler2D borderTexture;
-uniform bool useBorderTexture;
-uniform float borderWidth;
-uniform vec3 borderColor;
 uniform bool is360;
-
-uniform float cOffset;
-uniform float cScale;
-uniform float animateProg;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform vec2 threshold;
-uniform vec3 nanColor;
-uniform float nanAlpha;
-uniform float fillValue;
-uniform int maskValue;
-
-#define pi 3.141592653
-#define epsilon 0.0001
 
 vec2 giveUV(vec3 position){
     vec3 n = normalize(position);
@@ -47,34 +19,11 @@ vec2 giveMaskUV(vec3 position){
     vec3 n = normalize(position);
     float latitude = asin(n.y);
     float longitude = -atan(n.z, n.x);
-    latitude /= pi;
-    longitude /= (2. * pi);
+    latitude /= PI;
+    longitude /= (2. * PI);
     float u = longitude + 0.5;
     float v = latitude + 0.5;
     return vec2(u, v);
-}
-
-float sample1( 
-    #ifdef IS_FLAT
-        vec2 p,
-    #else
-        vec3 p,
-    #endif
-    int index
-    ) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
 }
 
 void main(){
@@ -121,6 +70,7 @@ void main(){
         #endif
         localCoord = fract(localCoord);
         float strength = sample1(localCoord, textureIdx);
+        rescaler(strength);
         bool valid = (strength >= threshold.x) && (strength <= threshold.y); 
         if (!valid){
             color = vec4(0.);

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -1,6 +1,5 @@
  // by Jeran Poehls
 out vec4 color;
-
 in vec3 aPosition;
 
 uniform bool is360;
@@ -71,21 +70,22 @@ void main(){
         localCoord = fract(localCoord);
         float strength = sample1(localCoord, textureIdx);
         rescaler(strength);
+        bool isnan = (useF16 ? isNaNBits(strength) : ( strength == 1.0)) 
+            || abs(strength - fillValue) < 0.005;
+        if (!isnan){
+            strength *= cScale;
+            strength = max(min(strength+cOffset,0.995), 0.0); // clamp color to [0, 1]
+            color = texture(cmap, vec2(strength, 0.5));
+            color.a = 1.;
+        } else {
+            color = vec4(nanColor, nanAlpha);
+        }
         bool valid = (strength >= threshold.x) && (strength <= threshold.y); 
         if (!valid){
             color = vec4(0.);
             return;
         }
-        bool isNaN = strength == 1. || abs(strength - fillValue) < 0.005;
-        strength = isNaN ? strength : (strength)*cScale;
-        strength = isNaN ? strength : min(strength+cOffset,0.99);
-        color = isNaN ? vec4(nanColor, nanAlpha) : texture(cmap, vec2(strength, 0.5));
-        if (!isNaN){
-            color.a = 1.;
-        }
-    } else {
-        color = vec4(nanColor, 1.);
-        color.a = nanAlpha;
-    }
-    // color = vec4( texCoord.x, 0. , 0., 1.);
+        return;
+    } 
+    color = vec4(nanColor, nanAlpha);
 }

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -70,7 +70,7 @@ void main(){
         localCoord = fract(localCoord);
         float strength = sample1(localCoord, textureIdx);
         rescaler(strength);
-        bool isnan = (useF16 ? isNaNBits(strength) : ( strength == 1.0)) 
+        bool isnan = isNaNBits(strength) || (!useF16 && ( strength == 1.0))
             || abs(strength - fillValue) < 0.005;
         if (!isnan){
             strength *= cScale;

--- a/src/components/textures/shaders/sphereVertex.glsl
+++ b/src/components/textures/shaders/sphereVertex.glsl
@@ -42,11 +42,17 @@ void main() {
         #endif
         float dispStrength = sample1(localCoord, textureIdx);
         rescaler(dispStrength);
-        float noNan = float(dispStrength != 1.0);
-        vec3 newPos = position + (normal * (dispStrength-displaceZero) * noNan * displacement);
-        //Pass out position for sphere frag
-        vec4 worldPos = modelViewMatrix * vec4( newPos, 1.0 );
-        gl_Position = projectionMatrix * worldPos;
+        bool isnan = useF16 ? isNaNBits(dispStrength) : dispStrength == 1.0;
+        if (!isnan){
+            vec3 newPos = position + (normal * (dispStrength - displaceZero) * displacement); // <---- Here, using dispStrength doesn't work for float16
+            //Pass out position for sphere frag
+            vec4 worldPos = modelViewMatrix * vec4( newPos, 1.0 );
+            gl_Position = projectionMatrix * worldPos;
+        } else{
+            vec4 worldPos = modelViewMatrix * vec4( position, 1.0 );
+            gl_Position = projectionMatrix * worldPos;
+        }
+        
     } else {
         vec4 worldPos = modelViewMatrix * vec4( position, 1.0 );
         gl_Position = projectionMatrix * worldPos;

--- a/src/components/textures/shaders/sphereVertex.glsl
+++ b/src/components/textures/shaders/sphereVertex.glsl
@@ -42,7 +42,7 @@ void main() {
         #endif
         float dispStrength = sample1(localCoord, textureIdx);
         rescaler(dispStrength);
-        bool isnan = useF16 ? isNaNBits(dispStrength) : dispStrength == 1.0;
+        bool isnan = isNaNBits(dispStrength) || (!useF16 && dispStrength == 1.);
         if (!isnan){
             vec3 newPos = position + (normal * (dispStrength - displaceZero) * displacement); // <---- Here, using dispStrength doesn't work for float16
             //Pass out position for sphere frag

--- a/src/components/textures/shaders/sphereVertex.glsl
+++ b/src/components/textures/shaders/sphereVertex.glsl
@@ -1,20 +1,7 @@
  // by Jeran Poehls
 
-#ifdef IS_FLAT
-    uniform sampler2D map[12];
-#else
-    uniform sampler3D map[12];
-#endif
-
-uniform vec3 textureDepths;
-
 uniform float displaceZero;
 uniform float displacement;
-uniform vec2 latBounds;
-uniform vec2 lonBounds;
-uniform float animateProg;
-
-uniform sampler2D remapTexture;
 uniform bool is360;
 
 vec2 giveUV(vec3 position){
@@ -25,29 +12,6 @@ vec2 giveUV(vec3 position){
     longitude = (longitude - lonBounds.x)/(lonBounds.y - lonBounds.x);
 
     return vec2(longitude, latitude);
-}
-
-float sample1(
-    #ifdef IS_FLAT
-        vec2 p,
-    #else
-        vec3 p,
-    #endif
-    int index
-    ) { // Shader doesn't support dynamic indexing so we gotta use switching
-    if (index == 0) return texture(map[0], p).r;
-    else if (index == 1) return texture(map[1], p).r;
-    else if (index == 2) return texture(map[2], p).r;
-    else if (index == 3) return texture(map[3], p).r;
-    else if (index == 4) return texture(map[4], p).r;
-    else if (index == 5) return texture(map[5], p).r;
-    else if (index == 6) return texture(map[6], p).r;
-    else if (index == 7) return texture(map[7], p).r;
-    else if (index == 8) return texture(map[8], p).r;
-    else if (index == 9) return texture(map[9], p).r;
-    else if (index == 10) return texture(map[10], p).r;
-    else if (index == 11) return texture(map[11], p).r;
-    else return 0.0;
 }
 
 out vec3 aPosition;
@@ -77,6 +41,7 @@ void main() {
             vec3 localCoord = texCoord * (textureDepths); // Scale up
         #endif
         float dispStrength = sample1(localCoord, textureIdx);
+        rescaler(dispStrength);
         float noNan = float(dispStrength != 1.0);
         vec3 newPos = position + (normal * (dispStrength-displaceZero) * noNan * displacement);
         //Pass out position for sphere frag

--- a/src/components/textures/shaders/volFragment.glsl
+++ b/src/components/textures/shaders/volFragment.glsl
@@ -34,6 +34,7 @@ uniform float fillValue;
 uniform int maskValue;
 uniform vec2 latBounds;
 uniform vec2 lonBounds;
+uniform vec2 valueRange;
 
 #define epsilon 0.000001
 #define pi 3.1415926535
@@ -63,8 +64,6 @@ vec2 realCoords(vec2 uv){
     return vec2(u, v);
 }
 
-
-
 float sample1(vec3 p, int index) { // Shader doesn't support dynamic indexing so we gotta use switching
     if (index == 0) return texture(map[0], p).r;
     else if (index == 1) return texture(map[1], p).r;
@@ -81,8 +80,24 @@ float sample1(vec3 p, int index) { // Shader doesn't support dynamic indexing so
     else return 0.0;
 }
 
+bool isNaN(float x) {
+    return x != x;
+}
 
+void denorm(out float x){
+    x *= (valueRange.y - valueRange.x);
+    x += valueRange.x;
+    x = isNaN(x) ? 1.0 : x;
+}
 
+void norm(out float x){
+    x -= valueRange.x;
+    x /= (valueRange.y - valueRange.x);
+}
+
+void rescaler(inout float x){
+    //LOGIC
+}
 
 void main() {
     vec3 rayDir = normalize(vDirection);
@@ -138,7 +153,7 @@ void main() {
         vec3 localCoord = texCoord * (textureDepths);  
         localCoord = fract(localCoord);
         float d = sample1(localCoord, textureIdx);
-
+        rescaler(d);
         bool cond = (d >= threshold.x) && (d <= threshold.y); 
 
         if (cond) {

--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -267,9 +267,10 @@ const Colorbar = ({units, metadata, valueScales} : {units: string, metadata: Rec
                 <LuSettings 
                     style={{
                         position:'absolute',
-                        left: '0%',
-                        bottom:'100%',
-                        cursor:'pointer'
+                        right: '101%',
+                        bottom:'50%',
+                        cursor:'pointer',
+                        transform:'translatey(50%)'
                     }}
                     size={20}
                 />

--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -11,7 +11,9 @@ import { useShallow } from 'zustand/shallow'
 import './css/Colorbar.css'
 import { linspace } from '@/utils/HelperFuncs';
 import Metadata from "./MetaData";
-
+import { LuSettings } from "react-icons/lu";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
+import ColorAdjuster from "./Elements/ColorAdjuster";
 const operationMap = {
     // Reductions
     Mean: "Mean",
@@ -260,6 +262,23 @@ const Colorbar = ({units, metadata, valueScales} : {units: string, metadata: Rec
             <FaMinus className='cursor-pointer' onClick={()=>setTickCount(Math.max(tickCount-1, 2))}/>
             <FaPlus className='cursor-pointer' onClick={()=>setTickCount(Math.min(tickCount+1, 10))}/>
         </div>
+        <Popover>
+            <PopoverTrigger asChild>
+                <LuSettings 
+                    style={{
+                        position:'absolute',
+                        left: '0%',
+                        bottom:'100%',
+                        cursor:'pointer'
+                    }}
+                    size={20}
+                />
+            </PopoverTrigger>
+            <PopoverContent>
+                <ColorAdjuster />
+            </PopoverContent>
+        </Popover>
+            
         </div>
         </>
         

--- a/src/components/ui/Colorbar.tsx
+++ b/src/components/ui/Colorbar.tsx
@@ -52,7 +52,7 @@ function Num2String(value: number){
 
 const Colorbar = ({units, metadata, valueScales} : {units: string, metadata: Record<string, any>, valueScales: {maxVal: number, minVal:number}}) => {
     const {colormap, variable, scalingFactor} = useGlobalStore(useShallow(s => s));
-    const {cScale, cOffset, setCScale, setCOffset} = usePlotStore(useShallow(s => s));
+    const {cScale, cOffset,colorScale, setColorScale, setCScale, setCOffset} = usePlotStore(useShallow(s => s));
     const {variable2, analysisMode, operation, kernelOperation, execute} = useAnalysisStore(useShallow(s => s));
 
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -241,12 +241,14 @@ const Colorbar = ({units, metadata, valueScales} : {units: string, metadata: Rec
                 {<Metadata data={metadata} variable={variable} isMobile={true} />}
                 {`${analysisString}`}
             </p>
-        {(cScale != 1 || cOffset != 0) && <RxReset size={25} style={{position:'absolute', top:'-25px', cursor:'pointer'}} 
+        {/* RESET */}
+        {(cScale != 1 || cOffset != 0 || colorScale) && <RxReset size={25} style={{position:'absolute', top:'-25px', cursor:'pointer'}} 
             onClick={()=>{
                 setNewMin(origMin); 
                 setNewMax(origMax); 
                 setDisplayMax(Num2String(origMax*Math.pow(10, scalingFactor??0))); 
-                setDisplayMin(Num2String(origMin*Math.pow(10, scalingFactor??0)))
+                setDisplayMin(Num2String(origMin*Math.pow(10, scalingFactor??0)));
+                setColorScale(undefined)
             }}
         />}
         <div

--- a/src/components/ui/Elements/ColorAdjuster.tsx
+++ b/src/components/ui/Elements/ColorAdjuster.tsx
@@ -6,10 +6,12 @@ import { useErrorStore } from '@/GlobalStates/ErrorStore'
 import { useShallow } from 'zustand/shallow'
 import { usePlotStore } from '@/GlobalStates/PlotStore'
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
+import { useGlobalStore } from '@/GlobalStates/GlobalStore'
 const ColorAdjuster = () => {
     const customShader = useRef('');
 	const {setError, setCustomError} = useErrorStore(useShallow(s => s))
 	const {colorScale} = usePlotStore(useShallow( s=>s))
+	const {useF16Textures, setUseF16Textures, setStatus} = useGlobalStore(useShallow(s => s))
 	const handleShader = () =>{
 		const shader = customShader.current
 		const {ok, log} = glslValidator(shader)
@@ -17,7 +19,7 @@ const ColorAdjuster = () => {
 			setError('glsl')
 			if (!log) return;
 			const thirdIdx = log.indexOf(":", log.indexOf(":", log.indexOf(":") + 1) + 1) // The error starts with the code location in the boilerplate. This starts after that 
-			setCustomError(log.slice(thirdIdx+1))
+			setCustomError(log.slice(thirdIdx+1, log.length-2))
 			return
 		} 
 		if (shader.length == 0){
@@ -29,18 +31,19 @@ const ColorAdjuster = () => {
 	}
 
 	return (
-		<div>
+		<div className='grid gap-2'>
 			{colorScale 
 			? <p>Current operation: {colorScale}</p>
 			: <p>Apply an operation to the current plot</p>
 			}
 			<QuickTip message={<div>Write operations in GLSL<br/> example: <b>x / 2.0</b></div>}>
-				<Input type='string' placeholder='apply operations to "x"'
+				<Input type='string' placeholder='e.g; abs(x)'
 					onChange={e=>customShader.current = e.target.value}
 				/>
 			</QuickTip>
-			<div className='flex pt-2'>
+			<div className='flex pt-2 '>
 				<Button
+				className='flex-grow'
 					variant='pink'
 					onClick={handleShader}
 				>
@@ -49,17 +52,18 @@ const ColorAdjuster = () => {
 				<Popover>
 					<PopoverTrigger asChild>
 						<Button variant='secondary'>
-							Functions List
+							<b>?</b>
 						</Button>
 					</PopoverTrigger>
 					<PopoverContent>
 						<p>Along with general arithmetic operations. The following globals can also be used:</p>
-						<ul className='columns-2 !list-none bg-gray-100 rounded-lg border-solid border-2'>
+						<ul className='grid grid-cols-2 !list-none bg-gray-100 rounded-lg border-solid border-2'>
 							{[
-								'abs(x)', 'min(x, y)', 'max(x, y)', 'sqrt(x)',
-								'floor(x)', 'ceil(x)', 'pow(x, y)', 'exp(x)','mod(x, y)',
-								'round(x)', 'mix(x, y, a)', 'exp2(x)',
-								'log(x)', 'log2(x)', 'fract(x)', 'inverseqrt(x)',
+								'abs(x)', 'sqrt(x)', 'min(x, y)', 'max(x, y)', 
+								'log(x)', 'log2(x)',  'exp(x)', 'exp2(x)', 
+								'pow(x, y)', 'floor(x)', 'ceil(x)',  ,'mod(x, y)',
+								'round(x)', 'mix(x, y, a)', 
+								'fract(x)', 'inverseqrt(x)',
 							].map((fn)=> (
 								<li key={fn} className='font-mono '>{fn}</li>
 							))}
@@ -70,6 +74,20 @@ const ColorAdjuster = () => {
 					</PopoverContent>
 				</Popover>
 			</div>
+			<QuickTip message={
+				<div>
+					By default, Browzarr uses <span className='font-mono'>8-bit</span> textures
+					to save memory.<br/>
+					Switching to <span className='font-mono'>16-bit</span> provides
+					greater granularity for high variability datasets.
+				</div>
+			}>
+				<Button variant='pink'
+					onClick={() =>{ setUseF16Textures(!useF16Textures); setStatus("Converting")}}
+				>
+					Use <span className='font-mono'>{useF16Textures ? '8-bit' : '16-bit'}</span> textures
+				</Button>
+			</QuickTip>
 			
 			
 		</div>

--- a/src/components/ui/Elements/ColorAdjuster.tsx
+++ b/src/components/ui/Elements/ColorAdjuster.tsx
@@ -34,33 +34,58 @@ const ColorAdjuster = () => {
 			? <p>Current operation: {colorScale}</p>
 			: <p>Apply an operation to the current plot</p>
 			}
-			<QuickTip message='Write operations in GLSL. Click __ for available methods'>
+			<QuickTip message={<div>Write operations in GLSL<br/> example: <b>x / 2.0</b></div>}>
 				<Input type='string' placeholder='apply operations to "x"'
 					onChange={e=>customShader.current = e.target.value}
 				/>
 			</QuickTip>
-			<Button
-				variant='pink'
-				onClick={handleShader}
-			>
-				Apply Operation
-			</Button>
-			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant='secondary'>
-						Functions List
-					</Button>
-				</PopoverTrigger>
-				<PopoverContent>
-					<p>Along with general arithmetic operations. The following globals can also be used:</p>
-					<ul className='columns-2'>
-						<li></li>
-					</ul>
-				</PopoverContent>
-			</Popover>
+			<div className='flex pt-2'>
+				<Button
+					variant='pink'
+					onClick={handleShader}
+				>
+					Apply Operation
+				</Button>
+				<Popover>
+					<PopoverTrigger asChild>
+						<Button variant='secondary'>
+							Functions List
+						</Button>
+					</PopoverTrigger>
+					<PopoverContent>
+						<p>Along with general arithmetic operations. The following globals can also be used:</p>
+						<ul className='columns-2 !list-none bg-gray-100 rounded-lg border-solid border-2'>
+							{[
+								'abs(x)', 'min(x, y)', 'max(x, y)', 'sqrt(x)',
+								'floor(x)', 'ceil(x)', 'pow(x, y)', 'exp(x)','mod(x, y)',
+								'round(x)', 'mix(x, y, a)', 'exp2(x)',
+								'log(x)', 'log2(x)', 'fract(x)', 'inverseqrt(x)',
+							].map((fn)=> (
+								<li key={fn} className='font-mono '>{fn}</li>
+							))}
+						</ul>
+						<p className='warn-box text-center'>Always use <b>FLOAT</b> <br/>
+							<s>50</s> → <b>50.0</b>
+						</p>
+					</PopoverContent>
+				</Popover>
+			</div>
+			
 			
 		</div>
 	)
 }
+
+export const functionInjector = (shader:string, colorScale: string | undefined) => {
+	if (!colorScale) return shader;
+	const functionText = `
+		denorm(x);
+		${colorScale}
+		norm(x);
+	`
+	return shader.replace('//LOGIC' , functionText)
+}
+
+
 
 export default ColorAdjuster

--- a/src/components/ui/Elements/ColorAdjuster.tsx
+++ b/src/components/ui/Elements/ColorAdjuster.tsx
@@ -1,38 +1,64 @@
 import React, {useRef} from 'react'
-import { Button } from '../button'
-import { Input } from '../input'
+import { Button, Input } from '@/components/ui'
 import { glslValidator } from '@/utils/glslValidator'
 import { QuickTip } from '../Widgets/QuickTip'
 import { useErrorStore } from '@/GlobalStates/ErrorStore'
 import { useShallow } from 'zustand/shallow'
-
+import { usePlotStore } from '@/GlobalStates/PlotStore'
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 const ColorAdjuster = () => {
     const customShader = useRef('');
 	const {setError, setCustomError} = useErrorStore(useShallow(s => s))
+	const {colorScale} = usePlotStore(useShallow( s=>s))
 	const handleShader = () =>{
-		const {ok, log} = glslValidator(customShader.current)
+		const shader = customShader.current
+		const {ok, log} = glslValidator(shader)
 		if (!ok){
 			setError('glsl')
 			if (!log) return;
-			const thirdIdx = log.indexOf(":", log.indexOf(":", log.indexOf(":") + 1) + 1)
+			const thirdIdx = log.indexOf(":", log.indexOf(":", log.indexOf(":") + 1) + 1) // The error starts with the code location in the boilerplate. This starts after that 
 			setCustomError(log.slice(thirdIdx+1))
 			return
 		} 
+		if (shader.length == 0){
+			usePlotStore.setState({colorScale:undefined});
+			return;
+		}
+		const glslString = `x = ${shader};`
+		usePlotStore.setState({colorScale:glslString})
 	}
 
 	return (
 		<div>
+			{colorScale 
+			? <p>Current operation: {colorScale}</p>
+			: <p>Apply an operation to the current plot</p>
+			}
 			<QuickTip message='Write operations in GLSL. Click __ for available methods'>
 				<Input type='string' placeholder='apply operations to "x"'
 					onChange={e=>customShader.current = e.target.value}
 				/>
 			</QuickTip>
 			<Button
+				variant='pink'
 				onClick={handleShader}
 			>
 				Apply Operation
 			</Button>
-
+			<Popover>
+				<PopoverTrigger asChild>
+					<Button variant='secondary'>
+						Functions List
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent>
+					<p>Along with general arithmetic operations. The following globals can also be used:</p>
+					<ul className='columns-2'>
+						<li></li>
+					</ul>
+				</PopoverContent>
+			</Popover>
+			
 		</div>
 	)
 }

--- a/src/components/ui/Elements/ColorAdjuster.tsx
+++ b/src/components/ui/Elements/ColorAdjuster.tsx
@@ -1,12 +1,40 @@
-import React from 'react'
+import React, {useRef} from 'react'
+import { Button } from '../button'
+import { Input } from '../input'
+import { glslValidator } from '@/utils/glslValidator'
+import { QuickTip } from '../Widgets/QuickTip'
+import { useErrorStore } from '@/GlobalStates/ErrorStore'
+import { useShallow } from 'zustand/shallow'
 
 const ColorAdjuster = () => {
-    
-  return (
-    <div>
-      
-    </div>
-  )
+    const customShader = useRef('');
+	const {setError, setCustomError} = useErrorStore(useShallow(s => s))
+	const handleShader = () =>{
+		const {ok, log} = glslValidator(customShader.current)
+		if (!ok){
+			setError('glsl')
+			if (!log) return;
+			const thirdIdx = log.indexOf(":", log.indexOf(":", log.indexOf(":") + 1) + 1)
+			setCustomError(log.slice(thirdIdx+1))
+			return
+		} 
+	}
+
+	return (
+		<div>
+			<QuickTip message='Write operations in GLSL. Click __ for available methods'>
+				<Input type='string' placeholder='apply operations to "x"'
+					onChange={e=>customShader.current = e.target.value}
+				/>
+			</QuickTip>
+			<Button
+				onClick={handleShader}
+			>
+				Apply Operation
+			</Button>
+
+		</div>
+	)
 }
 
 export default ColorAdjuster

--- a/src/components/ui/Elements/ColorAdjuster.tsx
+++ b/src/components/ui/Elements/ColorAdjuster.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const ColorAdjuster = () => {
+    
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default ColorAdjuster

--- a/src/components/ui/Elements/Error.tsx
+++ b/src/components/ui/Elements/Error.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dialog";
 
 export const Error = () => {
-    const {error, setError} = useErrorStore(useShallow(s => s))
+    const {error, customError, setError, setCustomError} = useErrorStore(useShallow(s => s))
   return (
     <>
     {error && <Dialog open={true} onOpenChange={e=>setError(null)}>
@@ -21,12 +21,17 @@ export const Error = () => {
             </DialogTitle>
             <div className='error-message'>
                 {ErrorList[error as keyof typeof ErrorList].description}
+                {customError &&
+                <div className='bg-red-50 p-2 mt-2 rounded-md border-solid border-1'>
+                    {customError}
+                </div>
+                }
             </div>
             <div className='flex justify-center mt-[10px]'>
                 <Button
                 variant='pink'
                     className='cursor-pointer hover:scale-[1.1]'
-                    onClick={e=>setError(null)}
+                    onClick={e=>{setError(null); setCustomError(null)}}
                 >
                 Okay
                 </Button>

--- a/src/components/ui/Elements/ErrorList.ts
+++ b/src/components/ui/Elements/ErrorList.ts
@@ -30,5 +30,9 @@ export const ErrorList = {
     badProj :{
         title: "Unrecognized Projection String",
         description: "The projection string provided is not recognized. Please check the string and try again."
+    },
+    glsl :{
+        title: "Invalid GLSL Code",
+        description: "The given function is invalid. Check the error message for additional information"
     }
 }

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -20,7 +20,6 @@ import { BsFillQuestionCircleFill } from "react-icons/bs";
 import { ChevronDown } from 'lucide-react';
 import {Select, SelectTrigger, SelectContent, SelectItem, SelectValue} from '@/components/ui'
 import { RiCloseLargeLine } from "react-icons/ri";
-import { reproject } from '@/components/textures/ProjectionTexture';
 import { Reprojection } from '../Elements/Reprojection';
 import { useAxisIndices } from '@/hooks';
 

--- a/src/hooks/useCommonUniforms.tsx
+++ b/src/hooks/useCommonUniforms.tsx
@@ -10,9 +10,9 @@ import { deg2rad } from '@/utils/HelperFuncs'
 export function useCommonUniforms() {
 	const {cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange, 
 		useBorderTexture, borderColor, borderWidth, borderTexture, is360Deg, showBorders} = usePlotStore(useShallow(s=>s))
-	const { textureArrayDepths, colormap, remapBorders, remapTexture} = useGlobalStore(useShallow(s => s))
+	const { textureArrayDepths, colormap, remapBorders, remapTexture, valueScales} = useGlobalStore(useShallow(s => s))
 	const {lonBounds, latBounds} = useCoordBounds()
-
+    
 	const uniforms = useMemo(() => ({
 		cScale: {value: cScale},
 		cOffset: {value: cOffset},
@@ -33,10 +33,11 @@ export function useCommonUniforms() {
 		nanColor: {value : new THREE.Color(nanColor)},
 		nanAlpha: {value: 1 - nanTransparency},
 		fillValue: {value: fillValue?? NaN},
+		valueRange: {value: new THREE.Vector2(valueScales.minVal, valueScales.maxVal)}
 	}), [
 		cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
 		textureArrayDepths, colormap, lonBounds, latBounds, useBorderTexture, borderTexture, borderWidth, 
-		borderColor, remapBorders, remapTexture, is360Deg, showBorders
+		borderColor, remapBorders, remapTexture, is360Deg, showBorders, valueScales
 	])
 	return uniforms
 
@@ -45,7 +46,7 @@ export function useCommonUniforms() {
 export function updateCommonUniforms(material: THREE.ShaderMaterial){
 	const {cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
 		useBorderTexture, borderColor, borderWidth, is360Deg, showBorders} = usePlotStore(useShallow(s=>s))
-	const {textureArrayDepths, colormap} = useGlobalStore(useShallow(s => s))
+	const {textureArrayDepths, colormap, valueScales} = useGlobalStore(useShallow(s => s))
 	const {lonBounds, latBounds} = useCoordBounds()
 
 	useEffect(()=>{
@@ -66,9 +67,11 @@ export function updateCommonUniforms(material: THREE.ShaderMaterial){
 		uniforms.borderColor.value = new THREE.Color(borderColor);
 		uniforms.borderWidth.value = borderWidth;
 		uniforms.is360.value = is360Deg;
+		uniforms.valueRange.value = new THREE.Vector2(valueScales.minVal, valueScales.maxVal);
 	},[[
 		cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
-		textureArrayDepths, colormap, lonBounds, latBounds, useBorderTexture, borderColor, borderWidth, is360Deg, showBorders
+		textureArrayDepths, colormap, lonBounds, latBounds, useBorderTexture, borderColor, borderWidth, is360Deg, showBorders,
+		valueScales
 	]])
 	
 	return;

--- a/src/hooks/useCommonUniforms.tsx
+++ b/src/hooks/useCommonUniforms.tsx
@@ -10,7 +10,7 @@ import { deg2rad } from '@/utils/HelperFuncs'
 export function useCommonUniforms() {
 	const {cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange, 
 		useBorderTexture, borderColor, borderWidth, borderTexture, is360Deg, showBorders} = usePlotStore(useShallow(s=>s))
-	const { textureArrayDepths, colormap, remapBorders, remapTexture, valueScales} = useGlobalStore(useShallow(s => s))
+	const { textureArrayDepths, colormap, remapBorders, remapTexture, valueScales, useF16Textures} = useGlobalStore(useShallow(s => s))
 	const {lonBounds, latBounds} = useCoordBounds()
     
 	const uniforms = useMemo(() => ({
@@ -24,6 +24,7 @@ export function useCommonUniforms() {
 		borderColor: {value: new THREE.Color(borderColor)},
 		remapBorders : {value: Boolean(remapBorders) && !Boolean(remapTexture)},
 		is360: {value: is360Deg},
+		useF16: {value: useF16Textures},
 		threshold: {value: new THREE.Vector2(valueRange[0],valueRange[1])},
 		latBounds: {value: new THREE.Vector2(deg2rad(latBounds[0]), deg2rad(latBounds[1]))},
 		lonBounds: {value: new THREE.Vector2(deg2rad(lonBounds[0]), deg2rad(lonBounds[1]))},
@@ -37,17 +38,23 @@ export function useCommonUniforms() {
 	}), [
 		cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
 		textureArrayDepths, colormap, lonBounds, latBounds, useBorderTexture, borderTexture, borderWidth, 
-		borderColor, remapBorders, remapTexture, is360Deg, showBorders, valueScales
+		borderColor, remapBorders, remapTexture, is360Deg, showBorders, valueScales, useF16Textures
 	])
 	return uniforms
-
 }
 
 export function updateCommonUniforms(material: THREE.ShaderMaterial){
 	const {cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
 		useBorderTexture, borderColor, borderWidth, is360Deg, showBorders} = usePlotStore(useShallow(s=>s))
-	const {textureArrayDepths, colormap, valueScales} = useGlobalStore(useShallow(s => s))
+	const {textureArrayDepths, colormap, valueScales, useF16Textures} = useGlobalStore(useShallow(s => s))
 	const {lonBounds, latBounds} = useCoordBounds()
+
+	// useEffect(()=>{
+	// 	// Cleanup function to dispose materials when they are remade in parent component
+	// 	if (material){
+	// 		material.dispose()
+	// 	}
+	// },[material])
 
 	useEffect(()=>{
 		if (!material) return;
@@ -68,10 +75,11 @@ export function updateCommonUniforms(material: THREE.ShaderMaterial){
 		uniforms.borderWidth.value = borderWidth;
 		uniforms.is360.value = is360Deg;
 		uniforms.valueRange.value = new THREE.Vector2(valueScales.minVal, valueScales.maxVal);
+		uniforms.useF16.value = useF16Textures;
 	},[[
 		cScale, cOffset, animProg, nanTransparency, nanColor, fillValue, maskTexture, maskValue, valueRange,
 		textureArrayDepths, colormap, lonBounds, latBounds, useBorderTexture, borderColor, borderWidth, is360Deg, showBorders,
-		valueScales
+		valueScales, useF16Textures
 	]])
 	
 	return;

--- a/src/utils/glslValidator.ts
+++ b/src/utils/glslValidator.ts
@@ -1,4 +1,4 @@
-const boilerPlate = `
+const boilerPlate = `#version 300 es
 precision mediump float;
 
 void colorscaler(out float x){

--- a/src/utils/glslValidator.ts
+++ b/src/utils/glslValidator.ts
@@ -1,3 +1,15 @@
+const boilerPlate = `
+precision mediump float;
+
+void colorscaler(out float x){
+	//LOGIC;
+}
+
+void main(){
+
+}
+`
+
 export const glslValidator = (source: string, type='fragment') => {
     const canvas = document.createElement("canvas");
 	const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
@@ -11,7 +23,7 @@ export const glslValidator = (source: string, type='fragment') => {
 
 	const shader = gl.createShader(shaderType);
 	if (!shader) return {ok: false, log:null}
-	gl.shaderSource(shader, source);
+	gl.shaderSource(shader, boilerPlate.replace('//LOGIC',source));
 	gl.compileShader(shader);
 
 	const ok = gl.getShaderParameter(shader, gl.COMPILE_STATUS);

--- a/src/utils/glslValidator.ts
+++ b/src/utils/glslValidator.ts
@@ -1,0 +1,23 @@
+export const glslValidator = (source: string, type='fragment') => {
+    const canvas = document.createElement("canvas");
+	const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+
+	if (!gl) {
+		return { ok: false, log: "WebGL not supported" };
+	}
+
+	const shaderType =
+		type === "fragment" ? gl.FRAGMENT_SHADER : gl.VERTEX_SHADER;
+
+	const shader = gl.createShader(shaderType);
+	if (!shader) return {ok: false, log:null}
+	gl.shaderSource(shader, source);
+	gl.compileShader(shader);
+
+	const ok = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+	const log = gl.getShaderInfoLog(shader);
+
+	gl.deleteShader(shader);
+
+	return { ok, log };
+}


### PR DESCRIPTION
This PR adds adjusting/inputting custom scales for the colormap as well as switching back and forth with Float16 textures for greater fidelity.

## Interface
> <img width="521" height="108" alt="image" src="https://github.com/user-attachments/assets/8fc85d0f-1e0d-495b-9870-3a857d513f55" />


> <img width="305" height="300" alt="image" src="https://github.com/user-attachments/assets/ad824e0a-f2f1-4884-92a5-c1a60d9b3e43" />

> <img width="416" height="590" alt="image" src="https://github.com/user-attachments/assets/ae882094-c89a-4c5d-9ff0-e512a290963b" />

A rudimentary glsl parser module will check each function before submitting it to the shader to let the user know if it's valid. 

<img width="534" height="272" alt="image" src="https://github.com/user-attachments/assets/184c302d-67b6-453b-8194-955b97dcef96" />


## Shader consolidation
I have consolidated a lot of the shader code into `commonUniform` and `commonHelper` chunks. This helped with injecting the user functions into each shader. I also implemented a bitwise nanChecker so the colorscale operations can operate as expected. Using a log function on a negative value will produce a nan, as seen here

> <img width="996" height="656" alt="image" src="https://github.com/user-attachments/assets/a0db5323-a482-490c-8428-9c61898c10fd" />

## Colorscale --> Vertex Shaders
With this new system I needed the new values to be reflected in the displacements of the vertices. Otherwise the colors wouldn't match up. This means the value scaling with the color bar now also affects vertices. I may add an option to disable this in the future.
<img width="453" height="583" alt="color_vertex" src="https://github.com/user-attachments/assets/a0cf0086-ddc0-431f-991d-1f4116ecbb3c" />

## Float16 textures
For datasets with high variance (like precipitation) even with the new scaling system, the lack of precision meant the resulting images were extremely grainy and blocky. The users can now swap the textures from Uint8 to Float16 for greater precision with these high variance datasets.

| Int8 | Float16|
| --- | ---|
|<img width="1330" height="804" alt="image" src="https://github.com/user-attachments/assets/5fabf225-33f9-4912-850f-a7da6b533a7c" /> | <img width="1288" height="805" alt="image" src="https://github.com/user-attachments/assets/cbca8453-dad9-478b-9506-53542bf2ab4e" /> |
| <img width="914" height="915" alt="image" src="https://github.com/user-attachments/assets/e9fa491c-81ae-498c-a3d1-8fcd0fd56ebc" /> | <img width="927" height="1001" alt="image" src="https://github.com/user-attachments/assets/023620e2-f5d1-4990-b25f-2b6dcdfd4885" /> |

## Known limitations and issues
* The values in the `Value Cropping` don't align with the new values

<img width="222" height="83" alt="image" src="https://github.com/user-attachments/assets/d2ee905d-bd5c-4cc1-be75-aaadf86f90d1" />

* For some reason in pointcloud, adjusting the value cropping value when a rather strong deviation from the normal value-range occurs, the plot disappears and won;t come back until resetting the colorscale


closes #616 #701 