### PR TITLE
Added opacity inverse

### DIFF
--- a/src/GlobalStates/GraphStore.ts
+++ b/src/GlobalStates/GraphStore.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+
+type GraphState = {
+    showPoints: boolean;
+    pointSize: number;
+    lineWidth: number;
+    lineColor: string;
+    pointColor: string;
+    useLineColor: boolean;
+    lineResolution: number;
+    useCustomColor: boolean;
+    useCustomPointColor: boolean;
+
+    setShowPoints: (showPoints: boolean) => void;
+    setLinePointSize: (pointSize: number) => void;
+    setLineWidth: (lineWidth: number) => void;
+    setLineColor: (lineColor: string) => void;
+    setPointColor: (pointColor: string) => void;
+    setUseLineColor: (lineColor: boolean) => void;
+    setLineResolution: (lineResolution: number) => void;
+    setUseCustomColor: (useCustomColor : boolean) => void;
+    setUseCustomPointColor: (useCustomPointColor: boolean) => void
+}
+
+export const useGraphStore = create<GraphState>((set, get) => ({
+    showPoints: true,
+    pointSize: 2,
+    lineWidth: 1.25,
+    lineColor: "#111111",
+    pointColor: "#EA8686",
+    useLineColor: false,
+    lineResolution: 3,
+    useCustomColor: false,
+    useCustomPointColor: false,
+
+    setShowPoints: (showPoints) => set({ showPoints }),
+    setLinePointSize: (pointSize) => set({ pointSize }),
+    setLineWidth: (lineWidth) => set({ lineWidth }),
+    setLineColor: (lineColor) => set({ lineColor }),
+    setPointColor: (pointColor) => set({ pointColor }),
+    setUseLineColor: (useLineColor) => set({ useLineColor }),
+    setLineResolution: (lineResolution) => set({ lineResolution }),
+    setUseCustomColor: (useCustomColor) => set({ useCustomColor }),
+    setUseCustomPointColor: (useCustomPointColor) => set({ useCustomPointColor}),
+}))

--- a/src/GlobalStates/PlotStore.ts
+++ b/src/GlobalStates/PlotStore.ts
@@ -13,13 +13,6 @@ type PlotState ={
   zRange: number[];
   quality: number;
   selectTS: boolean;
-  showPoints: boolean;
-  linePointSize: number;
-  lineWidth: number;
-  lineColor: string;
-  pointColor: string;
-  useLineColor: boolean;
-  lineResolution: number;
   animate: boolean;
   resetAnim: boolean;
   animProg: number;
@@ -27,9 +20,8 @@ type PlotState ={
   cScale: number;
   useRayMarch: boolean;
   resetCamera: boolean;
-  useCustomColor: boolean;
-  useCustomPointColor: boolean;
   transparency: number;
+  revTransparency: boolean;
   nanTransparency: number;
   nanColor: string;
   showBorders:boolean;
@@ -83,13 +75,6 @@ type PlotState ={
   setScaleIntensity: (scaleIntensity: number) => void;
   setPlotType: (plotType: string) => void;
   setSelectTS: (selectTS: boolean) => void;
-  setShowPoints: (showPoints: boolean) => void;
-  setLinePointSize: (linePointSize: number) => void;
-  setLineWidth: (lineWidth: number) => void;
-  setLineColor: (lineColor: string) => void;
-  setPointColor: (pointColor: string) => void;
-  setUseLineColor: (lineColor: boolean) => void;
-  setLineResolution: (lineResolution: number) => void;
   setAnimate: (animate: boolean) => void;
   setResetAnim: (resetAnim: boolean) => void;
   setAnimProg: (animProg: number) => void; 
@@ -97,9 +82,8 @@ type PlotState ={
   setCScale: (cScale: number) => void;
   setUseRayMarch: (useRayMarch: boolean) => void;
   setResetCamera: (resetCamera: boolean) => void;
-  setUseCustomColor: (useCustomColor: boolean) => void;
-  setUseCustomPointColor: (useCustomPointColor: boolean) => void;
   setTransparency: (transparency: number) => void;
+  setRevTransparency: (revTransparency: boolean) => void;
   setNanTransparency: (nanTraparency: number) => void;
   setNanColor: (nanColor: string) => void;
   setShowBorders: (showBorders: boolean) => void;
@@ -143,13 +127,6 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   yRange: [-1, 1],
   zRange: [-1, 1],
   selectTS: false,
-  showPoints: true,
-  linePointSize: 2,
-  lineWidth: 1.25,
-  lineColor: "#111111",
-  pointColor: "#EA8686",
-  useLineColor: false,
-  lineResolution: 3,
   animate: false,
   resetAnim: false,
   animProg: 0,
@@ -157,9 +134,8 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   cScale: 1,
   useRayMarch: false,
   resetCamera: false,
-  useCustomColor: false,
-  useCustomPointColor: false,
   transparency: 0,
+  revTransparency: false,
   nanTransparency: 1,
   nanColor: "#000000",
   showBorders: false,
@@ -215,13 +191,6 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   setScaleIntensity: (scaleIntensity) => set({ scaleIntensity }),
   setPlotType: (plotType) => set({ plotType }),
   setSelectTS: (selectTS) => set({ selectTS }),
-  setShowPoints: (showPoints) => set({ showPoints }),
-  setLinePointSize: (linePointSize) => set({ linePointSize }),
-  setLineWidth: (lineWidth) => set({ lineWidth }),
-  setLineColor: (lineColor) => set({ lineColor }),
-  setPointColor: (pointColor) => set({ pointColor }),
-  setUseLineColor: (useLineColor) => set({ useLineColor }),
-  setLineResolution: (lineResolution) => set({ lineResolution }),
   setAnimate: (animate) => set({ animate }),
   setResetAnim: (resetAnim) => set({ resetAnim }),
   setAnimProg: (animProg) => set({ animProg }),
@@ -229,9 +198,8 @@ export const usePlotStore = create<PlotState>((set, get) => ({
   setCScale: (cScale) => set({ cScale }),
   setUseRayMarch: (useRayMarch) => set({ useRayMarch }),
   setResetCamera: (resetCamera) => set({ resetCamera }),
-  setUseCustomColor: (useCustomColor) => set({ useCustomColor }),
-  setUseCustomPointColor: (useCustomPointColor) => set({ useCustomPointColor}),
   setTransparency: (transparency) => set({ transparency}),
+  setRevTransparency: (revTransparency) => set({ revTransparency }),
   setNanTransparency: (nanTransparency) => set({ nanTransparency }),
   setNanColor: (nanColor) => set({ nanColor }),
   setShowBorders: (showBorders) => set({ showBorders }),

--- a/src/components/plots/DataCube.tsx
+++ b/src/components/plots/DataCube.tsx
@@ -18,68 +18,70 @@ export const DataCube = ({ volTexture: propVolTexture }: DataCubeProps ) => {
     const volTexture = usePaddedTextures(propVolTexture);
     const {shape, flipY, remapTexture, dataShape} = useGlobalStore(useShallow(s => s)) //We have to useShallow when returning an object instead of a state. I don't fully know the logic yet
     const {xRange, yRange, zRange, quality, useOrtho, useRayMarch, transparency, colorScale,
-      vTransferRange, vTransferScale} = usePlotStore(useShallow(s => s))
+		vTransferRange, vTransferScale, revTransparency} = usePlotStore(useShallow(s => s))
     const meshRef = useRef<THREE.Mesh>(null!);
     const aspectRatio = shape.y/shape.x
     const timeRatio = shape.z/shape.x;
     const gridShape = useMemo(()=>{
-      if (remapTexture){
-        return new THREE.Vector3(remapTexture.image.width, remapTexture.image.height, dataShape[0])
-      } else return new THREE.Vector3(dataShape[2], dataShape[1], dataShape[0])
+		if (remapTexture){
+			return new THREE.Vector3(remapTexture.image.width, remapTexture.image.height, dataShape[0])
+		} else return new THREE.Vector3(dataShape[2], dataShape[1], dataShape[0])
       
     },[remapTexture, dataShape])
 	const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>new THREE.ShaderMaterial({
-      glslVersion: THREE.GLSL3,
-      uniforms: {
-          modelViewMatrixInverse: { value: new THREE.Matrix4() }, // Used for Orthographic RayMarcher
-          map: { value: volTexture},
-          dataShape: {value: gridShape},
-          remapTexture: { value: remapTexture},
-          scale: {value: shape},
-          flatBounds:{value: new THREE.Vector4(-xRange[1],-xRange[0],zRange[0] * timeRatio, zRange[1] * timeRatio)},
-          vertBounds:{value: new THREE.Vector2(yRange[0]*aspectRatio,yRange[1]*aspectRatio)},
-          steps: { value: quality },
-          transparency: {value: transparency},
-          opacityMag: {value: vTransferScale},
-          useClipScale: {value: vTransferRange},
-		  ...uniforms
-      },
-      defines: {
-        USE_VORIGIN: 1,
-        USE_VDIRECTION: 1,
-        ...(remapTexture ? { REPROJECT: true } : {})
-      },
-      vertexShader: useOrtho ? orthoVertex : vertexShader,
-      fragmentShader: useRayMarch ? functionInjector(rayMarchFrag, colorScale): functionInjector(ddaFrag, colorScale),
-      transparent: true,
-      blending: THREE.NormalBlending,
-      depthWrite: false,
-      side: useOrtho ? THREE.FrontSide : THREE.BackSide,
+		glslVersion: THREE.GLSL3,
+		uniforms: {
+			modelViewMatrixInverse: { value: new THREE.Matrix4() }, // Used for Orthographic RayMarcher
+			map: { value: volTexture},
+			dataShape: {value: gridShape},
+			remapTexture: { value: remapTexture},
+			scale: {value: shape},
+			flatBounds:{value: new THREE.Vector4(-xRange[1],-xRange[0],zRange[0] * timeRatio, zRange[1] * timeRatio)},
+			vertBounds:{value: new THREE.Vector2(yRange[0]*aspectRatio,yRange[1]*aspectRatio)},
+			steps: { value: quality },
+			transparency: {value: transparency},
+			revTransparency: {value: revTransparency},
+			opacityMag: {value: vTransferScale},
+			useClipScale: {value: vTransferRange},
+			...uniforms
+		},
+		defines: {
+			USE_VORIGIN: 1,
+			USE_VDIRECTION: 1,
+			...(remapTexture ? { REPROJECT: true } : {})
+		},
+		vertexShader: useOrtho ? orthoVertex : vertexShader,
+		fragmentShader: useRayMarch ? functionInjector(rayMarchFrag, colorScale): functionInjector(ddaFrag, colorScale),
+		transparent: true,
+		blending: THREE.NormalBlending,
+		depthWrite: false,
+		side: useOrtho ? THREE.FrontSide : THREE.BackSide,
     }),[useRayMarch, useOrtho, volTexture, colorScale, remapTexture]);
 
     const geometry = useMemo(() => new THREE.BoxGeometry(shape.x, shape.y, shape.z), [shape]);
 	updateCommonUniforms(shaderMaterial)
     useEffect(() => {
-      if (shaderMaterial) {
-        const uniforms = shaderMaterial.uniforms
-		    uniforms.dataShape.value = gridShape;
-        uniforms.scale.value = shape;
-        uniforms.flatBounds.value.set(-xRange[1], -xRange[0], zRange[0] * timeRatio, zRange[1] * timeRatio);
-        uniforms.vertBounds.value.set(yRange[0] * aspectRatio, yRange[1] * aspectRatio);
-        uniforms.steps.value = quality;
-        uniforms.transparency.value = transparency;
-        uniforms.opacityMag.value = vTransferScale;
-        uniforms.useClipScale.value = vTransferRange;
-        invalidate() // Needed because Won't trigger re-render if camera is stationary. 
-      }
-    }, [shape, gridShape, xRange, yRange, zRange, aspectRatio, quality, transparency, vTransferScale, vTransferRange]);
+		if (shaderMaterial) {
+			const uniforms = shaderMaterial.uniforms
+				uniforms.dataShape.value = gridShape;
+			uniforms.scale.value = shape;
+			uniforms.flatBounds.value.set(-xRange[1], -xRange[0], zRange[0] * timeRatio, zRange[1] * timeRatio);
+			uniforms.vertBounds.value.set(yRange[0] * aspectRatio, yRange[1] * aspectRatio);
+			uniforms.steps.value = quality;
+			uniforms.transparency.value = transparency;
+			uniforms.revTransparency.value = revTransparency;
+			uniforms.opacityMag.value = vTransferScale;
+			uniforms.useClipScale.value = vTransferRange;
+			invalidate() // Needed because Won't trigger re-render if camera is stationary. 
+		}
+    }, [shape, gridShape, xRange, yRange, zRange, aspectRatio, quality, transparency, revTransparency, vTransferScale, vTransferRange]);
     useFrame(({camera})=>{ // This calculates InverseModel matrix for the orthographic raymarcher
-      if (!useOrtho || !meshRef.current || !shaderMaterial) return;
-      meshRef.current.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, meshRef.current.matrixWorld);
-      shaderMaterial.uniforms.modelViewMatrixInverse.value
-          .copy(meshRef.current.modelViewMatrix)
-          .invert();
+		if (!useOrtho || !meshRef.current || !shaderMaterial) return;
+		meshRef.current.modelViewMatrix.multiplyMatrices(camera.matrixWorldInverse, meshRef.current.matrixWorld);
+		shaderMaterial.uniforms.modelViewMatrixInverse.value
+			.copy(meshRef.current.modelViewMatrix)
+			.invert();
     })
   return (
     <group >

--- a/src/components/plots/plotarea/LinePlot.tsx
+++ b/src/components/plots/plotarea/LinePlot.tsx
@@ -1,7 +1,7 @@
 import { Canvas } from '@react-three/fiber'
 import { parseLoc } from '@/utils/HelperFuncs'
 import { FixedTicks, ThickLine } from '@/components/plots'
-import {  RefObject, useEffect, useRef, useState } from 'react'
+import {  useEffect, useRef, useState } from 'react'
 import { ResizeBar, YScaler, XScaler, ShowLinePlot } from '@/components/ui'
 import './LinePlot.css'
 import { useGlobalStore } from '@/GlobalStates/GlobalStore'

--- a/src/components/plots/plotarea/PlotPoints.tsx
+++ b/src/components/plots/plotarea/PlotPoints.tsx
@@ -2,8 +2,8 @@ import React, {useRef, useMemo, useEffect, useState} from 'react'
 import * as THREE from 'three'
 import { useFrame } from '@react-three/fiber'
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
-import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow'
+import { useGraphStore } from '@/GlobalStates/GraphStore';
 
 interface pointSetters{
   setPointID:React.Dispatch<React.SetStateAction<[string,number]>>,
@@ -18,7 +18,7 @@ function PlotPoints({ points, tsID, pointSetters, scalers }: { points: THREE.Vec
   const [_reRender,setreRender] = useState<boolean>(false);
   const {setPointID, setPointLoc,setShowPointInfo} = pointSetters;
   const [zoom,setZoom] = useState<number>(1);
-  const {pointColor, pointSize, useCustomPointColor} = usePlotStore(useShallow(s => s))
+  const {pointColor, pointSize, useCustomPointColor} = useGraphStore(useShallow(s => s))
   const {xScale, yScale} = scalers;
   const {timeSeries} = useGlobalStore(useShallow(s => s))
   const [r, g, b] = timeSeries[tsID]['color']

--- a/src/components/plots/plotarea/ThickLine.tsx
+++ b/src/components/plots/plotarea/ThickLine.tsx
@@ -3,12 +3,12 @@
 import React, {useEffect, useMemo, useRef, useState} from 'react'
 import * as THREE from 'three'
 import { useGlobalStore } from '@/GlobalStates/GlobalStore';
-import { usePlotStore } from '@/GlobalStates/PlotStore';
 import { useShallow } from 'zustand/shallow'
 import vertexShader from '@/components/textures/shaders/thickLineVert.glsl'
 import { PlotPoints } from './PlotPoints';
 import { useThree } from '@react-three/fiber';
 import { invalidate } from '@react-three/fiber';
+import { useGraphStore } from '@/GlobalStates/GraphStore';
 
 
 function linspace(start: number, stop: number, num: number): number[] {
@@ -31,7 +31,7 @@ interface ThickLineProps {
 
 const ThickLine = ({height, xScale, yScale, pointSetters} : ThickLineProps) => {
     const {valueScales, timeSeries, colormap} = useGlobalStore(useShallow(s => s))
-    const {lineWidth, useLineColor, lineColor, showPoints, lineResolution, useCustomColor} = usePlotStore(useShallow(s => s))
+    const {lineWidth, useLineColor, lineColor, showPoints, lineResolution, useCustomColor} = useGraphStore(useShallow(s => s))
 	  const {camera} = useThree()
 
   const {maxVal, minVal} = valueScales

--- a/src/components/textures/shaders/DDAFrag.glsl
+++ b/src/components/textures/shaders/DDAFrag.glsl
@@ -9,12 +9,12 @@ out vec4 color;
 
 uniform vec3 dataShape;
 uniform vec3 scale;
-uniform float steps;
 uniform vec4 flatBounds;
 uniform vec2 vertBounds;
 uniform float transparency;
 uniform float opacityMag;
 uniform bool useClipScale;
+uniform bool revTransparency;
 
 vec2 hitBox(vec3 orig, vec3 dir) {
     vec3 boxMin = -(scale * 0.5);
@@ -126,7 +126,8 @@ void main() {
                     }
                 } else {
                     vec3 col = texture(cmap, vec2(d, 0.5)).rgb;
-                    float alpha = pow(max(d, 0.001), transparency * opacityMag);
+                    float alphaFac = revTransparency ? 1.0 - d : d;
+                    float alpha = pow(max(alphaFac, 0.001), transparency * opacityMag);
                     accumColor += (1.0 - alphaAcc) * alpha * col;
                     alphaAcc += alpha * (1.0 - alphaAcc);
                 }

--- a/src/components/textures/shaders/rayMarchFragment.glsl
+++ b/src/components/textures/shaders/rayMarchFragment.glsl
@@ -14,6 +14,7 @@ uniform vec2 vertBounds;
 uniform float transparency;
 uniform float opacityMag;
 uniform bool useClipScale;
+uniform bool revTransparency;
 
 
 vec2 hitBox(vec3 orig, vec3 dir) {
@@ -99,11 +100,12 @@ void main() {
         if (cond) {
             vec4 col = texture(cmap, vec2(d, 0.5));
             float alpha;
+            float alphaFac = revTransparency ? 1.0 - d : d;
             if (useClipScale){
-                float normalizedOpacity = clamp((d - threshold.x) / (threshold.y - threshold.x), 0.0, 1.0);
+                float normalizedOpacity = clamp((alphaFac - threshold.x) / (threshold.y - threshold.x), 0.0, 1.0);
                 alpha = pow(max(normalizedOpacity, 0.001), transparency*opacityMag);
             } else {
-                alpha = pow(max(d, 0.001), transparency*opacityMag);
+                alpha = pow(max(alphaFac, 0.001), transparency*opacityMag);
             }
             accumColor.rgb += (1.0 - alphaAcc) * alpha * col.rgb;
             alphaAcc += alpha * (1.0 - alphaAcc);

--- a/src/components/ui/LinePlotArea/PlotLineOptions.tsx
+++ b/src/components/ui/LinePlotArea/PlotLineOptions.tsx
@@ -9,13 +9,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { usePlotStore } from '@/GlobalStates/PlotStore'
 import { useShallow } from 'zustand/shallow'
 import { Slider } from "@/components/ui/slider"
+import { useGraphStore } from '@/GlobalStates/GraphStore'
 
 // Memoized Point Options
 const PointOptions = React.memo(function PointOptions(){
-  const { showPoints, linePointSize, pointColor, useCustomPointColor, setLinePointSize, setPointColor, setUseCustomPointColor } = usePlotStore(useShallow(s => s))
+  const { showPoints, pointSize, pointColor, useCustomPointColor, setLinePointSize, setPointColor, setUseCustomPointColor } = useGraphStore(useShallow(s => s))
   if (!showPoints) return null
   return (
     <>
@@ -25,7 +25,7 @@ const PointOptions = React.memo(function PointOptions(){
           min={1}
           max={10}
           step={0.1}
-          value={[linePointSize]}
+          value={[pointSize]}
           className='flex-1 my-2'
           onValueChange={(vals: number[]) => setLinePointSize(vals[0])}
         />
@@ -55,7 +55,7 @@ const PointOptions = React.memo(function PointOptions(){
 // Memoized Line Options
 const LineOptions = React.memo(function LineOptions(){
   const { lineWidth, lineColor, useLineColor, lineResolution, useCustomColor, 
-    setLineWidth, setLineColor, setUseLineColor, setLineResolution, setUseCustomColor,  } = usePlotStore(useShallow(s => s))
+    setLineWidth, setLineColor, setUseLineColor, setLineResolution, setUseCustomColor,  } = useGraphStore(useShallow(s => s))
   return (
     <>
       <div className='w-full flex items-center mb-2'>
@@ -113,7 +113,7 @@ const LineOptions = React.memo(function LineOptions(){
 })
 
 const PlotLineOptions = React.memo(function PlotLineOptions({menuRef} : {menuRef: React.RefObject<boolean>}){
-  const { showPoints, setShowPoints } = usePlotStore(useShallow(s => s))
+  const { showPoints, setShowPoints } = useGraphStore(useShallow(s => s))
 
   return (
     <div className='plotline-options'>

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -10,11 +10,6 @@ import { LuSettings } from "react-icons/lu";
 import { RxReset } from "react-icons/rx";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { Input, Switch, Hider, Button, Slider as UISlider, Switcher, Slider, QuickTip } from '@/components/ui';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import { parseLoc, normalize, denormalize } from '@/utils/HelperFuncs';
 import { BsFillQuestionCircleFill } from "react-icons/bs";
 import { ChevronDown } from 'lucide-react';
@@ -22,6 +17,12 @@ import {Select, SelectTrigger, SelectContent, SelectItem, SelectValue} from '@/c
 import { RiCloseLargeLine } from "react-icons/ri";
 import { Reprojection } from '../Elements/Reprojection';
 import { useAxisIndices } from '@/hooks';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FaLongArrowAltUp } from "react-icons/fa";
 
 function DeNorm(val : number, min : number, max : number){
     const range = max-min;
@@ -150,7 +151,8 @@ const DimSlicer = () =>{
 }
 
 const VolumeOptions = ()=>{
-  const { useRayMarch, quality, transparency, vTransferRange, vTransferScale, interpPixels, setQuality, setUseRayMarch, setTransparency, setVTransferRange, setVTransferScale} = usePlotStore(useShallow(s => s))
+  const { useRayMarch, quality, transparency, vTransferRange, vTransferScale, interpPixels, revTransparency,
+    setQuality, setUseRayMarch, setTransparency, setVTransferRange, setVTransferScale, setRevTransparency} = usePlotStore(useShallow(s => s))
   useEffect(()=>{
     if (!useRayMarch && interpPixels) setUseRayMarch(true)
   }, [interpPixels, useRayMarch])
@@ -188,7 +190,33 @@ const VolumeOptions = ()=>{
         </div>
       </Hider>
       <Switcher className={interpPixels ? 'opacity-40 !cursor-default' : undefined} leftText='DDA' rightText='Raymarch' state={!useRayMarch} onClick={()=> setUseRayMarch(!useRayMarch)}/>
-      <b>Transparency</b>
+      <div className='grid grid-cols-3 justify-between place-items-center'>
+        <b>Transparency</b>
+        <Button
+          variant='ghost'
+          className='px-0 w-10'
+          onClick={()=>setRevTransparency(!revTransparency)}
+        >
+          <FaLongArrowAltUp 
+            style={{
+              rotate:revTransparency ? '180deg' : '',
+              transition:'0.2s'
+            }}
+            size={20}
+          />
+        </Button>
+        <QuickTip message='Choose whether to clip higher or lower values first.'>
+            <Button 
+              variant={'outline'}
+              className='px-2'
+              onClick={()=>setRevTransparency(!revTransparency)}
+            >
+              <span className='text-justify'>{`${revTransparency ? 'High' : 'Low'} clip`}</span>
+          </Button>
+        </QuickTip>
+        
+      </div>
+      
       <UISlider
               min={0}
               max={10}
@@ -581,28 +609,18 @@ const AdjustPlot = () => {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <div style={enableCond ? {} : { pointerEvents: 'none' } }>
-          <Tooltip delayDuration={500} >
-            <TooltipTrigger asChild>
-              <div>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-10 cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
-                  style={{
-                    color: enableCond ? '' : 'var(--text-disabled)'
-                  }}
-                >
-                  <LuSettings className="size-8" />
-                </Button>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent
-              side={popoverSide === "left" ? "left" : "top"}
-              align={popoverSide === "left" ? "start" : "center"}
+          <QuickTip message={<span>Plot Settings</span>}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-10 cursor-pointer hover:scale-90 transition-transform duration-100 ease-out"
+              style={{
+                color: enableCond ? '' : 'var(--text-disabled)'
+              }}
             >
-              <span>Plot Settings</span>
-            </TooltipContent>
-          </Tooltip>
+              <LuSettings className="size-8" />
+            </Button>
+          </QuickTip>
         </div>
       </PopoverTrigger>
       <PopoverContent
@@ -615,9 +633,8 @@ const AdjustPlot = () => {
           popoverSide === 'top' ? 'mb-1' : ''
         }`}
       >
-        <Tooltip delayDuration={500}>
-          <TooltipTrigger asChild>
-            <Button
+        <QuickTip message='Close settings'>
+          <Button
               variant="ghost"
               size="icon"
               className="absolute top-0 right-1 z-10 cursor-pointer saturate-[180%]"
@@ -626,11 +643,7 @@ const AdjustPlot = () => {
             >
               <RiCloseLargeLine className="size-4" />
             </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            Close settings
-          </TooltipContent>
-        </Tooltip>
+        </QuickTip>
         <div className={`overflow-y-auto no-scrollbar -mx-4 px-4 ${popoverSide === 'top' ? 'max-h-[80vh]' : 'max-h-[70vh]'}`}>          
           <RxReset size={25} 
             style={{

--- a/src/components/ui/MainPanel/AdjustPlot.tsx
+++ b/src/components/ui/MainPanel/AdjustPlot.tsx
@@ -17,11 +17,6 @@ import {Select, SelectTrigger, SelectContent, SelectItem, SelectValue} from '@/c
 import { RiCloseLargeLine } from "react-icons/ri";
 import { Reprojection } from '../Elements/Reprojection';
 import { useAxisIndices } from '@/hooks';
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { FaLongArrowAltUp } from "react-icons/fa";
 
 function DeNorm(val : number, min : number, max : number){

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 hover:scale-90 transition-transform duration-100 ease-out",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
I split off some states from plot store to graph store to try to reduce the size of it.

This was a feature requested a long awhile ago. But just added the UI and functionality to apply opacity to high/low clip.

<img width="1289" height="781" alt="image" src="https://github.com/user-attachments/assets/03148418-419b-432f-bfdf-53237ec6da16" />
