### PR TITLE
Fix sphere issues

### DIFF
--- a/src/components/plots/SphereBlocks.tsx
+++ b/src/components/plots/SphereBlocks.tsx
@@ -9,7 +9,8 @@ import { invalidate } from '@react-three/fiber'
 import { usePaddedTextures } from '@/hooks/usePaddedTextures';
 import { updateCommonUniforms, useCommonUniforms } from '@/hooks/useCommonUniforms';
 import { functionInjector } from '../ui/Elements/ColorAdjuster';
-import { useDimAxis } from '@/hooks';
+import { useCoordBounds, useDimAxis } from '@/hooks';
+import { deg2rad } from '@/utils/HelperFuncs';
 const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[] | THREE.DataTexture[] | null}) => {
     const textures = usePaddedTextures(propTextures);
     const {isFlat, valueScales, remapTexture} = useGlobalStore(useShallow(s => s))
@@ -46,7 +47,9 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
         );
         return geo
     },[count])
+    
     const uniforms = useCommonUniforms()
+    const {lonBounds, latBounds} = useCoordBounds()
     const shaderMaterial = useMemo(()=>{
         const shader = new THREE.ShaderMaterial({
             glslVersion: THREE.GLSL3,
@@ -55,6 +58,8 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
                 remapTexture: { value: remapTexture },
                 displaceZero: {value: offsetNegatives ? 0 : (-valueScales.minVal/(valueScales.maxVal-valueScales.minVal))},
                 displacement: {value: displacement},
+                widthFactor: {value: Math.abs(deg2rad(lonBounds[1])-deg2rad(lonBounds[0]))/(2.0*Math.PI)},
+                vertFactor: {value: Math.abs(deg2rad(latBounds[1])-deg2rad(latBounds[0]))/(Math.PI)},
                 ...uniforms
             },
             defines:{
@@ -77,9 +82,11 @@ const SphereBlocks = ({textures: propTextures} : {textures: THREE.Data3DTexture[
             uniforms.map.value = textures;
             uniforms.displacement.value = displacement
             uniforms.displaceZero.value = offsetNegatives ? 0 : (-valueScales.minVal/(valueScales.maxVal-valueScales.minVal))
+            uniforms.widthFactor.value = Math.abs(deg2rad(lonBounds[1])-deg2rad(lonBounds[0]))/(2.0*Math.PI)
+            uniforms.vertFactor.value =  Math.abs(deg2rad(latBounds[1])-deg2rad(latBounds[0]))/(Math.PI)
         }
         invalidate();
-    },[valueScales, displacement, offsetNegatives, textures])
+    },[valueScales, displacement, offsetNegatives, lonBounds, textures])
 
     const nanMaterial = useMemo(()=>new THREE.MeshBasicMaterial({color:nanColor, opacity:(1-nanTransparency)}),[])
     nanMaterial.transparent = true;

--- a/src/components/textures/ProjectionTexture.ts
+++ b/src/components/textures/ProjectionTexture.ts
@@ -164,23 +164,27 @@ function createInverseUV(
     //We assume all irregular grids are in degrees for now. 
 	const normX = normalizeArray(xArray, is360? 0 : -180 , is360 ? 360 : 180);
 	const normY = normalizeArray(yArray, -90, 90);
+    const [xMin, xMax] = ArrayMinMax(normX);
+    const [yMin, yMax] = ArrayMinMax(normY);
 
 	const data = new Uint16Array(width * height * 4); // 4 for RGBA
 	let ptr = 0;
 	for (let j = 0; j < height; j++) {
-		const vRaw = height > 1 ? j / (height - 1) : 0;
+		const vRaw = height > 1 ? j / (height) : 0;
 		const v = vRaw;
 		const jIdx = findNearestIndex(normY, v);
-		const jNorm = yArray.length > 1 ? jIdx / (yArray.length - 1) : 0;
-
+		const jNorm = yArray.length > 1 ? jIdx / (yArray.length) : 0;
+        const vValid = v >= yMin && v <= yMax;
 		for (let i = 0; i < width; i++) {
-			const u = width > 1 ? i / (width - 1) : 0;
+			const u = width > 1 ? i / (width) : 0;
 			const iIdx = findNearestIndex(normX, u);
-			const iNorm = xArray.length > 1 ? iIdx / (xArray.length - 1) : 0;
+			const iNorm = xArray.length > 1 ? iIdx / (xArray.length) : 0;
+            const uValid = u >= xMin && u <= xMax;
 
+            const valid = uValid && vValid;
 			data[ptr++] = THREE.DataUtils.toHalfFloat(iNorm);
 			data[ptr++] = THREE.DataUtils.toHalfFloat(jNorm);
-			data[ptr++] = THREE.DataUtils.toHalfFloat(1.); // Set Valid so can be used in same shader logic
+			data[ptr++] = THREE.DataUtils.toHalfFloat(valid ? 1 : 0); // Set Valid so can be used in same shader logic
 			ptr++;
 		}
 	}

--- a/src/components/textures/shaders/sphereBlocksFrag.glsl
+++ b/src/components/textures/shaders/sphereBlocksFrag.glsl
@@ -25,5 +25,4 @@ void main() {
         }
     }
     Color = vec4(sampColor, 1.);
-    // Color = vec4(vec2(vUv.x > 0.55), 0.0 , 1.0);
 }

--- a/src/components/textures/shaders/sphereBlocksVert.glsl
+++ b/src/components/textures/shaders/sphereBlocksVert.glsl
@@ -4,6 +4,8 @@ attribute vec2 instanceUV;
 
 uniform float displaceZero;
 uniform float displacement;
+uniform float widthFactor;
+uniform float vertFactor;
 
 
 vec2 giveLonLat(vec2 uv) {
@@ -15,13 +17,14 @@ vec2 giveLonLat(vec2 uv) {
     return vec2(longitude, latitude);
 }
 
-vec3 givePosition(vec2 lonlat) {
+vec3 givePosition(vec2 lonlat, out float cosLat) {
     float longitude = lonlat.x;
     float latitude = lonlat.y;
     // Convert to Cartesian coordinates
-    float x = cos(latitude) * cos(longitude);
+    cosLat = cos(latitude);
+    float x = cosLat * cos(longitude);
     float y = sin(latitude);
-    float z = cos(latitude) * sin(longitude);
+    float z = cosLat * sin(longitude);
     
     return vec3(x, y, z);
 }
@@ -47,14 +50,14 @@ void main() {
             }
         }
     }
-    
     int zStepSize = int(textureDepths.y) * int(textureDepths.x); 
     int yStepSize = int(textureDepths.x); 
     vec2 sampleCoord = instanceUV;
     #ifdef REPROJECT
-        vec3 remap = texture(remapTexture, sampleCoord).rgb;
+        vec2 realUV = realCoords(sampleCoord);
+        vec3 remap = texture(remapTexture, realUV).rgb;
         sampleCoord = remap.rg;
-        if (remap.b < 0.5) sampleCoord = vec2(2.0); // I don't think this is ever the case
+        if (remap.b < 0.5) sampleCoord = vec2(2.0); 
     #endif
     #ifdef IS_FLAT
         ivec2 idx = clamp(ivec2(sampleCoord * textureDepths.xy), ivec2(0), ivec2(textureDepths.xy) - 1);
@@ -74,7 +77,7 @@ void main() {
     if (isnan){gl_Position = vec4(2.0, 2.0, 2.0, 1.0); return;}// Invalid value. Just hide it
 
     dispStrength *= cScale;
-    dispStrength = max(min(dispStrength+cOffset,0.995), 0.0);
+    dispStrength = clamp(dispStrength + cOffset, 0.0, 0.995);
 
     bool valid = (dispStrength >= threshold.x) && (dispStrength <= threshold.y); 
     if (!valid || abs(dispStrength - fillValue) < 0.005){ // Invalid value. Just hide it
@@ -83,11 +86,8 @@ void main() {
     } 
     
     vec2 lonlat = giveLonLat(instanceUV);
-    float latitudeFactor = cos(lonlat.y); // Maps -1..1 to proper latitude
-    vec2 centeredUV = (instanceUV - vec2(0.5, 0.5)) * vec2(2.0, 2.0); 
-    vec3 spherePosition = givePosition(lonlat);
-    float widthFactor = abs(lonBounds.y-lonBounds.x)/(2.0*PI);
-    float vertFactor = (latBounds.y-latBounds.x)/PI;
+    float latitudeFactor; // Maps -1..1 to proper latitude
+    vec3 spherePosition = givePosition(lonlat, latitudeFactor);
     float heightFactor = (dispStrength - displaceZero) * displacement;
     vec3 scaledPosition = position;
     scaledPosition.x *= latitudeFactor * widthFactor;
@@ -106,6 +106,4 @@ void main() {
     vec3 worldPosition = spherePosition + oriented;
     vStrength = dispStrength;
     gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
-
-    
 }

--- a/src/components/textures/shaders/sphereFrag.glsl
+++ b/src/components/textures/shaders/sphereFrag.glsl
@@ -52,7 +52,7 @@ void main(){
             vec2 realUV = realCoords(sampleCoord);
             vec3 remap = texture(remapTexture, realUV).rgb;
             sampleCoord = remap.rg;
-            if (remap.b < 0.5) sampleCoord = vec2(2.0); // I don't think this is ever the case
+            if (remap.b < 0.5) sampleCoord = vec2(2.0); 
     #endif
     bool inBounds = all(greaterThanEqual(sampleCoord, vec2(0.0))) &&
     all(lessThanEqual(sampleCoord, vec2(1.0)));


### PR DESCRIPTION
Sphere blocks was using wrong sample space for CRS. 
Optimized sphere blocks a bit by moving uniform calculations to the CPU side,

Added bounds check on the sphere texture for irregular arrays to hide invalid values.

| before | after|
| --- | ---|
|<img width="500" height="471" alt="image" src="https://github.com/user-attachments/assets/f547273d-d93a-4657-95a0-6d63c105636e" /> | <img width="520" height="496" alt="image" src="https://github.com/user-attachments/assets/8af813e9-e139-40a6-bca3-c29f65060f83" /> |

closes #731 