### PR TITLE
Jp/bug tweaks and fixes

### DIFF
--- a/src/components/plots/Sphere.tsx
+++ b/src/components/plots/Sphere.tsx
@@ -32,7 +32,6 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
       getColorIdx, incrementColorIdx} = usePlotStore(useShallow(s => s))
     const {xArray, yArray, zArray} = useDimAxis();
     const dimSlices = [zArray, yArray, xArray];
-    const {lonBounds, latBounds} = useCoordBounds()
     const geometry = useMemo(() => new THREE.IcosahedronGeometry(1, sphereResolution), [sphereResolution]);
     const uniforms = useCommonUniforms()
     const shaderMaterial = useMemo(()=>{
@@ -83,7 +82,7 @@ export const Sphere = ({textures: propTextures} : {textures: THREE.Data3DTexture
       }
     },[textures, displacement, fillValue, valueScales])
     
-    
+    const {lonBounds, latBounds} = useCoordBounds()
     function HandleTimeSeries(event: THREE.Intersection){
         const point = event.point.normalize();
 

--- a/src/components/plots/TransectMeshes.tsx
+++ b/src/components/plots/TransectMeshes.tsx
@@ -160,6 +160,7 @@ export const ColumnMeshes = () => {
 	const {xIdx, yIdx, zIdx} = useAxisIndices()
 	const meshes: THREE.Mesh[] = useMemo(()=>{
 		const meshes: THREE.Mesh[] = []
+		const originalXSteps = dataShape[xIdx]; // Need this because it messes up the depthScale after repro
 		const xSteps = remapTexture 
 						? remapTexture.image.width 
 						: dataShape[xIdx];
@@ -168,7 +169,7 @@ export const ColumnMeshes = () => {
 						: dataShape[yIdx];
 		const zSteps = dataShape[zIdx];
 		const aspectRatio = ySteps/xSteps; // This is not aspect ratio
-		const depthRatio = zSteps/xSteps;
+		const depthRatio = zSteps/originalXSteps;
 		for (const [_tsID, tsObj] of Object.entries(timeSeries)){
 			const {normal, uv, color} = tsObj
 			const position = normalToPos(uv, normal, {aspectRatio,depthRatio}, {xSteps, ySteps, zSteps})

--- a/src/components/plots/UVCube.tsx
+++ b/src/components/plots/UVCube.tsx
@@ -81,6 +81,7 @@ export const UVCube = ( {scale} : {scale?:THREE.Vector3} )=>{
 	
   function HandleTimeSeries(event: THREE.Intersection){
     const uv = event.uv!;
+    const timeUV = new THREE.Vector2().copy(uv); // Need this to flipY if necessary
     const normal = event.normal!;
     let newUV: THREE.Vector2 | undefined;
     if (remapTexture){ // Get new UV if reprojected and along z Axis
@@ -104,9 +105,11 @@ export const UVCube = ( {scale} : {scale?:THREE.Vector3} )=>{
       setDimCoords({});
     }
     lastNormal.current = dimAxis;
+    const coordUV = parseUVCoords({normal:normal,uv})
+    timeUV.y = flipY ? 1 - uv.y : uv.y;
     const tempTS = GetTimeSeries(
       { data: analysisMode ? analysisArray : GetCurrentArray(), shape: dataShape, stride: strides },
-      { uv: newUV ?? uv, normal }
+      { uv: newUV ?? timeUV, normal }
     )
     const plotDim = (normal.toArray()).map((val, idx) => {
       if (Math.abs(val) > 0) {
@@ -114,7 +117,7 @@ export const UVCube = ( {scale} : {scale?:THREE.Vector3} )=>{
       }
       return null;}).filter(idx => idx !== null);
     setPlotDim(2-plotDim[0]) //I think this 2 is only if there are 3-dims. Need to rework the logic
-    const coordUV = parseUVCoords({normal:normal,uv})
+    
     let dimCoords = coordUV.map((val,idx)=>val ? allAxis[idx][Math.round(val*allAxis[idx].length)] : null)
     const thisDimNames = axisDimNames.filter((_,idx)=> dimCoords[idx] !== null)
     const thisDimUnits = axisDimUnits.filter((_,idx)=> dimCoords[idx] !== null)

--- a/src/components/textures/ProjectionTexture.ts
+++ b/src/components/textures/ProjectionTexture.ts
@@ -206,10 +206,8 @@ function createInverseUV(
 export function handleIrregularGrid(){
     // This is needed for Sphere and other projections where the grid is not uniform. It creates an array for the ticks and update for sphere
     const {xArray, yArray} = getAxisDimAxis();
-    console.log(xArray,yArray)
     const {flipY} = useGlobalStore.getState()
     const isRegular = isUniformStep(xArray) && isUniformStep(yArray)
-    console.log(`isRegular: ${isRegular}`)
     if (isRegular) return;
     const {is360Deg, plotType} = usePlotStore.getState();
 	if(plotType == 'sphere') {

--- a/src/components/textures/ProjectionTexture.ts
+++ b/src/components/textures/ProjectionTexture.ts
@@ -206,8 +206,10 @@ function createInverseUV(
 export function handleIrregularGrid(){
     // This is needed for Sphere and other projections where the grid is not uniform. It creates an array for the ticks and update for sphere
     const {xArray, yArray} = getAxisDimAxis();
+    console.log(xArray,yArray)
     const {flipY} = useGlobalStore.getState()
     const isRegular = isUniformStep(xArray) && isUniformStep(yArray)
+    console.log(`isRegular: ${isRegular}`)
     if (isRegular) return;
     const {is360Deg, plotType} = usePlotStore.getState();
 	if(plotType == 'sphere') {

--- a/src/components/ui/MainPanel/Colormaps.tsx
+++ b/src/components/ui/MainPanel/Colormaps.tsx
@@ -103,12 +103,7 @@ const Colormaps = () => {
 
   let cmapTimeout: NodeJS.Timeout | undefined;
 
-  const updateColormap = (cmap: string) => {
-    if (cmapTimeout){
-      clearTimeout(cmapTimeout);
-      cmapTimeout = undefined;
-    }
-    setColormap(
+  const setCmap = (cmap: string) => setColormap(
       GetColorMapTexture(
         previousTextureRef.current,
         cmap === "Default" ? "Spectral" : cmap,
@@ -117,15 +112,19 @@ const Colormaps = () => {
         0,
         flipColormapRef.current
       )
-    );
+    )
+
+  const updateColormap = (cmap: string) => {
+    if (cmapTimeout){
+      clearTimeout(cmapTimeout);
+      cmapTimeout = undefined;
+    }
+    setCmap(cmap);
   }
 
   const restoreColormap = () => {
     cmapTimeout = setTimeout(()=>{
-      setColormap(
-      GetColorMapTexture(
-        previousTextureRef.current,
-        colormapName))
+      setCmap(colormapName);
     }, 100)
   }
 

--- a/src/components/ui/MainPanel/MetaDimSelector.tsx
+++ b/src/components/ui/MainPanel/MetaDimSelector.tsx
@@ -200,7 +200,8 @@ const MetaStatusBadges: React.FC<{
   availableDims: DimOption[];
   cacheSize: number;
   setCacheSize: React.Dispatch<React.SetStateAction<number>>;
-}> = React.memo(({ meta, availableDims, cacheSize, setCacheSize }) => {
+  setDataSize: React.Dispatch<React.SetStateAction<number>>;
+}> = React.memo(({ meta, availableDims, cacheSize, setCacheSize, setDataSize }) => {
   const {rows, collapsedSels} = useMetaSelectorStore((s) => s);
 
   const {initStore, idx4D} = useGlobalStore((s) => s);
@@ -248,7 +249,9 @@ const MetaStatusBadges: React.FC<{
   const texCount = sizeData.texCount;
   const tooBig = texCount > 12;
   const cachedSize = useMemo(() => {
-    return currentSize * 2/dtype;
+    const cachedSize = currentSize * 2/dtype;
+    setDataSize(cachedSize);
+    return cachedSize;
   }, [currentSize, meta]);
 
   const smallCache = cachedSize > cacheSize;
@@ -349,11 +352,11 @@ const MetaStatusBadges: React.FC<{
               <div className="flex items-center gap-4 w-full min-w-0">
                 <SliderThumbs
                   id="newCache-size"
-                  min={0}
-                  max={1000}
+                  min={200}
+                  max={1200}
                   value={[cacheSize / (1024 * 1024)]}
                   step={10}
-                  onValueChange={(e) => setCacheSize(maxSize + e[0] * (1024 * 1024))}
+                  onValueChange={(e) => setCacheSize(e[0] * (1024 * 1024))}
                   className="flex-1 min-w-0"
                 />
                 <div className="flex items-center gap-1 shrink-0">
@@ -598,10 +601,10 @@ export default function MetaDimSelector({ meta, metadata, onApply }: Props) {
 	const { ndSlices, axisMapping, ReFetch, compress, setCompress, coarsen, setCoarsen, kernelSize, setKernelSize, kernelDepth, setKernelDepth } = useZarrStore(
     useShallow(s => s))
 	const [cacheSize, setCacheSize] = useState(maxSize);
-
+  const [dataSize, setDataSize] = useState(maxSize)
 	const [displaySpat, setDisplaySpat] = useState(String(kernelSize));
 	const [displayDepth, setDisplayDepth] = useState(String(kernelDepth));
-
+  const smallCache = dataSize > cacheSize;
 	const availableDims: DimOption[] = useMemo(
 		() =>
 		dimArrays.map((values, idx) => {
@@ -829,6 +832,7 @@ export default function MetaDimSelector({ meta, metadata, onApply }: Props) {
 
               <div className="flex items-center justify-end ml-auto min-w-0">
                 <Button
+                  disabled={smallCache}
                   variant={'pink'}
                   className="cursor-pointer hover:scale-[1.05] shadow-sm h-8 px-4"
                   onClick={handlePlot}
@@ -843,6 +847,7 @@ export default function MetaDimSelector({ meta, metadata, onApply }: Props) {
               availableDims={availableDims}
               cacheSize={cacheSize}
               setCacheSize={setCacheSize}
+              setDataSize={setDataSize}
             />
           </div>
 

--- a/src/hooks/useDataFetcher.tsx
+++ b/src/hooks/useDataFetcher.tsx
@@ -81,7 +81,6 @@ export const useDataFetcher = () => {
                     setPlotOn(true);
                     setStatus(null);
                 }).then(()=>{
-                    parseExtent();
                     if(preProject)reproject();
                     else handleIrregularGrid();
                     setShow(true)
@@ -103,12 +102,13 @@ export const useDataFetcher = () => {
                 let { dimArrays, dimUnits, dimNames } = arrays;
                 useGlobalStore.setState({dimArrays, dimNames, dimUnits, 
                     axisDimArrays: dimArrays, axisDimNames: dimNames, axisDimUnits: dimUnits});
-
+                
                 const { axisMapping } = useZarrStore.getState();
                 const yIdx = (axisMapping.y >= 0 && axisMapping.y < dimArrays.length) ? axisMapping.y : Math.max(0, dimArrays.length - 2);
                 const targetDim = dimArrays[yIdx] || dimArrays[0];
                 const shouldFlip = (targetDim && targetDim.length >= 2) ? targetDim[1] < targetDim[0] : false;
-                setFlipY(shouldFlip);                
+                setFlipY(shouldFlip);   
+                parseExtent();             
             });
 
         } else {


### PR DESCRIPTION
- Fixed Transectmeshes changing the depthRatio when reprojecting
- Added a timeseriesUV that needs flipY data
- Updated colormaps to respect the flip value when going back after moving cursor off new Colormap
- disabled plot button while cache was too small for all data
- Moved parseExtent to after grabbing dims. Wasn't grabbing properly and breaking sphere when loaded from URL params